### PR TITLE
Gamemode and unitologist fixes

### DIFF
--- a/code/_global_vars/configuration.dm
+++ b/code/_global_vars/configuration.dm
@@ -8,7 +8,7 @@ var/changelog_hash      = ""
 var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 544)
 var/join_motd = null
 
-var/master_mode       = "extended" // "extended"
+var/master_mode       = "containment" // "extended"
 var/secondary_mode    = "extended"
 var/tertiary_mode     = "extended"
 var/secret_force_mode = "secret"   // if this is anything but "secret", the secret rotation will forceably choose this mode.

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -241,7 +241,7 @@ var/list/gamemode_cache = list()
 				src.probabilities[M.config_tag] = M.probability
 				if (M.votable)
 					src.votable_modes += M.config_tag
-	src.votable_modes += "secret"
+	//src.votable_modes += "secret"
 
 /datum/configuration/proc/load(filename, type = "config") //the type can also be game_options, in which case it uses a different switch. not making it separate to not copypaste code - Urist
 	var/list/Lines = file2list(filename)

--- a/code/controllers/subsystems/necromorph.dm
+++ b/code/controllers/subsystems/necromorph.dm
@@ -8,6 +8,7 @@ SUBSYSTEM_DEF(necromorph)
 	var/list/minor_vessels	=	list()	//Necromorphs that have AI and don't need a player, but can be posessed anyway if someone wants to do manual control
 
 	//Signal Lists
+	var/list/signals	=	list()	//List of all signal players
 	var/list/necroqueue = list()	//This is a list of signal players who are waiting to be put into the first available major vessel
 
 	//Marker

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -89,6 +89,11 @@
 		var/third_greatest_votes = 0
 		var/total_votes = 0
 
+		//Short circuit it for only a single choice, just return that choice as the only winner
+		if (choices.len == 1)
+			return list(list(choices[1]), list(), list())
+
+
 		//default-vote for everyone who didn't vote
 		if(!config.vote_no_default && choices.len)
 			var/non_voters = (GLOB.clients.len - total_votes)
@@ -320,7 +325,7 @@
 							continue
 						gamemode_names[M.config_tag] = capitalize(M.name) //It's ugly to put this here but it works
 						additional_text.Add("<td align = 'center'>[M.required_players]</td>")
-					gamemode_names["secret"] = "Secret"
+					//gamemode_names["secret"] = "Secret"
 				if("crew_transfer")
 					if(!evacuation_controller || !evacuation_controller.should_call_autotransfer_vote())
 						return 0
@@ -374,21 +379,25 @@
 			mode = vote_type
 			initiator = initiator_key
 			started_time = world.time
-			var/text = "[capitalize(mode)] vote started by [initiator]."
-			if(mode == "custom")
-				text += "\n[question]"
 
-			log_vote(text)
-			to_world("<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes.\nYou have [config.vote_period/10] seconds to vote.</font>")
+			if (choices.len > 1)
+				var/text = "[capitalize(mode)] vote started by [initiator]."
+				if(mode == "custom")
+					text += "\n[question]"
 
-			to_world(sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = GLOB.vote_sound_channel))
+				log_vote(text)
+				to_world("<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=\ref[src]'>here</a> to place your votes.\nYou have [config.vote_period/10] seconds to vote.</font>")
 
-			if(mode == "gamemode" && round_progressing)
-				round_progressing = 0
-				to_world("<font color='red'><b>Round start has been delayed.</b></font>")
+				to_world(sound('sound/ambience/alarm4.ogg', repeat = 0, wait = 0, volume = 50, channel = GLOB.vote_sound_channel))
+
+				if(mode == "gamemode" && round_progressing)
+					round_progressing = 0
+					to_world("<font color='red'><b>Round start has been delayed.</b></font>")
 
 
-			time_remaining = round(config.vote_period/10)
+				time_remaining = round(config.vote_period/10)
+			else
+				time_remaining = round(0)//If there's only one choice it will win
 			return 1
 		return 0
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -67,6 +67,7 @@
 	var/list/global_objectives =   list()   // Universal objectives if any.
 	var/list/candidates =          list()   // Potential candidates.
 	var/list/faction_members =     list()   // Semi-antags (in-round revs, borer thralls)
