### PR TITLE
Unified Structure Damage

### DIFF
--- a/code/game/gamemodes/godmode/god_structures.dm
+++ b/code/game/gamemodes/godmode/god_structures.dm
@@ -18,13 +18,15 @@
 /obj/structure/deity
 	icon = 'icons/obj/cult.dmi'
 	var/mob/living/deity/linked_god
-	var/health = 10
+	health = 10
+	hitsound = 'sound/effects/Glasshit.ogg'
 	var/power_adjustment = 1 //How much power we get/lose
 	var/build_cost = 0 //How much it costs to build this item.
 	var/deity_flags = DEITY_STRUCTURE_NEAR_IMPORTANT
 	density = 1
 	anchored = 1
 	icon_state = "tomealtar"
+	resistance = 0
 
 /obj/structure/deity/New(var/newloc, var/god)
 	..(newloc)
@@ -39,25 +41,12 @@
 		linked_god = null
 	return ..()
 
-/obj/structure/deity/attackby(obj/item/W as obj, mob/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.do_attack_animation(src)
-	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 50, 1)
-	user.visible_message(
-		"<span class='danger'>[user] hits \the [src] with \the [W]!</span>",
-		"<span class='danger'>You hit \the [src] with \the [W]!</span>",
-		"<span class='danger'>You hear something breaking!</span>"
-		)
-	take_damage(W.force)
 
-/obj/structure/deity/proc/take_damage(var/amount)
-	health -= amount
-	if(health < 0)
-		src.visible_message("\The [src] crumbles!")
-		qdel(src)
+/obj/structure/deity/zero_health()
+	src.visible_message("\The [src] crumbles!")
+	qdel(src)
 
-/obj/structure/deity/bullet_act(var/obj/item/projectile/P)
-	take_damage(P.damage)
+
 
 /obj/structure/deity/proc/attack_deity(var/mob/living/deity/deity)
 	return

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -61,8 +61,7 @@ for reference:
 	icon_state = "barricade"
 	anchored = 1.0
 	density = 1
-	var/health = 100
-	var/maxhealth = 100
+	max_health = 100
 	var/material/material
 	atom_flags = ATOM_FLAG_CLIMBABLE
 	layer = ABOVE_WINDOW_LAYER
@@ -78,8 +77,8 @@ for reference:
 	name = "[material.display_name] barricade"
 	desc = "This space is blocked off by a barricade made of [material.display_name]."
 	color = material.icon_colour
-	maxhealth = material.integrity
-	health = maxhealth
+	max_health = material.integrity
+	health = max_health
 
 /obj/structure/barricade/get_material()
 	return material
@@ -88,50 +87,29 @@ for reference:
 	if (istype(W, /obj/item/stack))
 		var/obj/item/stack/D = W
 		if(D.get_material_name() != material.name)
-			return //hitting things with the wrong type of stack usually doesn't produce messages, and probably doesn't need to.
-		if (health < maxhealth)
+			return 	TRUE
+		if (health < max_health)
 			if (D.get_amount() < 1)
 				to_chat(user, "<span class='warning'>You need one sheet of [material.display_name] to repair \the [src].</span>")
-				return
+				return	TRUE
 			visible_message("<span class='notice'>[user] begins to repair \the [src].</span>")
-			if(do_after(user,20,src) && health < maxhealth)
+			if(do_after(user,20,src) && health < max_health)
 				if (D.use(1))
-					health = maxhealth
+					health = max_health
 					visible_message("<span class='notice'>[user] repairs \the [src].</span>")
-				return
-		return
+				return	TRUE
+		return	TRUE
 	else
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		switch(W.damtype)
-			if("fire")
-				src.health -= W.force * 1
-			if("brute")
-				src.health -= W.force * 0.75
-			else
-		if (src.health <= 0)
-			visible_message("<span class='danger'>The barricade is smashed apart!</span>")
-			dismantle()
-			qdel(src)
-			return
-		..()
+		.=..()
+
+/obj/structure/barricade/zero_health()
+	dismantle()
 
 /obj/structure/barricade/proc/dismantle()
 	material.place_dismantled_product(get_turf(src))
 	qdel(src)
 	return
 
