### PR TITLE
Firedoor Nerfs

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1113,6 +1113,8 @@ About the new airlock wires panel:
 				to_chat(user, "<span class='notice'>The airlock's bolts prevent it from being forced.</span>")
 			else if(brace)
 				to_chat(user, "<span class='notice'>The airlock's brace holds it firmly in place.</span>")
+			else if((stat & BROKEN) && !density)//Broken doors must be open, they cannot be forced closed
+				to_chat(user, "<span class='notice'>The [src] is too damaged to be closed!</span>")
 			else if (C.use_tool(user, src, WORKTIME_FAST, QUALITY_PRYING, FAILCHANCE_NORMAL))
 				if(density)
 					spawn(0)	open(1)
@@ -1192,6 +1194,7 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/set_broken()
 	src.p_open = 1
+	welded = 0
 	stat |= BROKEN
 	if (secured_wires)
 		lock()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -103,7 +103,7 @@
 	return 1
 
 /obj/machinery/door/proc/can_close()
-	if(density || operating || !ticker)
+	if(density || operating || !ticker || (stat & BROKEN))
 		return 0
 	return 1
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -22,7 +22,8 @@
 	open_layer = BELOW_DOOR_LAYER
 	closed_layer = ABOVE_WINDOW_LAYER
 
-	maxhealth = 150
+	maxhealth = 50
+	min_force = 12
 
 	//These are frequenly used with windows, so make sure zones can pass.
 	//Generally if a firedoor is at a place where there should be a zone boundery then there will be a regular door underneath it.
@@ -144,6 +145,9 @@
 		if(A.fire || A.air_doors_activated)
 			alarmed = 1
 
+	if (check_unarmed_force(user))
+		return
+
 	//Firelock confirmation window removed. It is unimmersive HRP nonsense which doesn't belong here
 	//Also, necromorphs can't read warning labels
 
@@ -157,10 +161,7 @@
 	if(alarmed && density && lockdown && !allowed(user))
 		to_chat(user, "<span class='warning'>Access denied. Please wait for authorities to arrive, or for the alert to clear.</span>")
 		return
-	else
-		user.visible_message("<span class='notice'>\The [src] [density ? "open" : "close"]s for \the [user].</span>",\
-		"\The [src] [density ? "open" : "close"]s.",\
-		"You hear a beep, and a door opening.")
+
 
 	var/needs_to_close = 0
 	if(density)
@@ -338,8 +339,9 @@
 	return
 
 /obj/machinery/door/firedoor/close()
+
 	latetoggle()
-	return ..()
+	.= ..()
 
 /obj/machinery/door/firedoor/open(var/forced = 0)
 	if(hatch_open)

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -180,7 +180,7 @@ var/global/list/sparring_attack_cache = list()
 		setClickCooldown(u_attack.delay)
 		var/damage_done = target.hit(src, null, u_attack.damage*u_attack.structure_damage_mult) //TODO Later: Add in an attack flag for ignoring resistance?
 		u_attack.show_attack(src, target, null, damage_done)
-
+		return TRUE
 
 
 


### PR DESCRIPTION
A few major useability tweaks for necromorphs struggling to get around a ship with atmos problems:
-Significantly reduces the health of firelocks. They're meant to stop gases, not brute force
-Necros can actually hit firelocks with their basic attacks now
-Fixed welded doors being unbreakable
-All doors, globally, are no longer able to close once broken open. They must be repaired before you can close them. Being able to close them really defeated the point of breaking them