+	var/preference_candidacy_toggle = FALSE	// Whether to show an option in preferences to toggle candidacy
 
 	// ID card stuff.
 	var/default_access = list()
@@ -123,7 +124,6 @@
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
 		else
 			candidates |= player
-
 	return candidates
 
 // Builds a list of potential antags without actually setting them. Used to test mode viability.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -6,7 +6,7 @@ var/global/list/additional_antag_types = list()
 	var/round_description = "How did you even vote this in?"
 	var/extended_round_description = "This roundtype should not be spawned, let alone votable. Someone contact a developer and tell them the game's broken again."
 	var/config_tag = null
-	var/votable = 1
+	var/votable = FALSE
 	var/probability = 0
 
 	var/required_players = 0                 // Minimum players for round to start if voted in.
@@ -401,7 +401,7 @@ var/global/list/additional_antag_types = list()
 				players -= player
 
 		// If we don't have enough antags, draft people who voted for the round.
-		if(candidates.len < required_enemies)
+		if(candidates.len < max(required_enemies, antag_template.initial_spawn_target))
 			for(var/mob/new_player/player in players)
 				if(!antag_id || !(antag_id in player.client.prefs.never_be_special_role))
 					log_debug("[player.key] has not selected never for this role, so we are drafting them.")
@@ -409,6 +409,7 @@ var/global/list/additional_antag_types = list()
 					players -= player
 					if(candidates.len == required_enemies || players.len == 0)
 						break
+
 
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than required_enemies
 							//			required_enemies if the number of people with that role set to yes is less than recomended_enemies,

--- a/code/game/gamemodes/marker/marker.dm
+++ b/code/game/gamemodes/marker/marker.dm
@@ -18,7 +18,7 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	votable = TRUE
 	var/evac_points = 0
 	var/evac_threshold = 85 //2 hours until you get to evac.
-	var/marker_setup_time = 20 SECONDS	//TODO: Change this to 25 mins ish?
+	var/marker_setup_time = 25 MINUTES
 
 
 /datum/game_mode/marker/post_setup() //Mr Gaeta. Start the clock.
@@ -28,10 +28,8 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 		return
 	command_announcement.Announce("Delivery of alien artifact successful at [get_area(SSnecromorph.marker)].","Ishimura Deliveries Subsystem") //Placeholder
 	addtimer(CALLBACK(src, .proc/activate_marker), rand_between(0.85, 1.15)*marker_setup_time) //We have to spawn the marker quite late, so guess we'd best wait :)
-	crash_with("MARKER POST SETUP")
 
 /datum/game_mode/marker/proc/pick_marker_player()
-	crash_with("PICK MARKER PLAYER")
 	if (SSnecromorph.marker.player)
 		return	//There's already a marker player
 

--- a/code/game/gamemodes/marker/unitologist.dm
+++ b/code/game/gamemodes/marker/unitologist.dm
@@ -14,10 +14,11 @@ GLOBAL_LIST_EMPTY(unitologists_list)
 	role_text_plural = "Unitologists"
 	welcome_text = "You are part of a new religion which worships strange alien artifacts, believing that only through them can humanity truly transcend. You have been blessed with a psychic connection created by the <b>marker</b>, one of these artifacts. Serve the marker's will at all costs by bringing it human sacrifices and remember that its objectives come before your own..."
 	id = MODE_UNITOLOGIST
-	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE | ANTAG_OVERRIDE_JOB
+	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	skill_setter = /datum/antag_skill_setter/station
 	antaghud_indicator = "hudunitologist" // Used by the ghost antagHUD.
 	antag_indicator = "hudunitologist"// icon_state for icons/mob/mob.dm visual indicator.
+	preference_candidacy_toggle = TRUE
 
 datum/objective/unitologist
 	explanation_text = "Serve the marker at all costs."
