### PR TITLE
Test 2 Balance Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -24,7 +24,7 @@ meteor_act
 		accuracy -= organ.base_miss_chance
 
 
-	world << "[weapon] 	[accuracy]% acc against [src]"
+	//world << "[weapon] 	[accuracy]% acc against [src]"
 
 	//For humans, we run the accuracy check twice
 	//1. To see whether we hit anything at all. Fail, and the attack misses.

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -24,6 +24,8 @@ meteor_act
 		accuracy -= organ.base_miss_chance
 
 
+	world << "[weapon] 	[accuracy]% acc against [src]"
+
 	//For humans, we run the accuracy check twice
 	//1. To see whether we hit anything at all. Fail, and the attack misses.
 	if (!prob(accuracy))
@@ -51,7 +53,7 @@ meteor_act
 			P.on_hit(src, 100, def_zone)
 			return 100
 
-	var/obj/item/organ/external/organ = get_organ(def_zone)
+	var/obj/item/organ/external/organ = find_target_organ(def_zone)
 	var/armor = getarmor_organ(organ, P.check_armour)
 	var/penetrating_damage = ((P.damage + P.armor_penetration) * P.penetration_modifier) - armor
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -17,6 +17,7 @@
 	layer = LARGE_MOB_LAYER
 
 	biomass = 500
+	mass = 250
 	biomass_reclamation_time	=	15 MINUTES
 
 
@@ -114,7 +115,7 @@
 	set category = "Abilities"
 
 
-	.= brute_charge_attack(A, _delay = 1.5 SECONDS, _speed = 3.5, _lifespan = 8 SECONDS, _inertia = TRUE)
+	.= brute_charge_attack(A, _delay = 1.25 SECONDS, _speed = 3.5, _lifespan = 8 SECONDS, _inertia = TRUE)
 	if (.)
 		var/mob/living/carbon/human/H = src
 		if (istype(H))

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -12,6 +12,7 @@
 	unarmed_types = list(/datum/unarmed_attack/blades, /datum/unarmed_attack/bite/weak) //Bite attack is a backup if blades are severed
 	total_health = 70
 	biomass = 70
+	mass = 70
 
 	biomass_reclamation_time	=	7.5 MINUTES
 
@@ -77,6 +78,7 @@
 	total_health = 175
 	slowdown = 2.8
 	biomass = 175
+	mass = 120
 	mob_size	= MOB_LARGE
 	bump_flag 	= HEAVY
 
@@ -148,8 +150,8 @@
 	sharp = TRUE
 	edge = TRUE
 	shredding = TRUE
-	damage = 15
-	delay = 12
+	damage = 14
+	delay = 13
 	airlock_force_power = 2
 
 //Can't slash things without arms
@@ -159,8 +161,8 @@
 	return TRUE
 
 /datum/unarmed_attack/blades/strong
-	damage = 22
-	delay = 10
+	damage = 20
+	delay = 11
 	airlock_force_power = 3
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -9,6 +9,7 @@
 	can_obliterate = FALSE
 	healing_factor = 4	//Lots of constant healing
 	biomass	=	1600	//Endgame, real expensive
+	mass = 130
 
 	icon_template = 'icons/mob/necromorph/ubermorph.dmi'
 	single_icon = FALSE

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -63,6 +63,7 @@
 	var/virus_immune
 	var/biomass	=	80	//How much biomass does it cost to spawn this (for necros) and how much does it yield when absorbed by a marker
 		//This is in kilograms, and is thus approximately the mass of an average human male adult
+	var/mass = 80	//Actual mass of the resulting mob
 
 	var/plane	=	HUMAN_PLANE
 	var/layer = 0

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -366,7 +366,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 
 	H.mob_size = mob_size
-	H.mass = biomass
+	H.mass = src.mass
 	for(var/obj/item/organ/organ in H.contents)
 		if((organ in H.organs) || (organ in H.internal_organs))
 			qdel(organ)

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -3,8 +3,8 @@
 	icon_name = "head"
 	name = "head"
 	slot_flags = SLOT_BELT
-	max_damage = 65 //after 65 damage it goes SPLAT. noticably squishy when unarmored, a lot more durable when armored.
-	min_broken_damage = 35
+	max_damage = 75
+	min_broken_damage = 45
 	w_class = ITEM_SIZE_NORMAL
 	body_part = HEAD
 	parent_organ = BP_CHEST

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -36,7 +36,7 @@
 	var/fire_anim = null
 	var/screen_shake = 0 //shouldn't be greater than 2 unless zoomed
 	var/silenced = 0
-	var/move_accuracy_mod	=	-10	//Modifier applied to accuracy while moving. Should generally be negative
+	var/move_accuracy_mod	=	-7.5	//Modifier applied to accuracy while moving. Should generally be negative
 
 
 	var/list/dispersion = list(0)

--- a/code/modules/projectiles/guns/ds13/contactbeam.dm
+++ b/code/modules/projectiles/guns/ds13/contactbeam.dm
@@ -223,8 +223,9 @@
 	Projectile
 */
 /obj/item/projectile/beam/contact
-	damage = 60
+	damage = 70
 	armor_penetration = 10
+	accuracy	=	110
 
 
 

--- a/code/modules/projectiles/guns/ds13/divet.dm
+++ b/code/modules/projectiles/guns/ds13/divet.dm
@@ -47,7 +47,7 @@
 
 /obj/item/projectile/bullet/ls_slug
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
-	damage = 20
+	damage = 22.5
 	expiry_method = EXPIRY_FADEOUT
 	muzzle_type = /obj/effect/projectile/pulse/muzzle/light
 	fire_sound='sound/weapons/guns/fire/pulse_shot.ogg'

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -33,7 +33,7 @@
 	randpixel = 4	//Offset randomly on spawn by up to this much
 
 	var/accuracy = 100	//Base chance to hit, before various modifiers are applied. This can be above 100
-	var/distance_accuracy_falloff	=	2	//Amount subtracted from accuracy for each tile travelled
+	var/distance_accuracy_falloff	=	1.75	//Amount subtracted from accuracy for each tile travelled
 	var/dispersion = 0.0
 
 	var/damage = 10


### PR DESCRIPTION
Assorted things based on playtesting last night:

Bugfixes:
-Fixed a minor bug that was causing shots aimed at limbs to miss more than they should.
-Fixed incorrect mass setting on necromorphs which was making the force gun useless

Balance:
-Slightly reduced the accuracy penalties for firing while moving, and firing over distances
-Slightly reduced damage of slasher, and increased delay between its attacks
-Slightly increased the health of heads, to make headchopping a little less effective
-Buffed contact beam damage and accuracy
-Buffed divet damage 
-Slightly reduced windup time on brute charge