### PR TITLE
Bleeding and Belts

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -40,8 +40,9 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /mob/living/attackby(obj/item/I, mob/user)
 	if(!ismob(user))
 		return 0
-	if(can_operate(src,user) && I.do_surgery(src,user)) //Surgery
-		return 1
+	if(can_operate(src,user))
+		if (I.do_surgery(src,user) || (user.a_intent == I_HELP && !(I.item_flags & ITEM_FLAG_NO_BLUDGEON))) //Surgery
+			return TRUE
 	return I.attack(src, user, user.zone_sel.selecting)
 
 /mob/living/carbon/human/attackby(obj/item/I, mob/user)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -11,6 +11,7 @@
 	var/heal_burn = 0
 	var/animal_heal = 3
 	var/apply_sounds
+	item_flags = ITEM_FLAG_NO_BLUDGEON
 
 /obj/item/stack/medical/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if (!istype(M))

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -108,12 +108,7 @@
 	item_state = "utility"
 	overlay_flags = BELT_OVERLAY_ITEMS
 	can_hold = list(
-		///obj/item/weapon/combitool,
-		/obj/item/weapon/tool/crowbar,
-		/obj/item/weapon/tool/screwdriver,
-		/obj/item/weapon/tool/weldingtool,
-		/obj/item/weapon/tool/wirecutters,
-		/obj/item/weapon/tool/wrench,
+		/obj/item/weapon/tool,
 		/obj/item/device/multitool,
 		/obj/item/device/flashlight,
 		/obj/item/stack/cable_coil,
@@ -160,8 +155,28 @@
 	icon_state = "medicalbelt"
 	item_state = "medical"
 	can_hold = list(
+		/obj/item/device/healthanalyzer,
+		/obj/item/weapon/reagent_containers/dropper,
+		/obj/item/weapon/reagent_containers/glass/beaker,
+		/obj/item/weapon/reagent_containers/glass/bottle,
+		/obj/item/weapon/reagent_containers/pill,
+		/obj/item/weapon/reagent_containers/syringe,
+		/obj/item/weapon/flame/lighter/zippo,
+		/obj/item/weapon/storage/fancy/cigarettes,
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/stack/medical,
 		/obj/item/device/flashlight/pen,
-		/obj/item/weapon/storage/med_pouch
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/head/surgery,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/weapon/tool/crowbar,
+		/obj/item/device/flashlight,
+		/obj/item/taperoll,
+		/obj/item/weapon/extinguisher/mini,
+		/obj/item/weapon/storage/med_pouch,
+		/obj/item/bodybag
 		)
 
 /obj/item/weapon/storage/belt/holster/security
@@ -169,9 +184,33 @@
 	desc = "Can hold security gear like handcuffs and flashes."
 	icon_state = "securitybelt"
 	item_state = "security"
-	storage_slots = 10
-	can_hold = list()
+	storage_slots = 7
 	overlay_flags = BELT_OVERLAY_ITEMS|BELT_OVERLAY_HOLSTER
+	can_hold = list(
+		/obj/item/weapon/tool/crowbar,
+		/obj/item/weapon/grenade,
+		/obj/item/weapon/reagent_containers/spray/pepper,
+		/obj/item/weapon/handcuffs,
+		/obj/item/device/flash,
+		/obj/item/clothing/glasses,
+		/obj/item/ammo_casing/shotgun,
+		/obj/item/ammo_magazine,
+		/obj/item/weapon/reagent_containers/food/snacks/donut/,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/melee/telebaton,
+		/obj/item/weapon/flame/lighter,
+		/obj/item/clothing/glasses/hud/security,
+		/obj/item/device/flashlight,
+		/obj/item/modular_computer/pda,
+		/obj/item/device/radio/headset,
+		/obj/item/device/hailer,
+		/obj/item/device/megaphone,
+		/obj/item/weapon/melee,
+		/obj/item/taperoll,
+		/obj/item/device/holowarrant,
+		/obj/item/weapon/magnetic_ammo,
+		/obj/item/device/binoculars
+		)
 
 /obj/item/weapon/storage/belt/general
 	name = "equipment belt"
@@ -245,7 +284,7 @@
 	desc = "Can hold forensic gear like fingerprint powder and luminol."
 	icon_state = "forensicbelt"
 	item_state = "forensic"
-	storage_slots = 8
+	storage_slots = 7
 	overlay_flags = BELT_OVERLAY_HOLSTER
 	can_hold = list(
 		/obj/item/weapon/reagent_containers/spray/luminol,
@@ -333,8 +372,7 @@
 	desc = "Can hold security gear like handcuffs and flashes, with more pouches for more storage."
 	icon_state = "swatbelt"
 	item_state = "swatbelt"
-	storage_slots = 18
-	can_hold = list()
+	storage_slots = 10
 
 /obj/item/weapon/storage/belt/waistpack
 	name = "waist pack"

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -244,10 +244,10 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 /obj/item/organ/external/proc/get_agony_multiplier()
 	return has_genitals() ? 2 : 1
 
-/obj/item/organ/external/proc/sever_artery() //disabling this proc by checking for tendon cuts, which are also disabled.
+/obj/item/organ/external/proc/sever_artery()
 	if(species && species.has_organ[BP_HEART])
 		var/obj/item/organ/internal/heart/O = species.has_organ[BP_HEART]
-		if(!BP_IS_ROBOTIC(src) && !(status & ORGAN_TENDON_CUT) && !initial(O.open))
+		if(!BP_IS_ROBOTIC(src) && !(status & ORGAN_ARTERY_CUT) && !initial(O.open))
 			status |= ORGAN_ARTERY_CUT
 			return TRUE
 	return FALSE


### PR DESCRIPTION
Some small medical +belt changes and fixes:

Mostly reverts changes to belts from squadisnotbroken, his PR broke medical belts among other things

Reverts a bizarre deliberately introduced bug which was intended to disable arterial bleeding, but never actually did this.  Arterial bleeding is pretty cool and makes some gory spray patterns, we don't really want to disable it.

Halved blood loss from arterial spray, just to make it less of a pain

Tweaked surgery targeting code to prevent hitting the target when in help intent. If you actually want to murder someone who is lying on a table, you now need to switch to harm intent to strike them with weapons.

Thoroughly tested fixing internal bleeding, it works well. It was reported not working, but unclear if i've fixed that or simply can't reproduce it