### PR TITLE
Random List Rework

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1052,6 +1052,7 @@
 #include "code\game\objects\random\misc.dm"
 #include "code\game\objects\random\random.dm"
 #include "code\game\objects\random\tools.dm"
+#include "code\game\objects\random\weapons.dm"
 #include "code\game\objects\structures\barsign.dm"
 #include "code\game\objects\structures\bedsheet_bin.dm"
 #include "code\game\objects\structures\catwalk.dm"

--- a/code/game/objects/random/misc.dm
+++ b/code/game/objects/random/misc.dm
@@ -6,4 +6,59 @@
 
 
 /obj/random/rare/item_to_spawn()
-	return pickweight(list(/obj/random/projectile  = 1))
+	return pickweight(list(/obj/random/gun  = 1, /obj/item/stack/power_node = 1))
+
+
+
+/obj/random/maintenance //Clutter and loot for maintenance and away missions
+	name = "random maintenance item"
+	desc = "This is a random maintenance item."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "gift1"
+
+/obj/random/maintenance/item_to_spawn()
+	return pickweight(list(/obj/random/junk = 3,
+				/obj/random/trash = 3,
+				/obj/random/maintenance/clean = 5))
+
+/obj/random/maintenance/clean
+/*Maintenance loot lists without the trash, for use inside things.
+Individual items to add to the maintenance list should go here, if you add
+something, make sure it's not in one of the other lists.*/
+	name = "random clean maintenance item"
+	desc = "This is a random clean maintenance item."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "gift2"
+
+/obj/random/maintenance/clean/item_to_spawn()
+	return pickweight(list(/obj/random/tech_supply = 70,
+				/obj/random/tool = 150,
+				/obj/random/medical = 40,
+				/obj/random/medical/lite = 80,
+				/obj/random/firstaid = 20,
+				/obj/random/powercell = 50,
+				/obj/random/technology_scanner = 80,
+				/obj/random/bomb_supply = 80,
+				/obj/random/contraband = 1,
+				/obj/random/action_figure = 2,
+				/obj/random/plushie = 2,
+				/obj/random/material = 40,
+				/obj/random/coin = 5,
+				/obj/random/toy = 20,
+				/obj/random/tank = 20,
+				/obj/random/soap = 5,
+				/obj/random/drinkbottle = 5,
+				/obj/random/loot = 1,
+				/obj/random/advdevice = 50,
+				/obj/random/smokes = 30,
+				/obj/random/masks = 10,
+				/obj/random/snack = 60,
+				/obj/random/storage = 30,
+				/obj/random/shoes = 20,
+				/obj/random/gloves = 10,
+				/obj/random/glasses = 20,
+				/obj/random/hat = 10,
+				/obj/random/suit = 20,
+				/obj/random/clothing = 30,
+				/obj/random/accessory = 20,
+				/obj/random/cash = 10))

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -289,91 +289,7 @@
 				/obj/item/weapon/reagent_containers/food/drinks/bottle/patron))
 
 
-/obj/random/gun
-	name = "Random Gun"
-	desc = "This is a random gun."
-	icon = 'icons/obj/gun.dmi'
-	icon_state = "energykill100"
 
