### PR TITLE
Added a preference toggle for saccade speeds

### DIFF
--- a/code/__defines/client.dm
+++ b/code/__defines/client.dm
@@ -8,3 +8,5 @@
 #define KEY_MIDDLE	/datum/click_handler/modifier/middle
 #define KEY_CTRLALT	/datum/click_handler/modifier/ctrlalt
 #define KEY_CTRLSHIFT	/datum/click_handler/modifier/ctrlshift
+
+#define SACCADE_BASE_SPEED	0.45	//Time in deciseconds to move the camera over one tile

--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -55,11 +55,22 @@
 			view = temp_view
 
 
+//Returns the total distance infront of the mob that this client can see, taking into account view radius and offset
+/client/proc/get_view_length()
+	return temp_view + (view_offset_magnitude / WORLD_ICON_SIZE)
+
+
 /client/proc/set_view_offset(var/direction, var/magnitude)
+	view_offset_magnitude = magnitude //Cache this
 	var/vector2/offset = (Vector2.FromDir(direction))*magnitude
 	if (pixel_x != offset.x || pixel_y != offset.y) //If the values already match the target, don't interrupt the animation by repeating it
 		.=TRUE //Offset has changed, return true
-		animate(src, pixel_x = offset.x, pixel_y = offset.y, time = 5, easing = SINE_EASING)
+		var/saccade_time = SACCADE_BASE_SPEED / text2num(get_preference_value(/datum/client_preference/saccade_speed))
+		world << "Saccade time before dist [saccade_time]"
+		var/saccade_distance = sqrt((get_view_length()**2)*2)	//Pythagoras helps us find the distance of the saccade. Hypotenuse = square root of A squared + B squared
+		saccade_time *= saccade_distance
+		world << "Saccade dist	[saccade_distance]	Time After:[saccade_time]"
+		animate(src, pixel_x = offset.x, pixel_y = offset.y, time = saccade_time, easing = SINE_EASING)
 
 
 /client/proc/setup_click_catcher()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -53,3 +53,8 @@
 		//MOUSE HANDLING//
 		////////////
 	var/last_click_atom	//The atom we last clicked, if it was on a turf
+
+	/*-------------------------------
+		View Handling
+	--------------------------------*/
+	var/view_offset_magnitude	//Cached when view offset is set

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -194,9 +194,16 @@ var/list/_client_preferences_by_type
 	key = "HARDSUIT_ACTIVATION"
 	options = list(GLOB.PREF_MIDDLE_CLICK, GLOB.PREF_CTRL_CLICK, GLOB.PREF_ALT_CLICK, GLOB.PREF_CTRL_SHIFT_CLICK)
 
+/datum/client_preference/saccade_speed
+	description = "Saccade Speed"
+	key = "SACCADE_SPEED"
+	options = list("0.2", "0.3", "0.5", "0.75", "0.9", "1", "1.25", "1.5", "2", "2.5", "3")
+	default_value = "1"
+
 /datum/client_preference/show_credits
 	description = "Show End Titles"
 	key = "SHOW_CREDITS"
+
 
 
 /********************


### PR DESCRIPTION
Adds a control for players to adjust saccade speeds, in the preference tab.
Should help with disorientation from view shifting, by setting the speed to something thats more comfortable for you 

Possible values range from 20% to 300% of standard speed