### PR TITLE
Replaceable cells for energy guns

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -10,8 +10,8 @@ GLOBAL_LIST_INIT(registered_cyborg_weapons, list())
 
 	var/obj/item/weapon/cell/power_supply //What type of power cell this uses
 	var/charge_cost = 20 //How much energy is needed to fire.
-	var/max_shots = 10 //Determines the capacity of the weapon's power cell. Specifying a cell_type overrides this value.
-	var/cell_type = null
+	var/max_shots = 10 //Determines the capacity of the weapon's power cell. Specifying a default_cell_type overrides this value.
+	var/default_cell_type = null
 	var/projectile_type = /obj/item/projectile/beam/practice
 	var/modifystate
 	var/charge_meter = 1	//if set, the icon state will be chosen based on the current charge
@@ -33,8 +33,8 @@ GLOBAL_LIST_INIT(registered_cyborg_weapons, list())
 
 /obj/item/weapon/gun/energy/New()
 	..()
-	if(cell_type)
-		power_supply = new cell_type(src)
+	if(default_cell_type)
+		power_supply = new default_cell_type(src)
 	else
 		power_supply = new /obj/item/weapon/cell/device/variable(src, max_shots*charge_cost)
 	if(self_recharge)

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -51,7 +51,7 @@
 /obj/item/weapon/gun/energy/pulse_rifle/destroyer
 	name = "pulse destroyer"
 	desc = "A heavy-duty, pulse-based energy weapon. Because of its complexity and cost, it is rarely seen in use except by specialists."
-	cell_type = /obj/item/weapon/cell/super
+	default_cell_type = /obj/item/weapon/cell/super
 	fire_delay = 25
 	projectile_type=/obj/item/projectile/beam/pulse/destroy
 	charge_cost= 40

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -52,6 +52,7 @@
 	name = "pulse destroyer"
 	desc = "A heavy-duty, pulse-based energy weapon. Because of its complexity and cost, it is rarely seen in use except by specialists."
 	default_cell_type = /obj/item/weapon/cell/super
+	cell_types = list(/obj/item/weapon/cell/super)
 	fire_delay = 25
 	projectile_type=/obj/item/projectile/beam/pulse/destroy
 	charge_cost= 40

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -102,6 +102,7 @@
 	w_class = ITEM_SIZE_HUGE
 	projectile_type = /obj/item/projectile/meteor
 	default_cell_type = /obj/item/weapon/cell/potato
+	cell_types = list(/obj/item/weapon/cell/potato)
 	self_recharge = 1
 	recharge_time = 5 //Time it takes for shots to recharge (in ticks)
 	charge_meter = 0

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -101,7 +101,7 @@
 	slot_flags = SLOT_BELT|SLOT_BACK
 	w_class = ITEM_SIZE_HUGE
 	projectile_type = /obj/item/projectile/meteor
-	cell_type = /obj/item/weapon/cell/potato
+	default_cell_type = /obj/item/weapon/cell/potato
 	self_recharge = 1
 	recharge_time = 5 //Time it takes for shots to recharge (in ticks)
 	charge_meter = 0

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -13,7 +13,7 @@
 	wielded_item_state = "gun_wielded"
 
 	projectile_type = /obj/item/projectile/temp
-	cell_type = /obj/item/weapon/cell/high
+	default_cell_type = /obj/item/weapon/cell/high
 	combustion = 0
 
 

--- a/code/modules/projectiles/guns/energy/temperature.dm
+++ b/code/modules/projectiles/guns/energy/temperature.dm
@@ -14,6 +14,7 @@
 
 	projectile_type = /obj/item/projectile/temp
 	default_cell_type = /obj/item/weapon/cell/high
+	cell_types = list(/obj/item/weapon/cell/potato)
 	combustion = 0
 
 


### PR DESCRIPTION
Energy guns can have their cells removed now as long as they have the removable_cell flag ticked.

Added necessary procs and vars.

This PR will segue into changes to the plasma cutter in another PR.