-/obj/random/gun/item_to_spawn()
-	return pickweight(list(/obj/random/energy = 1, /obj/random/projectile = 2, /obj/random/handgun = 1.5))
-
-/obj/random/energy
-	name = "Random Energy Weapon"
-	desc = "This is a random energy weapon."
-	icon = 'icons/obj/gun.dmi'
-	icon_state = "energykill100"
-
-/obj/random/energy/item_to_spawn()
-	return pickweight(list(/obj/item/weapon/gun/energy/forcegun = 1,
-	/obj/item/weapon/gun/energy/contact = 1))
-	/*return pickweight(list(/obj/item/weapon/gun/energy/laser = 4,
-				/obj/item/weapon/gun/energy/gun = 3,
-				/obj/item/weapon/gun/energy/retro = 2,
-				/obj/item/weapon/gun/energy/lasercannon = 2,
-				/obj/item/weapon/gun/energy/xray = 3,
-				/obj/item/weapon/gun/energy/sniperrifle = 1,
-				/obj/item/weapon/gun/energy/gun/nuclear = 1,
-				/obj/item/weapon/gun/energy/ionrifle = 2,
-				/obj/item/weapon/gun/energy/toxgun = 3,
-				/obj/item/weapon/gun/energy/taser = 4,
-				/obj/item/weapon/gun/energy/crossbow/largecrossbow = 2,
-				/obj/item/weapon/gun/energy/stunrevolver = 4))*/
-
-/obj/random/projectile
-	name = "Random Projectile Weapon"
-	desc = "This is a random projectile weapon."
-	icon = 'icons/obj/gun.dmi'
-	icon_state = "revolver"
-
-/obj/random/projectile/item_to_spawn()
-	return pickweight(list(/obj/item/weapon/gun/projectile/automatic/pulse_rifle = 1,
-	/obj/item/weapon/gun/projectile/automatic/bullpup = 0.5,
-	/obj/item/weapon/gun/projectile/ripper = 1,
-	/obj/item/weapon/gun/projectile/seeker = 1))
-	/*
-	return pickweight(list(/obj/item/weapon/gun/projectile/shotgun/pump = 3,
-				/obj/item/weapon/gun/projectile/automatic/c20r = 2,
-				/obj/item/weapon/gun/projectile/automatic/sts35 = 2,
-				/obj/item/weapon/gun/projectile/automatic/z8 = 2,
-				/obj/item/weapon/gun/projectile/beretta = 4,
-				/obj/item/weapon/gun/projectile/colt = 4,
-				/obj/item/weapon/gun/projectile/sec = 4,
-				/obj/item/weapon/gun/projectile/sec/wood = 3,
-				/obj/item/weapon/gun/projectile/pistol = 4,
-				/obj/item/weapon/gun/projectile/pirate = 5,
-				/obj/item/weapon/gun/projectile/revolver = 2,
-				/obj/item/weapon/gun/projectile/automatic/wt550 = 3,
-				/obj/item/weapon/gun/projectile/revolver/detective = 4,
-				/obj/item/weapon/gun/projectile/revolver/mateba = 2,
-				/obj/item/weapon/gun/projectile/shotgun/doublebarrel = 4,
-				/obj/item/weapon/gun/projectile/shotgun/doublebarrel/sawn = 3,
-				/obj/item/weapon/gun/projectile/heavysniper = 1,
-				/obj/item/weapon/gun/projectile/shotgun/pump/combat = 2))*/
-
-/obj/random/handgun
-	name = "Random Handgun"
-	desc = "This is a random sidearm."
-	icon = 'icons/obj/gun.dmi'
-	icon_state = "secgundark"
-
-/obj/random/handgun/item_to_spawn()
-	return pickweight(list(/obj/item/weapon/gun/projectile/divet = 1))
-
-/obj/random/ammo
-	name = "Random Ammunition"
-	desc = "This is random ammunition."
-	icon = 'icons/obj/ammo.dmi'
-	icon_state = "45-10"
-
-/obj/random/ammo/item_to_spawn()
-	return pickweight(list(/obj/item/ammo_magazine/pulse = 1.5,
-	/obj/item/ammo_magazine/sawblades = 1,
-	/obj/item/ammo_magazine/bullpup = 1,
-	/obj/item/weapon/cell/force = 0.75,
-	/obj/item/ammo_magazine/seeker = 1,
-	/obj/item/weapon/cell/contact = 0.75,
-	/obj/item/ammo_magazine/divet = 1.5))
 
 /obj/random/action_figure
 	name = "random action figure"
@@ -899,57 +815,7 @@ obj/random/obstruction/item_to_spawn()
 				/obj/item/weapon/spacecash/bundle/c100 = 2,
 				/obj/item/weapon/spacecash/bundle/c1000 = 1))
 
-/obj/random/maintenance //Clutter and loot for maintenance and away missions
-	name = "random maintenance item"
-	desc = "This is a random maintenance item."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "gift1"
 
