### PR TITLE
Necromorph Hud Reduction

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -255,27 +255,28 @@
 	hud_elements |= mymob.zone_sel
 
 	//Handle the gun settings buttons
-	mymob.gun_setting_icon = new /obj/screen/gun/mode(null)
-	mymob.gun_setting_icon.icon = ui_style
-	mymob.gun_setting_icon.color = ui_color
-	mymob.gun_setting_icon.alpha = ui_alpha
-	hud_elements |= mymob.gun_setting_icon
-	//FAIL POINT 1
+	if(hud_data.has_guns)
+		mymob.gun_setting_icon = new /obj/screen/gun/mode(null)
+		mymob.gun_setting_icon.icon = ui_style
+		mymob.gun_setting_icon.color = ui_color
+		mymob.gun_setting_icon.alpha = ui_alpha
+		hud_elements |= mymob.gun_setting_icon
+		//FAIL POINT 1
 
-	mymob.item_use_icon = new /obj/screen/gun/item(null)
-	mymob.item_use_icon.icon = ui_style
-	mymob.item_use_icon.color = ui_color
-	mymob.item_use_icon.alpha = ui_alpha
+		mymob.item_use_icon = new /obj/screen/gun/item(null)
+		mymob.item_use_icon.icon = ui_style
+		mymob.item_use_icon.color = ui_color
+		mymob.item_use_icon.alpha = ui_alpha
 
-	mymob.gun_move_icon = new /obj/screen/gun/move(null)
-	mymob.gun_move_icon.icon = ui_style
-	mymob.gun_move_icon.color = ui_color
-	mymob.gun_move_icon.alpha = ui_alpha
+		mymob.gun_move_icon = new /obj/screen/gun/move(null)
+		mymob.gun_move_icon.icon = ui_style
+		mymob.gun_move_icon.color = ui_color
+		mymob.gun_move_icon.alpha = ui_alpha
 
-	mymob.radio_use_icon = new /obj/screen/gun/radio(null)
-	mymob.radio_use_icon.icon = ui_style
-	mymob.radio_use_icon.color = ui_color
-	mymob.radio_use_icon.alpha = ui_alpha
+		mymob.radio_use_icon = new /obj/screen/gun/radio(null)
+		mymob.radio_use_icon.icon = ui_style
+		mymob.radio_use_icon.color = ui_color
+		mymob.radio_use_icon.alpha = ui_alpha
 
 	mymob.client.screen = list()
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
@@ -140,6 +140,10 @@
 	BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right/simple)
 	)
 
+
+	//HUD Handling
+	hud_type = /datum/hud_data/necromorph
+
 /datum/species/necromorph/psychosis_vulnerable()
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/species/species_hud.dm
+++ b/code/modules/mob/living/carbon/human/species/species_hud.dm
@@ -11,6 +11,7 @@
 	var/has_throw = 1     // Set to draw throw button.
 	var/has_resist = 1    // Set to draw resist button.
 	var/has_internals = 1 // Set to draw the internals toggle button.
+	var/has_guns	=	1	//Set to draw the gun/aiming toggle buttons
 	var/list/equip_slots = list() // Checked by mob_can_equip().
 
 	// Contains information on the position and tag for all inventory slots
@@ -92,3 +93,10 @@
 		"mask" =         list("loc" = ui_shoes,     "name" = "Mask", "slot" = slot_wear_mask, "state" = "mask",  "toggle" = 1),
 		"back" =         list("loc" = ui_sstore1,   "name" = "Back", "slot" = slot_back,      "state" = "back"),
 		)
+
+
+/datum/hud_data/necromorph
+	gear = list()
+	has_internals = FALSE
+	has_nutrition = FALSE
+	has_guns = FALSE


### PR DESCRIPTION
A very simple first draft of a necromorph hud, this PR just cuts out unnecessary elements. Equipment slots, gun targeting, etc. Notably the pockets are gone, those were screwing up brute intent selection.

Its nothing special, but its functional. The brute can click its intent now