### PR TITLE
Bodybag fix

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -78,6 +78,8 @@
 	if(!(ishuman(user) || isrobot(user)))	return 0
 	if(opened)	return 0
 	if(contents.len)	return 0
+	if (QDELETED(src))
+		return 0
 	visible_message("[user] folds up the [name]")
 	. = new item_path(get_turf(src))
 	qdel(src)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -43,6 +43,7 @@
 
 /obj/structure/closet/Destroy()
 	dump_contents()
+	.=..()
 
 /obj/structure/closet/LateInitialize(mapload, ...)
 	var/list/will_contain = WillContain()


### PR DESCRIPTION
closes #145 
a parent call was missing in a destroy override, causing delayed deletion