-/obj/random/maintenance/item_to_spawn()
-	return pickweight(list(/obj/random/junk = 4,
-				/obj/random/trash = 4,
-				/obj/random/maintenance/clean = 5))
-
-/obj/random/maintenance/clean
-/*Maintenance loot lists without the trash, for use inside things.
-Individual items to add to the maintenance list should go here, if you add
-something, make sure it's not in one of the other lists.*/
-	name = "random clean maintenance item"
-	desc = "This is a random clean maintenance item."
-	icon = 'icons/obj/items.dmi'
-	icon_state = "gift2"
-
-/obj/random/maintenance/clean/item_to_spawn()
-	return pickweight(list(/obj/random/tech_supply = 100,
-				/obj/random/medical = 40,
-				/obj/random/medical/lite = 80,
-				/obj/random/firstaid = 20,
-				/obj/random/powercell = 50,
-				/obj/random/technology_scanner = 80,
-				/obj/random/bomb_supply = 80,
-				/obj/random/contraband = 1,
-				/obj/random/action_figure = 2,
-				/obj/random/plushie = 2,
-				/obj/random/material = 40,
-				/obj/random/coin = 5,
-				/obj/random/toy = 20,
-				/obj/random/tank = 20,
-				/obj/random/soap = 5,
-				/obj/random/drinkbottle = 5,
-				/obj/random/loot = 1,
-				/obj/random/advdevice = 50,
-				/obj/random/smokes = 30,
-				/obj/random/masks = 10,
-				/obj/random/snack = 60,
-				/obj/random/storage = 30,
-				/obj/random/shoes = 20,
-				/obj/random/gloves = 10,
-				/obj/random/glasses = 20,
-				/obj/random/hat = 10,
-				/obj/random/suit = 20,
-				/obj/random/clothing = 30,
-				/obj/random/accessory = 20,
-				/obj/random/cash = 10))
 
 /obj/random/loot /*Better loot for away missions and salvage */
 	name = "random loot"
@@ -958,7 +824,7 @@ something, make sure it's not in one of the other lists.*/
 	icon_state = "gift3"
 
 /obj/random/loot/item_to_spawn()