-/obj/structure/barricade/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			visible_message("<span class='danger'>\The [src] is blown apart!</span>")
-			qdel(src)
-			return
-		if(2.0)
-			src.health -= 25
-			if (src.health <= 0)
-				visible_message("<span class='danger'>\The [src] is blown apart!</span>")
-				dismantle()
-			return
 
 /obj/structure/barricade/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)//So bullets will fly over and stuff.
 	if(air_group || (height==0))
@@ -156,7 +134,7 @@ for reference:
 	density = 1
 	icon_state = "barrier0"
 	var/health = 100.0
-	var/maxhealth = 100.0
+	var/max_health = 100.0
 	var/locked = 0.0
 //	req_access = list(access_maint_tunnels)
 
@@ -186,8 +164,8 @@ for reference:
 					return
 			return
 		else if(isWrench(W))
-			if (src.health < src.maxhealth)
-				src.health = src.maxhealth
+			if (src.health < src.max_health)
+				src.health = src.max_health
 				src.emagged = 0
 				src.req_access = list(access_security)
 				visible_message("<span class='warning'>[user] repairs \the [src]!</span>")

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -53,7 +53,7 @@
 
 /obj/structure/closet/airlock_crush(var/crush_damage)
 	..()
-	damage(crush_damage)
+	take_damage(crush_damage, used_weapon = src)
 	for(var/atom/movable/AM in src)
 		AM.airlock_crush()
 	return

--- a/code/game/objects/items/weapons/tools/screwdrivers.dm
+++ b/code/game/objects/items/weapons/tools/screwdrivers.dm
@@ -6,6 +6,7 @@
 	worksound = WORKSOUND_SCREW_DRIVING
 	slot_flags = SLOT_BELT | SLOT_EARS
 	w_class = ITEM_SIZE_TINY
+	sharp = TRUE
 	throw_speed = 3
 	throw_range = 5
 	matter = list(MATERIAL_STEEL = 800, MATERIAL_PLASTIC = 400)

--- a/code/game/objects/items/weapons/tools/workbench.dm
+++ b/code/game/objects/items/weapons/tools/workbench.dm
@@ -6,8 +6,8 @@
 	icon_state = "deadspace_workbench"
 	standalone = TRUE //No connecting, uses its own icon
 	can_plate = FALSE
-	maxhealth = 500 //Hard to break
-	health = 500
+	resistance = 10
+	max_health = 200 //Hard to break
 
 /obj/structure/table/workbench
 

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -2,8 +2,12 @@
 	icon = 'icons/obj/structures.dmi'
 	w_class = ITEM_SIZE_NO_CONTAINER
 
-	var/breakable
+	var/breakable = TRUE
+	var/resistance = 5
+	var/health
+	var/max_health = 20
 	var/parts
+	var/hitsound = 'sound/weapons/smash.ogg'
 
 	var/list/connections = list("0", "0", "0", "0")
 	var/list/other_connections = list("0", "0", "0", "0")
@@ -13,11 +17,17 @@
 	var/list/footstep_sounds	//footstep sounds when stepped on
 	var/step_priority = 1	//Priority of the sound attached to this
 
+
 /obj/structure/proc/get_footstep_sound()
 	if(LAZYLEN(footstep_sounds)) return pick(footstep_sounds)
 
 /obj/structure/New()
 	.=..()
+	if (max_health) //Not everything sets both of these. either will do
+		health = max_health
+	else if (health)
+		max_health = health
+
 	if(LAZYLEN(footstep_sounds) && istype(loc, /turf/simulated/floor))
 		var/turf/simulated/floor/T = get_turf(src)
 		T.step_structures |= src
@@ -32,37 +42,20 @@
 
 /obj/structure/attack_hand(mob/user)
 	..()
