### PR TITLE
Communication Fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2039,6 +2039,7 @@
 #include "code\modules\mob\observer\freelook\marker\biomass.dm"
 #include "code\modules\mob\observer\freelook\marker\marker.dm"
 #include "code\modules\mob\observer\freelook\marker\master.dm"
+#include "code\modules\mob\observer\freelook\marker\necrochat.dm"
 #include "code\modules\mob\observer\freelook\marker\necroshop.dm"
 #include "code\modules\mob\observer\freelook\marker\necrovision.dm"
 #include "code\modules\mob\observer\freelook\marker\signal.dm"

--- a/code/controllers/subsystems/necromorph.dm
+++ b/code/controllers/subsystems/necromorph.dm
@@ -87,16 +87,7 @@ SUBSYSTEM_DEF(necromorph)
 
 
 
-//Global Necromorph Procs
-//-------------------------
-/proc/message_necromorphs(var/message)
-	//Message all the necromorphs
-	for (var/key in SSnecromorph.necromorph_players)
-		var/mob/M = SSnecromorph.necromorph_players[key]
-		to_chat(M, message)
-	//Message all the unitologists too
-	for(var/atom/M in GLOB.unitologists_list)
-		to_chat(M, "<span class='cult'>[src]: [message]</span>")
+
 
 //Possible future todo: Allow this to take some kind of faction id in order to allow a necros vs necros gamemode
 /proc/get_marker()

--- a/code/game/gamemodes/marker/unitologist.dm
+++ b/code/game/gamemodes/marker/unitologist.dm
@@ -1,14 +1,14 @@
 GLOBAL_DATUM_INIT(unitologists, /datum/antagonist/unitologist, new)
 GLOBAL_LIST_EMPTY(unitologists_list)
-
+/*
 /mob/proc/message_unitologists()
 	set category = SPECIES_NECROMORPH
 	set name = "Commune with the marker"
 	set src = usr
 	var/message = input("Say what?","Text") as null|text
 	message = sanitize(message)
-	message_necromorphs("<span class='cult'><b>Marker hivemind -</b> [usr]: [message]</span>")
-
+	message_necromorphs("<span class='cult'>[usr]: [message]</span>")
+*/
 /datum/antagonist/unitologist
 	role_text = "Unitologist"
 	role_text_plural = "Unitologists"
@@ -39,7 +39,7 @@ datum/objective/unitologist
 	return
 
 /datum/antagonist/unitologist/proc/give_collaborators(mob/living/our_owner)
-	our_owner.verbs |= /mob/proc/message_unitologists
+	//our_owner.verbs |= /mob/proc/message_unitologists
 	to_chat(our_owner, "<span class='warning'>The marker has established a psychic link between you and your fellow unitologists.</span>")
 	to_chat(our_owner, "<span class='warning'><i>Your mind is flooded with several names, these people must also share a connection to the marker...</i></span>")
 	for(var/mob/living/minion in GLOB.unitologists_list)

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -86,7 +86,6 @@
 	'sound/effects/creatures/necromorph/leaper/leaper_speech_3.ogg',
 	'sound/effects/creatures/necromorph/leaper/leaper_speech_4.ogg')
 	)
-	speech_chance = 50
 
 /datum/species/necromorph/leaper/enhanced
 	name = SPECIES_NECROMORPH_LEAPER_ENHANCED

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
@@ -164,7 +164,7 @@
 	.=..()
 	H.verbs |= /mob/proc/necro_evacuate	//Add the verb to vacate the body. its really just a copy of ghost
 	H.verbs |= /mob/proc/prey_sightings //Verb to see the sighting information on humans
-	H.verbs |= /mob/proc/message_unitologists
+	//H.verbs |= /mob/proc/message_unitologists
 	make_scary(H)
 
 /datum/species/necromorph/proc/make_scary(mob/living/carbon/human/H)
@@ -247,5 +247,13 @@
 
 //Individual necromorphs are identified only by their species
 /datum/species/necromorph/get_random_name()
-	return src.name
+	return "[src.name] [rand(0,999)]"
 
+// Used to update alien icons for aliens.
+/datum/species/necromorph/handle_login_special(var/mob/living/carbon/human/H)
+	SSnecromorph.necromorph_players[H.key] = H
+
+// As above.
+/datum/species/necromorph/handle_logout_special(var/mob/living/carbon/human/H)
+	if (SSnecromorph.necromorph_players[H.key] == H)
+		SSnecromorph.necromorph_players -= H.key	//If they're evacuating to become a signal, they will be re-added to the list immediately

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -38,7 +38,6 @@
 
 	step_priority = 1	//We'll play our footstep sounds on hard surfaces only
 	step_volume = VOLUME_NEAR_SILENT
