### PR TITLE
Crafting and Saw Tweaks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -256,6 +256,7 @@
 #include "code\datums\communication\pray.dm"
 #include "code\datums\communication\~defines.dm"
 #include "code\datums\craft\item.dm"
+#include "code\datums\craft\lockout.dm"
 #include "code\datums\craft\menu.dm"
 #include "code\datums\craft\recipe.dm"
 #include "code\datums\craft\step.dm"

--- a/code/datums/craft/lockout.dm
+++ b/code/datums/craft/lockout.dm
@@ -1,0 +1,22 @@
+/datum/extension/craft_lockout
+	/datum/extension/charge
+	name = "Craft"
+	base_type = /datum/extension/craft_lockout
+	expected_type = /mob/living
+	flags = 1	// This is EXTENSION_FLAG_IMMEDIATE. The defines don't reach this folder
+	var/duration
+	var/ongoing_timer
+
+/datum/extension/craft_lockout/New(var/atom/_holder, var/lock_time)
+	.=..()
+	duration = lock_time
+	ongoing_timer = addtimer(CALLBACK(src, /datum/extension/craft_lockout/proc/stop), duration)
+
+/datum/extension/craft_lockout/proc/stop()
+	remove_extension(holder, /datum/extension/craft_lockout)
+
+/proc/apply_craft_lockout(var/mob/user, var/time)
+	set_extension(user, /datum/extension/craft_lockout, time)
+
+/proc/release_craft_lockout(var/mob/user)
+	remove_extension(user, /datum/extension/craft_lockout)

--- a/code/datums/craft/recipe.dm
+++ b/code/datums/craft/recipe.dm
@@ -79,6 +79,11 @@
 	if (!T)
 		return FALSE
 
+	var/datum/extension/craft_lockout/CL = get_extension(user, /datum/extension/craft_lockout)
+	if (istype(CL))
+		//Already crafting
+		return FALSE
+
 	//CRAFT_ON_SURFACE flag requires you to work on a table or bench. It must be on the tile directly infront of the user
 	//This check is skipped if there is no user
 	if (user && (flags & CRAFT_ON_SURFACE))

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -722,7 +722,7 @@
 ****************************/
 /obj/item/weapon/tool/proc/refresh_upgrades()
 //First of all, lets reset any var that could possibly be altered by an upgrade
-	degradation = initial(degradation) * 1.05 ** repair_frequency //Degradation gets slightly worse each time the tool is repaired
+	degradation = initial(degradation) * 1.10 ** repair_frequency //Degradation gets slightly worse each time the tool is repaired
 	workspeed = initial(workspeed)
 	precision = initial(precision)
 	suitable_cell = initial(suitable_cell)

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -76,9 +76,9 @@
 	tool_qualities = list()
 	switched_on_qualities = list(QUALITY_SAWING = 60, QUALITY_CUTTING = 50, QUALITY_WIRE_CUTTING = 20, QUALITY_DIGGING = 35)
 	max_upgrades = 4
-	degradation = 0.05
-	use_power_cost = 0.22
-	passive_power_cost = 0.03
+	degradation = 0.1
+	use_power_cost = 0.44
+	passive_power_cost = 0.04
 	suitable_cell = /obj/item/weapon/cell
 	toggleable = TRUE
 	atom_flags = ATOM_FLAG_NO_BLOOD


### PR DESCRIPTION
Fixes bugs that allowed duplicate/infinite crafting by adding a lockout behaviour. Only one crafting recipe can be worked on at a time

Balance Changes:
Increases power usage and degradation rate of the plasma saw
Increases damage caused by makeshift repairs with duct tape