-	return pickweight(list(/obj/random/projectile = 10,
+	return pickweight(list(/obj/random/rare = 10,
 				/obj/random/voidhelmet = 10,
 				/obj/random/voidsuit = 10,
 				/obj/random/hardsuit = 10,

--- a/code/game/objects/random/tools.dm
+++ b/code/game/objects/random/tools.dm
@@ -6,7 +6,7 @@
 
 /obj/random/tool/item_to_spawn()
 	return pickweight(list(/obj/random/rare = 3.5,
-				/obj/random/ammo	=	10,
+				/obj/random/ammo	=	12,
 				/obj/item/weapon/tool/screwdriver = 8,
 				/obj/item/weapon/tool/screwdriver/electric = 2,
 				/obj/item/weapon/tool/screwdriver/combi_driver = 1,
@@ -68,7 +68,6 @@
 				/obj/random/tool_upgrade = 25,
 				/obj/random/lathe_disk = 10,
 				/obj/random/gun_tool = 5,
-				/obj/random/ammo = 10,
 				///obj/random/mecha_equipment = 5
 				))
 

--- a/code/game/objects/random/tools.dm
+++ b/code/game/objects/random/tools.dm
@@ -5,7 +5,7 @@
 	has_postspawn = TRUE
 
 /obj/random/tool/item_to_spawn()
-	return pickweight(list(/obj/random/rare = 1,
+	return pickweight(list(/obj/random/rare = 3.5,
 				/obj/random/ammo	=	10,
 				/obj/item/weapon/tool/screwdriver = 8,
 				/obj/item/weapon/tool/screwdriver/electric = 2,
@@ -21,17 +21,18 @@
 				/obj/item/weapon/tool/crowbar/pneumatic = 2,
 				/obj/item/weapon/tool/wrench = 8,
 				/obj/item/weapon/tool/wrench/big_wrench = 2,
-				/obj/item/weapon/tool/saw = 8,
-				/obj/item/weapon/tool/saw/circular = 2,
-				/obj/item/weapon/tool/saw/advanced_circular = 1,
-				/obj/item/weapon/tool/saw/plasma = 2,
+				///obj/item/weapon/tool/saw = 8,
+				///obj/item/weapon/tool/saw/circular = 2,
+				///obj/item/weapon/tool/saw/advanced_circular = 1,
+				/obj/item/weapon/tool/saw/plasma = 13,
 				/obj/item/weapon/tool/shovel = 5,
 				/obj/item/weapon/tool/shovel/spade = 2.5,
-				/obj/item/weapon/tool/pickaxe = 2,
-				/obj/item/weapon/tool/pickaxe/jackhammer = 1,
-				/obj/item/weapon/tool/pickaxe/drill = 1,
-				/obj/item/weapon/tool/pickaxe/diamonddrill = 0.5,
-				/obj/item/weapon/tool/pickaxe/excavation = 1,
+				///obj/item/weapon/tool/pickaxe = 2,
+				///obj/item/weapon/tool/pickaxe/jackhammer = 1,
+				///obj/item/weapon/tool/pickaxe/drill = 1,
+				///obj/item/weapon/tool/pickaxe/diamonddrill = 0.5,
+				///obj/item/weapon/tool/pickaxe/excavation = 1,
+				/obj/item/weapon/tool/pickaxe/ds_rocksaw = 5.5,
 				/obj/item/weapon/tool/tape_roll = 12,
 				/obj/item/weapon/tool/tape_roll/fiber = 2,
 				/obj/item/weapon/storage/belt/utility = 5,
@@ -66,9 +67,9 @@
 				///obj/random/pouch = 5,
 				/obj/random/tool_upgrade = 25,
 				/obj/random/lathe_disk = 10,
-				///obj/random/rig_module = 5,
+				/obj/random/gun_tool = 5,
+				/obj/random/ammo = 10,
 				///obj/random/mecha_equipment = 5
-				/obj/item/stack/power_node = 5
 				))
 
 

--- a/code/game/objects/random/weapons.dm
+++ b/code/game/objects/random/weapons.dm
@@ -1,0 +1,67 @@
+/obj/random/gun
+	name = "Random Gun"
+	desc = "This is a random gun."
+	icon = 'icons/obj/gun.dmi'
+	icon_state = "energykill100"
+
+/obj/random/gun/item_to_spawn()
+	return pickweight(list(/obj/random/gun_tech = 1, /obj/random/gun_security = 1.5, /obj/random/gun_tool = 2))
+
+/obj/random/gun_tech
+	name = "Random Energy Weapon"
+	desc = "This is a random energy weapon."
+	icon = 'icons/obj/gun.dmi'
+	icon_state = "energykill100"
+
+/obj/random/gun_tech/item_to_spawn()
+	return pickweight(list(/obj/item/weapon/gun/energy/contact = 1))
+
+
+/obj/random/gun_security
+	name = "Random Projectile Weapon"
+	desc = "This is a random projectile weapon."
+	icon = 'icons/obj/gun.dmi'
+	icon_state = "revolver"
+
+/obj/random/gun_security/item_to_spawn()
+	return pickweight(list(/obj/item/weapon/gun/projectile/automatic/pulse_rifle = 1,
+	/obj/item/weapon/gun/projectile/automatic/bullpup = 0.5,
+	/obj/item/weapon/gun/projectile/divet = 2,
+	/obj/item/weapon/gun/projectile/seeker = 1))
+
+/obj/random/gun_tool
+	name = "Random Projectile Weapon"
+	desc = "This is a random projectile weapon."
+	icon = 'icons/obj/gun.dmi'
+	icon_state = "revolver"
+
+/obj/random/gun_tool/item_to_spawn()
+	return pickweight(list(
+	/obj/item/weapon/gun/projectile/ripper = 0.5,
+	/obj/item/weapon/gun/energy/forcegun = 0.5,
+	/obj/item/weapon/gun/energy/ds_miningcutter = 1,
+	/obj/item/weapon/gun/energy/ds_plasmacutter = 0.5))
+
+/obj/random/handgun
+	name = "Random Handgun"
+	desc = "This is a random sidearm."
+	icon = 'icons/obj/gun.dmi'
+	icon_state = "secgundark"
+
+/obj/random/handgun/item_to_spawn()
+	return pickweight(list(/obj/item/weapon/gun/projectile/divet = 1))
+
+/obj/random/ammo
+	name = "Random Ammunition"
+	desc = "This is random ammunition."
+	icon = 'icons/obj/ammo.dmi'
+	icon_state = "45-10"
+
+/obj/random/ammo/item_to_spawn()
+	return pickweight(list(/obj/item/ammo_magazine/pulse = 1.5,
+	/obj/item/ammo_magazine/sawblades = 1,
+	/obj/item/ammo_magazine/bullpup = 1,
+	/obj/item/weapon/cell/force = 0.75,
+	/obj/item/ammo_magazine/seeker = 1,
+	/obj/item/weapon/cell/contact = 0.75,
+	/obj/item/ammo_magazine/divet = 1.5))

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -126,5 +126,5 @@
 		/obj/random/handgun,
 		/obj/random/handgun,
 		/obj/random/handgun,
-		/obj/random/projectile,
-		/obj/random/projectile)
+		/obj/random/gun,
+		/obj/random/gun)


### PR DESCRIPTION
Modifies a few contents of random loot lists to get setting-specific content into the game.
-Removes ordinary saws and pickaxes from the lists, replacing them with plasma saw and rock saw
-Divides guns into three main types. Tech, tools, and military. Tool guns are more common and found in random tool lists
-Tweaks maintenance loot for more tool spawns
-Adds ammo drops into the various loot spawns

This is a fairly minor measure for now, to really take effect, more loot spawners should be mapped in around maintenance. Specifically, lots of
/obj/random/maintenance

Plenty of
/obj/random/tool

And a few 
/obj/random/ammo