-	speech_chance = 100 //Lots of these sounds
 	species_audio = list(
 	SOUND_ATTACK = list('sound/effects/creatures/necromorph/twitcher/twitcher_attack_1.ogg',
 	'sound/effects/creatures/necromorph/twitcher/twitcher_attack_2.ogg',

--- a/code/modules/mob/observer/freelook/marker/master.dm
+++ b/code/modules/mob/observer/freelook/marker/master.dm
@@ -2,7 +2,7 @@
 	//The master signal is the player who controls the marker. Essentially the leader of the necromorphs
 */
 /mob/observer/eye/signal/master
-	name = "The marker"
+	name = "Marker"
 	icon = 'icons/mob/necromorph/mastersignal.dmi'
 	icon_state = "mastersignal"
 	pixel_x = -7
@@ -14,8 +14,6 @@
 	verbs -= /mob/observer/eye/signal/verb/become_master_signal_verb
 	verbs -= /mob/observer/eye/signal/verb/leave_marker_verb
 
-/mob/observer/eye/signal/master/set_name(mob/body)
-	return FALSE
 
 /mob/observer/eye/signal/verb/become_master_signal_verb()
 	set name = "Become Master Signal"
@@ -49,11 +47,13 @@
 
 	SSnecromorph.marker.open_shop(src)
 
+/*
 /mob/observer/eye/signal/master/verb/message_servants()
 	set name = "Contact servants"
 	set src = usr
 	set category = SPECIES_NECROMORPH
 	usr.message_unitologists()
+*/
 
 //Finds out if the passed thing is the marker player.
 //The thing can be a mob, client, or ckey. They will all work

--- a/code/modules/mob/observer/freelook/marker/necrochat.dm
+++ b/code/modules/mob/observer/freelook/marker/necrochat.dm
@@ -1,0 +1,36 @@
+/*
+	Quick-hack necromorph comms:
+
+	This is not an ideal implementation.
+	This would be better implemented as:
+	1. A communication channel, using the same system as dsay, asay, ooc, etc
+		or
+	2. A hivemind IC language, being the only one necromorphs know
+*/
+/mob/observer/eye/signal/say(var/message)
+	message = sanitize(message)
+	message_necromorphs("<span class='cult'>[usr]: [message]</span>")
+
+
+/mob/living/carbon/human/necromorph/say(var/message)
+	message = sanitize(message)
+	message_necromorphs("<span class='cult'>[usr]: [message]</span>")
+
+	if(prob(species.speech_chance) && check_audio_cooldown(SOUND_SPEECH))
+		set_audio_cooldown(SOUND_SPEECH, 5 SECONDS)
+		play_species_audio(src, SOUND_SPEECH, VOLUME_LOW, TRUE)
+
+
+
+//Global Necromorph Procs
+//-------------------------
+/proc/message_necromorphs(var/message)
+	//Message all the necromorphs
+	for (var/key in SSnecromorph.necromorph_players)
+		var/mob/M = SSnecromorph.necromorph_players[key]
+		to_chat(M, message)
+	//Message all the unitologists too
+	/*
+	for(var/atom/M in GLOB.unitologists_list)
+		to_chat(M, "<span class='cult'>[src]: [message]</span>")
+		*/

--- a/code/modules/mob/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal.dm
@@ -23,31 +23,13 @@
 	if(ismob(body))
 		key = body.key
 		possess(src) //Possess thyself
-		set_name(body)
+		SetName("[initial(name)] ([key])")
 
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
 
 	verbs |= /mob/proc/prey_sightings
 
 	forceMove(T)
-
-/**
-
-	Method to set the name of this signal observer to that of the one who's controlling it. Overridden by the "master signal" who should just be called "the marker".
-
-*/
-
-/mob/observer/eye/signal/proc/set_name(mob/body)
-	if(body.mind && body.mind.name)
-		name = body.mind.name
-	else
-		if(body.real_name)
-			name = body.real_name
-		else
-			if(gender == MALE)
-				name = capitalize(pick(GLOB.first_names_male)) + " " + capitalize(pick(GLOB.last_names))
-			else
-				name = capitalize(pick(GLOB.first_names_female)) + " " + capitalize(pick(GLOB.last_names))
 
 //Joining and leaving
 //-------------------------------
@@ -67,11 +49,9 @@
 
 
 /mob/proc/join_marker()
-	if (key)
-		SSnecromorph.necromorph_players |= key
-
 	message_necromorphs(SPAN_NOTICE("[key] has joined the necromorph horde."))
 	var/mob/observer/eye/signal/S = new(src)
+
 
 	return S
 
@@ -146,8 +126,12 @@
 
 //Necroqueue Handling
 //---------------------------
+
+
 /mob/observer/eye/signal/Login()
 	.=..()
+	SSnecromorph.necromorph_players[key] = src
+
 	spawn(1)	//Prevents issues when downgrading from master
 		if (!istype(src, /mob/observer/eye/signal/master))	//The master doesn't queue
 
@@ -192,3 +176,7 @@
 		return
 
 	to_chat(src, SPAN_DANGER("Error: No marker found!"))
+
+
+
+


### PR DESCRIPTION
Routes all signal and necromorph chat to necromorph telepathic communication.

After internal discussion, we couldn't agree on how to handle necromorphs, but agreed on an interim step for now of removing their access to necromorph comms.

Sets names of signals and necromorphs properly in an identifiable manner. Necros are assigned a random number so the marker can tell them apart