-	if(breakable)
-		if(HULK in user.mutations)
-			user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
-			attack_generic(user,1,"smashes")
-		else if(istype(user,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = user
-			if(H.species.can_shred(user))
-				attack_generic(user,1,"slices")
+	if(breakable && user.a_intent == I_HURT)
+		user.strike_structure(src)
+		return 1
 	return ..()
 
 /obj/structure/attack_tk()
 	return
 
-/obj/structure/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			qdel(src)
-			return
-		if(2.0)
-			if(prob(50))
-				qdel(src)
-				return
-		if(3.0)
-			return
-
 /obj/structure/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
-	if(!breakable || !damage || !wallbreaker)
+	if(!breakable || !damage)
 		return 0
-	visible_message("<span class='danger'>[user] [attack_verb] the [src] apart!</span>")
+	visible_message("<span class='danger'>[user] [attack_verb] the [src]!</span>")
 	attack_animation(user)
-	spawn(1) qdel(src)
+	take_damage(damage, BRUTE, user, user)
 	return 1
 
 /obj/structure/proc/can_visually_connect()
@@ -134,15 +127,64 @@
 				AM.loc = loc
 				AM.ex_act(severity++, epicentre)
 
-			qdel(src)
-			return
+			take_damage(rand(150,300), BRUTE, null, epicentre)
 		if(2.0)
 			if(prob(50))
 				for(var/atom/movable/AM in contents)
 					AM.loc = loc
 					AM.ex_act(severity++, epicentre)
 
-				qdel(src)
-				return
+			take_damage(rand(60,150), BRUTE, null, epicentre)
+
 		if(3.0)
-			return
+			take_damage(rand(25,60), BRUTE, null, epicentre)
+
+/obj/structure/bullet_act(var/obj/item/projectile/P)
+	take_damage(P.get_structure_damage(), user = P.firer, used_weapon = P)
+
+
+/obj/structure/attackby(var/obj/item/C, var/mob/user)
+	if (breakable && user.a_intent == I_HURT)
+		playsound(src, hitsound, VOLUME_MID, 1)
+		user.do_attack_animation(src)
+		take_damage(C.force, C.damtype, user, C)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		return
+	.=..()
+
+/obj/structure/hitby(AM as mob|obj, var/speed=THROWFORCE_SPEED_DIVISOR)
+	..()
+	if(ismob(AM))
+		return
+	var/obj/O = AM
+	var/tforce = O.throwforce * (speed/THROWFORCE_SPEED_DIVISOR)
+
+	take_damage(tforce, BRUTE, O.thrower, O)
+
+//Called when a structure takes damage
+/obj/structure/proc/take_damage(var/amount, var/damtype = BRUTE, var/user, var/used_weapon, var/bypass_resist = FALSE)
+	if (!bypass_resist)
+		amount -= resistance
+
+	if (amount <= 0)
+		return FALSE
+
+	health -= amount
+
+	if (health <= 0)
+		health = 0
+		return zero_health(amount, damtype, user, used_weapon, bypass_resist)//Some zero health overrides do things with a return value
+	else
+		update_icon()
+		return TRUE
+
+/obj/structure/proc/updatehealth()
+	if (health <= 0)
+		health = 0
+		return zero_health()
+
+//Called when health drops to zero. Parameters are the params of the final hit that broke us, if this was called from take_damage
+/obj/structure/proc/zero_health(var/amount, var/damtype = BRUTE, var/user, var/used_weapon, var/bypass_resist)
+	if (breakable)
+		qdel(src)
+	return TRUE

--- a/code/game/objects/structures/alien/alien.dm
+++ b/code/game/objects/structures/alien/alien.dm
@@ -3,57 +3,8 @@
 	desc = "There's something alien about this."
 	icon = 'icons/mob/alien.dmi'
 	layer = ABOVE_OBJ_LAYER
-	var/health = 50
-
-/obj/structure/alien/proc/healthcheck()
-	if(health <=0)
-		set_density(0)
-		qdel(src)
-	return
-
-/obj/structure/alien/bullet_act(var/obj/item/projectile/Proj)
-	health -= Proj.damage
-	..()
-	healthcheck()
-	return
-
-/obj/structure/alien/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			health-=50
-		if(2.0)
-			health-=50
-		if(3.0)
-			if (prob(50))
-				health-=50
-			else
-				health-=25
-	healthcheck()
-	return
-
-/obj/structure/alien/hitby(AM as mob|obj)
-	..()
-	visible_message("<span class='danger'>\The [src] was hit by \the [AM].</span>")
-	var/tforce = 0
-	if(ismob(AM))
-		tforce = 10
-	else
-		tforce = AM:throwforce
-	playsound(loc, 'sound/effects/attackblob.ogg', 100, 1)
-	health = max(0, health - tforce)
-	healthcheck()
-	..()
-	return
-
-/obj/structure/alien/attack_generic()
-	attack_hand(usr)
-
-/obj/structure/alien/attackby(var/obj/item/weapon/W, var/mob/user)
-	health = max(0, health - W.force)
-	playsound(loc, 'sound/effects/attackblob.ogg', 100, 1)
-	healthcheck()
-	..()
-	return
+	health = 50
+	hitsound = 'sound/effects/attackblob.ogg'
 
 /obj/structure/alien/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group) return 0

--- a/code/game/objects/structures/alien/resin.dm
+++ b/code/game/objects/structures/alien/resin.dm
@@ -41,10 +41,10 @@
 			if(locate(/obj/item/organ/internal/xeno/hivenode) in M.internal_organs)
 				visible_message("<span class='alium'>\The [user] strokes \the [name] and it melts away!</span>")
 				health = 0
-				healthcheck()
+				updatehealth()
 				return
 		visible_message("<span class='danger'>\The [user] claws at \the [src]!</span>")
 		// Todo check attack datums.
 		health -= rand(5,10)
-	healthcheck()
+	updatehealth()
 	return

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -7,7 +7,8 @@
 	anchored = 1
 	unacidable = 1//Dissolving the case would also delete the gun.
 	alpha = 150
-	var/health = 14
+	health = 20
+	resistance = 10
 	var/destroyed = 0
 
 /obj/structure/displaycase/Initialize()
@@ -23,37 +24,21 @@
 	if(contents.len)
 		to_chat(user, "Inside you see [english_list(contents)].")
 
-/obj/structure/displaycase/ex_act(severity)
-	switch(severity)
-		if (1)
-			new /obj/item/weapon/material/shard(loc)
-			for(var/atom/movable/AM in src)
-				AM.dropInto(loc)
-			qdel(src)
-		if (2)
-			if (prob(50))
-				take_damage(15)
-		if (3)
-			if (prob(50))
-				take_damage(5)
 
-/obj/structure/displaycase/bullet_act(var/obj/item/projectile/Proj)
-	..()
-	take_damage(Proj.get_structure_damage())
 
-/obj/structure/displaycase/proc/take_damage(damage)
-	health -= damage
-	if(health <= 0)
-		if (!destroyed)
-			set_density(0)
-			destroyed = 1
-			new /obj/item/weapon/material/shard(loc)
-			for(var/atom/movable/AM in src)
-				AM.dropInto(loc)
-			playsound(src, "shatter", 70, 1)
-			update_icon()
-	else
-		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
+/obj/structure/displaycase/take_damage(var/amount, var/damtype = BRUTE, var/user, var/used_weapon, var/bypass_resist)
+	.=..()
+	playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
+
+/obj/structure/displaycase/zero_health()
+	if (!destroyed)
+		set_density(0)
+		destroyed = 1
+		new /obj/item/weapon/material/shard(loc)
+		for(var/atom/movable/AM in src)
+			AM.dropInto(loc)
+		playsound(src, "shatter", 70, 1)
+		update_icon()
 
 /obj/structure/displaycase/update_icon()
 	if(destroyed)
@@ -64,14 +49,3 @@
 	for(var/atom/movable/AM in contents)
 		underlays += AM.appearance
 
-/obj/structure/displaycase/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	take_damage(W.force)
-	..()
-
-/obj/structure/displaycase/attack_hand(mob/user as mob)
-	add_fingerprint(user)
-	if(!destroyed)
-		to_chat(usr, text("<span class='warning'>You kick the display case.</span>"))
-		visible_message("<span class='warning'>[usr] kicks the display case.</span>")
-		take_damage(2)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -6,7 +6,7 @@
 	layer = BELOW_OBJ_LAYER
 	w_class = ITEM_SIZE_NO_CONTAINER
 	var/state = 0
-	var/health = 200
+	health = 200
 	var/cover = 50 //how much cover the girder provides against projectiles.
 	var/material/reinf_material
 	var/reinforcing = 0
@@ -34,19 +34,10 @@
 	if(Proj.original != src && !prob(cover))
 		return PROJECTILE_CONTINUE //pass through
 
-	var/damage = Proj.get_structure_damage()
-	if(!damage)
-		return
+	.=..()
 
-	if(!istype(Proj, /obj/item/projectile/beam))
-		damage *= 0.4 //non beams do reduced damage
-
-	health -= damage
-	..()
-	if(health <= 0)
-		dismantle()
-
-	return
+/obj/structure/girder/zero_health()
+	dismantle()
 
 /obj/structure/girder/proc/reset_girder()
 	anchored = 1

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -8,7 +8,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	layer = BELOW_OBJ_LAYER
 	explosion_resistance = 1
-	var/health = 10
+	health = 20
 	var/destroyed = 0
 	var/on_frame = FALSE
 
@@ -20,8 +20,6 @@
 	update_connections(1)
 	update_icon()
 
-/obj/structure/grille/ex_act(severity)
-	qdel(src)
 
 /obj/structure/grille/update_icon()
 	update_onframe()
@@ -118,8 +116,7 @@
 		. = PROJECTILE_CONTINUE
 		damage = between(0, (damage - Proj.damage)*(Proj.damage_type == BRUTE? 0.4 : 1), 10) //if the bullet passes through then the grille avoids most of the damage
 
-	src.health -= damage*0.2
-	spawn(0) healthcheck() //spawn to make sure we return properly if the grille is deleted
+	take_damage(damage*0.2, user = Proj.firer, used_weapon = Proj)
 
 /obj/structure/grille/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(isWirecutter(W))

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -11,8 +11,8 @@
 
 	var/material/material
 	var/broken =    FALSE
-	var/health =    70
-	var/maxhealth = 70
+	health =    70
+	max_health = 70
 	var/neighbor_status = 0
 
 /obj/structure/railing/mapped
@@ -43,8 +43,8 @@
 
 	name = "[material.display_name] [initial(name)]"
 	desc = "An unremarkable [material.display_name] railing. Guards against human stupidity."
-	maxhealth = round(material.integrity / 5)
-	health = maxhealth
+	max_health = round(material.integrity / 5)
+	health = max_health
 	color = material.icon_colour
 
 	if(material.products_need_process())
@@ -75,8 +75,8 @@
 
 /obj/structure/railing/examine(mob/user)
 	. = ..()
-	if(health < maxhealth)
-		switch(health / maxhealth)
+	if(health < max_health)
+		switch(health / max_health)
 			if(0.0 to 0.5)
 				to_chat(user, "<span class='warning'>It looks severely damaged!</span>")
 			if(0.25 to 0.5)
@@ -84,13 +84,11 @@
 			if(0.5 to 1.0)
 				to_chat(user, "<span class='notice'>It has a few scrapes and dents.</span>")
 
-/obj/structure/railing/proc/take_damage(amount)
-	health -= amount
-	if(health <= 0)
-		visible_message("<span class='danger'>\The [src] [material.destruction_desc]!</span>")
-		playsound(loc, 'sound/effects/grillehit.ogg', 50, 1)
-		material.place_shard(get_turf(usr))
-		qdel(src)
+/obj/structure/railing/zero_health(amount)
+	visible_message("<span class='danger'>\The [src] [material.destruction_desc]!</span>")
+	playsound(loc, 'sound/effects/grillehit.ogg', 50, 1)
+	material.place_shard(get_turf(usr))
+	qdel(src)
 
 /obj/structure/railing/proc/NeighborsCheck(var/UpdateNeighbors = 1)
 	neighbor_status = 0
@@ -252,12 +250,12 @@
 
 	// Repair
 	if(isWelder(W))
-		if(health >= maxhealth)
+		if(health >= max_health)
 			to_chat(user, "<span class='warning'>\The [src] does not need repairs.</span>")
 			return
 		if(W.use_tool(user, src, WORKTIME_SLOW, QUALITY_WELDING, FAILCHANCE_NORMAL))
 			user.visible_message("<span class='notice'>\The [user] repairs some damage to \the [src].</span>", "<span class='notice'>You repair some damage to \the [src].</span>")
-			health = min(health+(maxhealth/5), maxhealth)
+			health = min(health+(max_health/5), max_health)
 
 
 	// Install
@@ -270,15 +268,8 @@
 			update_icon()
 		return
 
-	if(W.force && (W.damtype == "fire" || W.damtype == "brute"))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		visible_message("<span class='danger'>\The [src] has been [LAZYLEN(W.attack_verb) ? pick(W.attack_verb) : "attacked"] with \the [W] by \the [user]!</span>")
-		take_damage(W.force)
-		return
 	. = ..()
 
-/obj/structure/railing/ex_act(severity)
-	qdel(src)
 
 /obj/structure/railing/do_climb(var/mob/living/user)
 	if(!can_climb(user))
@@ -307,5 +298,5 @@
 
 	user.visible_message("<span class='danger'>\The [user] climbed over \the [src]!</span>")
 	if(!anchored || material.is_brittle())
-		take_damage(maxhealth) // Fatboy
+		take_damage(max_health) // Fatboy
 	climbers -= user

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -11,11 +11,11 @@
 	var/list/loot = list(/obj/item/weapon/cell,/obj/item/stack/material/iron,/obj/item/stack/rods)
 	var/lootleft = 1
 	var/emptyprob = 95
-	var/health = 40
+	health = 40
 	var/is_rummaging = 0
 
 /obj/structure/rubble/New()
-	if(prob(emptyprob)) 
+	if(prob(emptyprob))
 		lootleft = 0
 	..()
 
@@ -63,23 +63,20 @@
 		is_rummaging = 0
 	else
 		to_chat(user, "<span class='warning'>Someone is already rummaging here!</span>")
-		
+
 /obj/structure/rubble/attackby(var/obj/item/I, var/mob/user)
 	if (istype(I, /obj/item/weapon/pickaxe))
 		var/obj/item/weapon/pickaxe/P = I
 		visible_message("[user] starts clearing away \the [src].")
-		if(do_after(user,P.digspeed, src))
+		if(P.use_tool(user = user, target =  src, base_time = WORKTIME_SLOW, required_quality = QUALITY_EXCAVATION, fail_chance = FAILCHANCE_HARD, required_stat = "construction"))
 			visible_message("[user] clears away \the [src].")
 			if(lootleft && prob(1))
 				var/obj/item/booty = pick(loot)
 				booty = new booty(loc)
 			qdel(src)
-	else 
-		..()
-		health -= I.force
-		if(health < 1)
-			visible_message("[user] clears away \the [src].")
-			qdel(src)
+	else
+		.=..()
+
 
 /obj/structure/rubble/house
 	loot = list(/obj/item/weapon/archaeological_find/bowl,

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "nest"
 	buckle_pixel_shift = "x=0;y=6"
-	var/health = 100
+	health = 100
 
 /obj/structure/bed/nest/update_icon()
 	return

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -15,8 +15,7 @@
 	color = COLOR_GUNMETAL
 
 	var/damage = 0
-	var/maxhealth = 10
-	var/health = 10
+	max_health = 10
 	var/stripe_color
 
 	blend_objects = list(/obj/machinery/door, /turf/simulated/wall) // Objects which to blend with
@@ -159,26 +158,15 @@
 	take_damage(damage)
 	return
 
-/obj/structure/wall_frame/hitby(AM as mob|obj, var/speed=THROWFORCE_SPEED_DIVISOR)
-	..()
-	if(ismob(AM))
-		return
-	var/obj/O = AM
-	var/tforce = O.throwforce * (speed/THROWFORCE_SPEED_DIVISOR)
-	if (tforce < 15)
-		return
 
-	take_damage(tforce)
+
+/obj/structure/wall_frame/zero_health()
+	dismantle()
 
 /obj/structure/wall_frame/proc/dismantle()
 	new /obj/item/stack/material/steel(get_turf(src))
 	qdel(src)
 
-/obj/structure/wall_frame/proc/take_damage(dam)
-	if(dam)
-		damage = max(0, damage + dam)
-		update_damage()
-	return
 
 /obj/structure/wall_frame/proc/update_damage()
 	if(damage >= 150)

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -140,6 +140,7 @@
 	damage = 25
 	airlock_force_power = 5
 	airlock_force_speed = 2.5
+	structure_damage_mult = 1.5	//Wrecks obstacles
 	shredding = TRUE //Better environment interactions, even if not sharp
 
 //Brute punch causes knockback on any mob smaller than itself

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -650,7 +650,7 @@
 	level = 1			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions
 	dir = 0				// dir will contain dominant direction for junction pipes
-	var/health = 10 	// health points 0-10
+	health = 10 	// health points 0-10
 	alpha = 192 // Plane and alpha modified for mapping, reset to normal on spawn.
 	plane = ABOVE_TURF_PLANE
 	layer = DISPOSALS_PIPE_LAYER
@@ -840,22 +840,13 @@
 				broken(0)
 				return
 			if(2.0)
-				health -= rand(5,15)
-				healthcheck()
+				take_damage(rand(5,15))
 				return
 			if(3.0)
-				health -= rand(0,15)
-				healthcheck()
+				take_damage(rand(0,15))
 				return
 
 
-	// test health for brokenness
-	proc/healthcheck()
-		if(health < -2)
-			broken(0)
-		else if(health<1)
-			broken(1)
-		return
 
 	//attack by item
 	//weldingtool: unfasten and convert to obj/disposalconstruct
@@ -870,6 +861,9 @@
 			if (I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_WELDING, FAILCHANCE_NORMAL))
 				playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
 				welded()
+
+	zero_health()
+		broken(1)
 
 	// called when pipe is cut with welder
 	proc/welded()

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -9,8 +9,7 @@
 	layer = TABLE_LAYER
 	throwpass = 1
 	var/flipped = 0
-	var/maxhealth = 10
-	var/health = 10
+	max_health = 30
 
 	// For racks.
 	var/can_reinforce = 1
@@ -46,18 +45,18 @@
 			take_damage(rand(75, 125))//Enough to break a plastic table and sometimes a marble one
 
 /obj/structure/table/proc/update_material()
-	var/old_maxhealth = maxhealth
+	var/old_max_health = max_health
 	if(!material)
-		maxhealth = 10
+		max_health = 10
 	else
-		maxhealth = material.integrity / 2
+		max_health = material.integrity / 2
 
 		if(reinforced)
-			maxhealth += reinforced.integrity / 2
+			max_health += reinforced.integrity / 2
 
-	health += maxhealth - old_maxhealth
+	health += max_health - old_max_health
 
-/obj/structure/table/proc/take_damage(amount)
+/obj/structure/table/take_damage(var/amount, var/damtype = BRUTE, var/user, var/used_weapon, var/bypass_resist)
 	// If the table is made of a brittle material, and is *not* reinforced with a non-brittle material, damage is multiplied by TABLE_BRITTLE_MATERIAL_MULTIPLIER
 	if(material && material.is_brittle())
 		if(reinforced)
@@ -65,10 +64,10 @@
 				amount *= TABLE_BRITTLE_MATERIAL_MULTIPLIER
 		else
 			amount *= TABLE_BRITTLE_MATERIAL_MULTIPLIER
-	health -= amount
-	if(health <= 0)
-		visible_message("<span class='warning'>\The [src] breaks down!</span>")
-		return break_to_parts() // if we break and form shards, return them to the caller to do !FUN! things with
+	.=..() // if we break and form shards, return them to the caller to do !FUN! things with
+
+/obj/structure/table/zero_health()
+	return break_to_parts()
 
 /obj/structure/table/Initialize()
 	. = ..()
@@ -99,8 +98,8 @@
 
 /obj/structure/table/examine(mob/user)
 	. = ..()
-	if(health < maxhealth)
-		switch(health / maxhealth)
+	if(health < max_health)
+		switch(health / max_health)
 			if(0.0 to 0.5)
 				to_chat(user, "<span class='warning'>It looks severely damaged!</span>")
 			if(0.25 to 0.5)
@@ -150,12 +149,12 @@
 		dismantle(W, user)
 		return 1
 
-	if(health < maxhealth && isWelder(W))
+	if(health < max_health && isWelder(W))
 		to_chat(user, "<span class='notice'>You begin reparing damage to \the [src].</span>")
 		if (W.use_tool(user, src, WORKTIME_NORMAL, QUALITY_WELDING, FAILCHANCE_NORMAL))
 			user.visible_message("<span class='notice'>\The [user] repairs some damage to \the [src].</span>",
 			                              "<span class='notice'>You repair some damage to \the [src].</span>")
-			health = max(health+(maxhealth/5), maxhealth) // 20% repair per application
+			health = max(health+(max_health/5), max_health) // 20% repair per application
 			return 1
 
 	if(!material && can_plate && istype(W, /obj/item/stack/material))

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -84,7 +84,7 @@
 	anchored = 1
 	plane = ABOVE_TURF_PLANE//on the floor
 	layer = CATWALK_LAYER//probably? Should cover cables, pipes and the rest of objects that are secured on the floor
-	var/health = 100
+	health = 100
 
 obj/structure/net/Initialize(var/mapload)
 	. = ..()
@@ -117,20 +117,14 @@ obj/structure/net/Initialize(var/mapload)
 			if (!do_after(user, 20, src))
 				visible_message("<span class='warning'>[user] stops cutting through \the [src] with \the [W]!</span>")
 				return
-			health -= 20 * (1 + (SH.force-10)/10)//the sharper the faster, every point of force above 10 adds 10 % to damage
+			take_damage(20 * (1 + (SH.force-10)/10))//the sharper the faster, every point of force above 10 adds 10 % to damage
 		visible_message("<span class='warning'>[user] cuts through \the [src]!</span>")
 		new /obj/item/stack/net(src.loc)
 		qdel(src)
 
 /obj/structure/net/bullet_act(obj/item/projectile/P)
 	. = PROJECTILE_CONTINUE //few cloth ribbons won't stop bullet or energy ray
-	if(P.damage_type != BURN)//beams, lasers, fire. Bullets won't make a lot of damage to the few hanging belts.
-		return
-	visible_message("<span class='warning'>\The [P] hits \the [src] and tears it!</span>")
-	health -= P.damage
-	if (health < 0)
-		visible_message("<span class='warning'>\The [src] is torn apart!</span>")
-		qdel(src)
+	.=..()
 
 /obj/structure/net/update_connections()//maybe this should also be called when any of the walls nearby is removed but no idea how I can make it happen
 	overlays.Cut()


### PR DESCRIPTION
This ambitious PR makes all structure damage be handled through one unified base code set. Removing a lot of duplicated effort and annoying special cases, making it much easier to damage any particular structure

In time, this could be expanded to machinery, objects, and eventually all atoms. thats probably a pipe dream but we'll see

mostly i did this now because of isssues with barricades. This makes structure barricades break properly

There are still some deployable barricades which count as machinery rather than structures, they will be dealt with in time