@@ -46,12 +47,3 @@ datum/objective/unitologist
 		if(minion && minion != our_owner)
 			to_chat(our_owner, "Fellow unitologist: [minion.real_name]")
 			our_owner.mind.store_memory("<b>Fellow unitologist</b>: [minion.real_name]")
-
-/*
-/datum/antagonist/rogue_ai/build_candidate_list()
-	..()
-	for(var/datum/mind/player in candidates)
-		if(player.assigned_role && player.assigned_role != "AI")
-			candidates -= player
-	return candidates
-*/ //Useful code that lets you force candidate selection. Use this for marker?

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -9,7 +9,6 @@
 	extended_round_description = "We are on an unavoidable collision course with an asteroid field. You have only a moment to prepare before you are barraged by dust and meteors. As if it was not enough, all kinds of negative events seem to happen more frequently. Good Luck."
 	config_tag = "meteor"
 	required_players = 5				// Definitely not good for low-pop
-	votable = 1
 	shuttle_delay = 2
 	var/next_wave = INFINITY			// Set in post_setup() correctly to take into account potential longer pre-start times.
 	var/alert_sent = 0

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -42,6 +42,8 @@
 	. += "<table>"
 	for(var/ntype in subtypesof(/datum/species/necromorph))
 		var/datum/species/necromorph/N = ntype
+		if (!initial(N.marker_spawnable))
+			continue
 		var/necro_id = initial(N.name)
 		. += "<tr><td>[necro_id]: </td><td>"
 		if(necro_id in pref.never_be_special_role)
@@ -53,6 +55,8 @@
 	var/list/all_antag_types = GLOB.all_antag_types_
 	for(var/antag_type in all_antag_types)
 		var/datum/antagonist/antag = all_antag_types[antag_type]
+		if (!antag.preference_candidacy_toggle)
+			continue
 		. += "<tr><td>[antag.role_text]: </td><td>"
 		if(jobban_isbanned(preference_mob(), antag.id) || (antag.id == MODE_MALFUNCTION && jobban_isbanned(preference_mob(), "AI")))
 			. += "<span class='danger'>\[BANNED\]</span><br>"

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -27,7 +27,7 @@ var/list/ghost_traps
 	var/ghost_trap_message = "They are occupying a positronic brain now."
 	var/ghost_trap_role = "Positronic Brain"
 	var/can_set_own_name = TRUE
-	var/list_as_special_role = TRUE	// If true, this entry will be listed as a special role in the character setup
+	var/list_as_special_role = FALSE	// If true, this entry will be listed as a special role in the character setup
 
 	var/list/request_timeouts
 

--- a/code/modules/mob/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal.dm
@@ -137,7 +137,7 @@
 /mob/observer/eye/signal/Login()
 	.=..()
 	SSnecromorph.necromorph_players[key] = src
-	//client.show_popup_menus = FALSE	//TODO: Figure out a way to not need this
+	SSnecromorph.signals |= src
 
 	spawn(1)	//Prevents issues when downgrading from master
 		if (!istype(src, /mob/observer/eye/signal/master))	//The master doesn't queue
@@ -153,9 +153,13 @@
 	if (!istype(src, /mob/observer/eye/signal/master))
 		SSnecromorph.remove_from_necroqueue(src)
 	.=..()
+	spawn()
+		if (!QDELETED(src))
+			qdel(src)	//A signal shouldn't exist with nobody in it
 
 /mob/observer/eye/signal/Destroy()
 	SSnecromorph.remove_from_necroqueue(src)
+	SSnecromorph.signals -= src
 	.=..()
 
 


### PR DESCRIPTION
closes #124 
Marker player is selected from signals instead of live unitologists
Marker gamemode renamed to Containment, and it is now the default
Voting windows now instantly auto-end without showing a window, if there is only one choice. 
Removed defunct bay gamemodes from voting window
Removed Secret and Extended so there's only one choice
Removed defunct bay antags and ghost traps from preference candidacy selection
Removed fleshy brute from candidacy selection
Fixed a lot of little bugs in role picking