### PR TITLE
Charging and limb balancing

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -210,11 +210,11 @@
 /turf/simulated/wall/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			take_damage(rand(250, 400))
+			take_damage(rand(500, 800))
 		if(2.0)
-			take_damage(rand(150, 250))
+			take_damage(rand(250, 400))
 		if(3.0)
-			take_damage(rand(0, 150))
+			take_damage(rand(100, 200))
 		else
 	return
 

--- a/code/modules/mob/living/abilities/charge_brute.dm
+++ b/code/modules/mob/living/abilities/charge_brute.dm
@@ -15,7 +15,7 @@
 	.=..()
 	//Parent will return false if something stopped our charge
 	if (.)
-		//When the brute moves, it also impacts things in tiles either side of it
+		//When the brute moves, it also impacts mobs in tiles either side of it
 		var/charge_direction = get_dir(oldloc, newloc)
 		var/list/turfs = list(get_step(mover, turn(charge_direction, 90)), get_step(mover, turn(charge_direction, -90)))
 
@@ -24,14 +24,8 @@
 			if (!continue_charge)
 				break
 
-			if (T.density)
-				continue_charge = src.bump(mover, T)
-
-			if (!continue_charge)
-				break
-
-			for (var/atom/A in T)
-				if (ismob(A) || A.density)
+			for (var/mob/A in T)
+				if (ismob(A))
 					continue_charge = src.bump(mover, A)
 
 				if (!continue_charge)

--- a/code/modules/mob/living/abilities/gallop.dm
+++ b/code/modules/mob/living/abilities/gallop.dm
@@ -82,7 +82,7 @@
 		user.visible_message(SPAN_DANGER("[user] crumples under the impact [istype(used_weapon, /obj) ? "of":"from"] [used_weapon]"))
 		stop_crash(used_weapon)
 
-/datum/extension/gallop/proc/user_bumped(var/atom/obstacle)
+/datum/extension/gallop/proc/user_bumped(var/mob/user, var/atom/obstacle)
 	if (!crashed)
 		user.visible_message(SPAN_DANGER("[user] crashes into [obstacle]"))
 		stop_crash(obstacle)

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -140,9 +140,13 @@
 
 
 //Leap attack
-/atom/movable/proc/leaper_leap(var/atom/A)
+/atom/movable/proc/leaper_leap(var/mob/living/A)
 	set name = "Leap"
 	set category = "Abilities"
+
+	//Leap autotargets enemies within one tile of the clickpoint
+	if (!isliving(A))
+		A = autotarget_enemy_mob(A, 1, src, 999)
 
 	var/mob/living/carbon/human/H = src
 
@@ -162,9 +166,13 @@
 	return leap_attack(A, _cooldown = 6 SECONDS, _delay = 1.5 SECONDS, _speed = 6, _maxrange = 11,_lifespan = 8 SECONDS, _maxrange = 20)
 
 
-/atom/movable/proc/leaper_leap_enhanced(var/atom/A)
+/atom/movable/proc/leaper_leap_enhanced(var/mob/living/A)
 	set name = "Leap"
 	set category = "Abilities"
+
+	//Leap autotargets enemies within one tile of the clickpoint
+	if (!isliving(A))
+		A = autotarget_enemy_mob(A, 1, src, 999)
 
 	var/mob/living/carbon/human/H = src
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -171,9 +171,13 @@
 /*
 	Abilities
 */
-/atom/movable/proc/slasher_charge(var/atom/A)
+/atom/movable/proc/slasher_charge(var/mob/living/A)
 	set name = "Charge"
 	set category = "Abilities"
+
+	//Charge autotargets enemies within one tile of the clickpoint
+	if (!isliving(A))
+		A = autotarget_enemy_mob(A, 1, src, 999)
 
 
 	.= charge_attack(A, _delay = 1 SECONDS, _speed = 5.5, _lifespan = 6 SECONDS)
@@ -190,10 +194,13 @@
 		shake_animation(30)
 
 
-/atom/movable/proc/slasher_charge_enhanced(var/atom/A)
+/atom/movable/proc/slasher_charge_enhanced(var/mob/living/A)
 	set name = "Charge"
 	set category = "Abilities"
 
+	//Charge autotargets enemies within one tile of the clickpoint
+	if (!isliving(A))
+		A = autotarget_enemy_mob(A, 1, src, 999)
 
 	.= charge_attack(A, _delay = 0.75 SECONDS, _speed = 6.5, _lifespan = 6 SECONDS)
 	if (.)

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -95,9 +95,13 @@
 
 //Twitcher charge
 //Aside from being faster moving, it also kicks off with a shortrange teleport, and has a much lower cooldown
-/mob/living/carbon/human/proc/twitcher_charge(var/atom/A)
+/mob/living/carbon/human/proc/twitcher_charge(var/mob/living/A)
 	set name = "Charge"
 	set category = "Abilities"
+
+	//Charge autotargets enemies within one tile of the clickpoint
+	if (!isliving(A))
+		A = autotarget_enemy_mob(A, 1, src, 999)
 
 
 	.= charge_attack(A, _delay = 1.3 SECONDS, _speed = 7, _cooldown = 6 SECONDS)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -12,6 +12,7 @@
 	min_age = 16
 	max_age = 65
 	gluttonous = GLUT_TINY
+	limb_health_factor = 1.15
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_LACE
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_NORMAL | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -3,8 +3,8 @@
 	icon_name = "head"
 	name = "head"
 	slot_flags = SLOT_BELT
-	max_damage = 75
-	min_broken_damage = 45
+	max_damage = 80
+	min_broken_damage = 50
 	w_class = ITEM_SIZE_NORMAL
 	body_part = HEAD
 	parent_organ = BP_CHEST

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -42,8 +42,8 @@
 	name = "lower body"
 	organ_tag = BP_GROIN
 	icon_name = "groin"
-	max_damage = 45
-	min_broken_damage = 25
+	max_damage = 90
+	min_broken_damage = 50
 	w_class = ITEM_SIZE_LARGE
 	body_part = LOWER_TORSO
 	parent_organ = BP_CHEST


### PR DESCRIPTION
New Feature:
Charge attacks now have autoaim. Clicking within 1 tile of a live enemy mob will target them instead of the floor you probably clicked on
Added a timeout to charge attacks. If the user doesn't move for 0.75 seconds during a charge, it will cancel itself.
Reduced the crash stun times on charge attacks by 30%
Partially reverted a recent change to brute; Brute's charge now only has wide collision against mobs, not objects, so less getting caught on small obstacles

Balance:
Doubled the base health of groins. Since the victim loses both legs by losing it, it makes sense for it to have as much health as both legs together
Slightly increased head health
In addition to the above, globally increased the health of human limbs by 15%
Significantly increases ex_act damage dealt to walls. This is primarily for the purpose of brutes gradually breaking them down

These changes should help to mitigate the impact of recent fixes that made delimbing far easier

Bugfixes:
Fixed leaper gallop displaying an incorrect message that the leaper crashed into itself