### PR TITLE
Necrohelp

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2044,6 +2044,7 @@
 #include "code\modules\mob\observer\freelook\marker\marker.dm"
 #include "code\modules\mob\observer\freelook\marker\master.dm"
 #include "code\modules\mob\observer\freelook\marker\necrochat.dm"
+#include "code\modules\mob\observer\freelook\marker\necrohelp.dm"
 #include "code\modules\mob\observer\freelook\marker\necroshop.dm"
 #include "code\modules\mob\observer\freelook\marker\necrovision.dm"
 #include "code\modules\mob\observer\freelook\marker\signal.dm"

--- a/code/datums/extensions/interactive.dm
+++ b/code/datums/extensions/interactive.dm
@@ -4,11 +4,19 @@
 	var/list/host_predicates
 	var/list/user_predicates
 
+	//UI values
+	var/list/content_data = list()
+	var/list/data  = list()
+	var/template
+	var/title
+	var/vector2/dimensions
+
 /datum/extension/interactive/New(var/datum/holder, var/host_predicates = list(), var/user_predicates = list())
 	..()
 
 	src.host_predicates = host_predicates ? host_predicates : list()
 	src.user_predicates = user_predicates ? user_predicates : list()
+	generate_content_data()
 
 /datum/extension/interactive/Destroy()
 	host_predicates.Cut()
@@ -34,3 +42,27 @@
 	if(..())
 		return TRUE
 	return extension_act(href, href_list, usr)
+
+
+
+/datum/extension/interactive/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+
+	data = content_data
+	data += ui_data(user)
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, template, title, dimensions.x, dimensions.y, state = GLOB.interactive_state)
+		ui.set_initial_data(data)
+		ui.set_auto_update(1)
+		ui.open()
+
+
+
+
+
+//Generate and cache the common data once
+/datum/extension/interactive/proc/generate_content_data()
+	return
+
+/datum/extension/interactive/ui_data(var/mob/user)
+	return list()

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -98,6 +98,53 @@
 	)
 
 
+#define BRUTE_PASSIVE_1	"<h2>PASSIVE: Tunnel Vision:</h2><br>\
+The brute has extremely restricted vision, able only to see a few tiles infront of it, and none behind it. This makes it very vulnerable to flanking attacks. Keep the enemy infront of you!"
+
+#define BRUTE_PASSIVE_2	"<h2>PASSIVE: Organic Plating:</h2><br>\
+The brute's front and side are covered in tough armor, impenetrable to most light weapons. This armor has a 95% chance to intercept attacks, and blocks a flat 25 damage at the front, or 15 at the side.<br>\
+Any projectiles completely blocked in this matter will ricochet off and possibly hit something else. Melee attackers will be stunned, opening them to a counter attack.<br>\
+<br>\
+The unarmored areas are extremely vulnerable, and there's no armor on the rear. Any hit that isn't caused by armor will send the brute into a forced curl for 5 seconds. This forcing effect has a 1 minute cooldown."
+
+
+#define BRUTE_CHARGE_DESC	"<h2>Charge:</h2><br>\
+<h3>Hotkey: Ctrl+Alt+Click </h3><br>\
+<h3>Cooldown: 20 seconds</h3><br>\
+The user screams for a few seconds, then starts barrelling towards the target at moderate speed. While charging, the brute will hit all mobs it passes near.<br>\
+This charge has high momentum, and will keep going for a long time, or until stopped by an obstacle<br>\
+If the user hits a solid obstacle while charging, they will be stunned and take some minor damage. The obstacle will also be hit hard, and destroyed in some cases. <br>\
+<br>\
+The brute's charge is a high risk move. If used correctly, it's like bowling people, allowing you to smash through a crowd and send them flying. But you will be stunned and vulnerable afterwards, and easily surrounded."
+
+
+#define BRUTE_SLAM_DESC "<h2>Slam:</h2><br>\
+<h3>Hotkey: Alt Click</h3><br>\
+<h3>Cooldown: 8 seconds</h3><br>\
+The brute's signature move. Slam causes the user to rear back over 1.25 seconds, and then smash down in a devastating hit. The resulting strike hits a 3x2 area of effect infront of the user.<br>\
+Mobs hit by slam will take up to 40 damage depending on distance, and will be knocked down. This damage is doubled if the victim was already lying down when hit, making it an excellent finishing move<br>\
+<br>\
+Slam deals massive damage to any objects caught in its radius, making it an excellent obstacle-clearing ability. It will easily break through doors, barricades, machinery, girders, windows, etc. With repeated uses and some patience, you can even dig your way through solid walls, creating new paths<br>\
+Slam is heavily telegraphed, and hard to land hits with. Don't count on reliably hitting humans with it if they have any space to dodge"
+
+#define BRUTE_CURL "<h2>Curl:</h2><br>\
+<h3>Hotkey: Ctrl+Shift+Click</h3><br>\
+The user curls up into a ball, attempting to shield their vulnerable parts from damage, but becoming unable to turn, move or attack. While curled up, the strength of the brute's organic armor is massively increased (75% more!) and its coverage is increased to 100%<br>\
+This causes the brute to be practically invincible to attacks from the front and side, however the rear is still completely undefended.<br>\
+Brute will be forced into a reflexive curl under certain circumstances, but it can also be used manually. With the right timing, you can tank an entire firing squad while they waste ammo and deal no damage to you, leaving them vulnerable for your allies to attack from another angle."
+
+/datum/species/necromorph/brute/get_ability_descriptions()
+	.= ""
+	. += BRUTE_PASSIVE_1
+	. += "<hr>"
+	. += BRUTE_PASSIVE_2
+	. += "<hr>"
+	. += BRUTE_CHARGE_DESC
+	. += "<hr>"
+	. += BRUTE_SLAM_DESC
+	. += "<hr>"
+	. += BRUTE_CURL
+
 /datum/species/necromorph/brute/fleshy
 	name = SPECIES_NECROMORPH_BRUTE_FLESH
 	icon_normal = "brute-f"

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -93,6 +93,43 @@
 	'sound/effects/creatures/necromorph/leaper/leaper_speech_4.ogg')
 	)
 
+#define LEAPER_LEAP_DESC	"<h2>Leap:</h2><br>\
+<h3>Hotkey: Ctrl+Alt+Click </h3><br>\
+<h3>Cooldown: 6 seconds</h3><br>\
+The user screams for a few seconds, then leaps through the air towards the target at high speed. If they successfully hit the target, that target is knocked down, leaving them vulnerable to followup attacks.<br>\
+Leap has some autoaim, clicking within 1 tile of a living mob is enough to target them. It will not home in on targets though, so you're in trouble if they move after you start.<br>\
+While in the air, the leaper doesn't count as touching the ground, and will harmlessly soar over ground traps and barricades<br>\
+If the user hits a solid obstacle while leaping, they will be knocked down and take some moderate damage. The obstacle will also be hit hard, and destroyed in some cases. <br>\
+<br>\
+Leap is best used to initiate a fight by ambushing an unaware opponent. Combined with the leaper's long vision range, you can jump on someone before they've even seen you, and catch them by surprise"
+
+
+#define LEAPER_TAILSTRIKE_DESC "<h2>Tailstrike:</h2><br>\
+<h3>Hotkey: Alt+Click</h3><br>\
+<h3>Cooldown: 2.5 seconds</h3><br>\
+The leaper stands on its arms, swinging its tail around over 0.75 seconds to deal a powerful hit to a target up to 2 tiles away.<br>\
+Tailstrike hits hard, and can even destroy obstacles, but it is slow, heavily telegraphed, and easy to dodge. Very difficult to land on a target that won't stay still<br>\
+
+Best used to finish off stunned/downed/injured victims, or for smashing a path through doors and terrain"
+
+#define LEAPER_GALLOP_DESC "<h2>Gallop:</h2><br>\
+<h3>Hotkey: Ctrl+Shift+Click</h3><br>\
+<h3>Cooldown: 10 seconds</h3><br>\
+The leaper breaks into a gallop, gaining a HUGE boost to speed for 4 seconds. During this time it briefly becomes the fastest of all necromorphs.<br>\
+While galloping, the leaper is very vulnerable. Taking any damage, or bumping into any obstacles, will cause it to collapse and become stunned for a while<br>\
+
+Gallop is great to use to follow up a Leap into battle, allowing you to quickly escape before your victim gets their bearings and hits you. <br>\
+It can be used to chase down a fleeing opponent, to move along long hallways quickly, and it also allows the leaper to serve as a beast of burden, dragging corpses back faster than anyone else can."
+
+/datum/species/necromorph/leaper/get_ability_descriptions()
+	.= ""
+	. += LEAPER_LEAP_DESC
+	. += "<hr>"
+	. += LEAPER_TAILSTRIKE_DESC
+	. += "<hr>"
+	. += LEAPER_GALLOP_DESC
+
+
 /datum/species/necromorph/leaper/enhanced
 	name = SPECIES_NECROMORPH_LEAPER_ENHANCED
 	marker_spawnable = FALSE 	//Enable this once we have sprites for it

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
@@ -165,6 +165,7 @@
 	.=..()
 	H.verbs |= /mob/proc/necro_evacuate	//Add the verb to vacate the body. its really just a copy of ghost
 	H.verbs |= /mob/proc/prey_sightings //Verb to see the sighting information on humans
+	H.verbs |= /datum/proc/help //Verb to see your own abilities
 	//H.verbs |= /mob/proc/message_unitologists
 	make_scary(H)
 
@@ -254,6 +255,10 @@
 // Used to update alien icons for aliens.
 /datum/species/necromorph/handle_login_special(var/mob/living/carbon/human/H)
 	SSnecromorph.necromorph_players[H.key] = H
+	to_chat(H, "You are a [name]. \n\
+	[blurb]\n\
+	\n\
+	Check the Abilities tab, use the Help ability to find out what your controls and abilities do!")
 
 // As above.
 /datum/species/necromorph/handle_logout_special(var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -4,6 +4,7 @@
 
 #define SLASHER_DODGE_EVASION	60
 #define SLASHER_DODGE_DURATION	1.5 SECONDS
+
 /datum/species/necromorph/slasher
 	name = SPECIES_NECROMORPH_SLASHER
 	name_plural =  "Slashers"
@@ -155,6 +156,31 @@
 	damage = 14
 	delay = 13
 	airlock_force_power = 2
+
+#define SLASHER_CHARGE_DESC	"<h2>Charge:</h2><br>\
+<h3>Hotkey: Ctrl+Alt+Click </h3><br>\
+<h3>Cooldown: 20 seconds</h3><br>\
+The user screams for a few seconds, then runs towards the target at high speed. If they successfully hit the target, they deal two free melee attacks on impact.<br>\
+Charge has some autoaim, clicking within 1 tile of a living mob is enough to target them. It will also attempt to home in on targets, but will not path around obstacles<br>\
+If the user hits a solid obstacle while charging, they will be stunned and take some minor damage. The obstacle will also be hit hard, and destroyed in some cases. <br>\
+<br>\
+Charge is a great move to initiate a fight, or to damage obstacles blocking your path. If you manage to land that first hit on a human, it is devastating, and often fatal."
+
+
+#define SLASHER_DODGE_DESC "<h2>Dodge:</h2><br>\
+<h3>Hotkey: Alt+Click</h3><br>\
+<h3>Cooldown: 6 seconds</h3><br>\
+A simple trick, dodge causes the user to leap one tile to the side, and gain a large but brief bonus to evasion, making them almost impossible to hit.<br>\
+The evasion bonus only lasts 1.5 seconds, so it's best used while an enemy is already firing at you. <br>\
+
+Dodge is a skill that requires careful timing, but if used correctly, it can allow you to assault an entrenched firing line, and get close enough to land a few hits."
+
+/datum/species/necromorph/slasher/get_ability_descriptions()
+	.= ""
+	. += SLASHER_CHARGE_DESC
+	. += "<hr>"
+	. += SLASHER_DODGE_DESC
+
 
 //Can't slash things without arms
 /datum/unarmed_attack/blades/is_usable(var/mob/living/carbon/human/user, var/mob/living/carbon/human/target, var/zone)

--- a/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
@@ -70,6 +70,34 @@
 	delay = 16
 	airlock_force_power = 1.5
 
+#define SPITTER_PASSIVE	"<h2>PASSIVE: No Friendly Fire:</h2><br>\
+All projectiles fired by this necromorph will harmlessly pass over other necromorphs, and will only hit enemies."
+
+
+#define SPITTER_SNAP_DESC	"<h2>Snapshot:</h2><br>\
+<h3>Hotkey: Middle Click </h3><br>\
+<h3>Cooldown: 3 seconds</h3><br>\
+Fires an instant autoaimed shot at a target within a 5 tile range, dealing 10 burn damage on hit. <br>\
+In addition, it douses the victim in acid, dealing up to 10 additional burn damage over time <br>\
+<br>\
+Snapshot requires no manual aiming at all, and is thusly great to use in the middle of a chaotic brawl, to deal extra damage to humans who are already in melee"
+
+
+#define SPITTER_LONGSHOT_DESC "<h2>Long Shot:</h2><br>\
+<h3>Hotkey: Alt+Click</h3><br>\
+After a half-second windup, Fires a long ranged unguided bolt of acid, dealing 20 burn damage on hit<br>\
+In addition, it douses the victim in acid, dealing up to 20 additional burn damage over time <br>\
+Long shot is powerful and has no cooldown, but is easily dodged<br>\
+
+Best used for harassment, skirmishing and initiating fights from afar against unwary targets"
+
+/datum/species/necromorph/slasher/spitter/get_ability_descriptions()
+	.= ""
+	. += SPITTER_PASSIVE
+	. += "<hr>"
+	. += SPITTER_SNAP_DESC
+	. += "<hr>"
+	. += SPITTER_LONGSHOT_DESC
 
 /*
 	Snapshot fires a highly accurate projectile which autoaims at a nearby target.

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -85,6 +85,42 @@
 	'sound/effects/footstep/twitcher_footstep_4.ogg')
 	)
 
+#define TWITCHER_PASSIVE	"<h2>PASSIVE: Temporal Displacement:</h2><br>\
+The twitcher is out of phase with normal time as a result of a stasis module embedded in their body. This causes them to randomly displace in a random direction periodically while moving<br>\
+
+When hit by any attack, a defensive effect triggers, that attack deals 75% less damage, and the twitcher blinks one tile in a random direction. <br>\
+This defensive effect has a cooldown of 3 seconds."
+
+
+#define TWITCHER_CHARGE_DESC	"<h2>Charge:</h2><br>\
+<h3>Hotkey: Ctrl+Alt+Click </h3><br>\
+<h3>Cooldown: 6 seconds</h3><br>\
+The user screams for a few seconds, teleports 2 tiles towards the target, then runs the rest of the distance towards the target at extreme speed. If they successfully hit the target, they deal two free melee attacks on impact.<br>\
+Charge has some autoaim, clicking within 1 tile of a living mob is enough to target them. It will also attempt to home in on targets, but will not path around obstacles<br>\
+If the user hits a solid obstacle while charging, they will be stunned and take some minor damage. The obstacle will also be hit hard, and destroyed in some cases. <br>\
+<br>\
+Charge is a great move to initiate a fight, or to damage obstacles blocking your path. If you manage to land that first hit on a human, it is devastating, and often fatal."
+
+
+#define TWITCHER_STEPSTRIKE_DESC "<h2>Step Strike:</h2><br>\
+<h3>Hotkey: Middle Click</h3><br>\
+<h3>Cooldown: 3 seconds</h3><br>\
+The user teleports up to 2 tiles towards a nearby enemy, and then deals a free melee attack to them.<br>\
+This ability is completely autoaimed, picking a random target, and always moving to a new position even if the target is already in reach. Naturally, this constant movement makes the user hard to shoot at.<br>\
+Step strike puts your melee attack on cooldown, but it can still be used if your attack is already cooling. So for optimal damage output, use it immediately after landing a normal hit.<br>\
+
+All of these properties combined make Step Strike tricky and disorienting to use, but when used properly, the twitcher is a master close combatant"
+
+/datum/species/necromorph/slasher/twitcher/get_ability_descriptions()
+	.= ""
+	. += TWITCHER_PASSIVE
+	. += "<hr>"
+	. += TWITCHER_CHARGE_DESC
+	. += "<hr>"
+	. += TWITCHER_STEPSTRIKE_DESC
+
+
+
 //Setup the twitch extension which handles a lot of the special behaviour
 /datum/species/necromorph/slasher/twitcher/add_inherent_verbs(var/mob/living/carbon/human/H)
 	.=..()

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -93,6 +93,51 @@
 	inherent_verbs = list(/mob/living/carbon/human/proc/ubermorph_battlecry, /mob/living/carbon/human/proc/ubermorph_regenerate, /mob/living/carbon/human/proc/ubermorph_lunge, /mob/proc/shout, /mob/proc/sense_verb)
 	modifier_verbs = list(KEY_CTRLALT = list(/mob/living/carbon/human/proc/ubermorph_battlecry), KEY_CTRLSHIFT = list(/mob/proc/sense_verb), KEY_ALT = list(/mob/living/carbon/human/proc/ubermorph_lunge))
 
+#define UBERMORPH_PASSIVE	"<h2>PASSIVE: Immortal:</h2><br>\
+The Ubermorph cannot be killed by any means. While it can be dismembered, those limbs can always grow back, and its chest can never be destroyed. <br>\
+No amount of damage can finish it off, not even massive explosives can do the trick. Any damage dealt is just delaying the inevitable, ubermorph cannot die.<br>\
+<br>\
+In addition, the ubermorph passively regenerates 4 health per second."
+
+#define UBERMORPH_REGENERATE_DESC	"<h2>Regenerate:</h2><br>\
+The Ubermorph starts shaking and screaming in pain, as it regrows a missing limb and heals 40 health, over a period of 4 seconds. Even the head can be regrown."
+
+
+#define UBERMORPH_LUNGE_DESC	"<h2>Lunge:</h2><br>\
+<h3>Hotkey: Alt+Click </h3><br>\
+The user rears back for half a second, then stabs forward up to two tiles, punching through any human in the way. The victim takes 30 brute damage, and also heavy damage to an internal organ.<br>\
+Targeted at the chest or head, this will cause an injury that will usually result in inevitable death. It can also be used to deal heavy damage to obstacles, enabling doors and walls to be quickly broken down"
+
+
+#define UBERMORPH_BATTLECRY_DESC "<h2>Battlecry:</h2><br>\
+<h3>Hotkey: Ctrl+Alt+Click</h3><br>\
+<h3>Cooldown: 30 seconds</h3><br>\
+The ubermorph drives all nearby allies into a psychic frenzy, granting them a 30% increase to movespeed and attackspeed. Note that attackspeed affects cooldowns of attacks and abilities, and windup times on abilities.<br>\
+This effect lasts for 60 seconds. Multiple applications will refresh the duration, but do not stack.<br>\
+In addition, battlecry deals 15 damage to all visible enemies.<br>\
+Battlecry is best used just before an assault to break the last of the human resistance. If things somehow go south, the damage effect can also be used to scare off people attempting to hold the ubermorph hostage by repeatedly dismembering it."
+
+#define UBERMORPH_SENSE_DESC "<h2>Sense:</h2><br>\
+<h3>Hotkey: Ctrl+Shift+Click</h3><br>\
+<h3>Cooldown: 12 seconds</h3><br>\
+The ubermorph sends out a psychic pulse, detecting all living beings in a radius of 9 tiles. Any humans detected in this matter will be shown onscreen, both to the ubermorph,and to any other nearby necromorphs.<br>\
+Sense does not require line of sight, and it can detect people in other rooms, behind walls, in total darkness, or hiding inside objects, like lockers, morgue-drawers, vehicles, etc.<br>\
+<br>\
+Best used near the end, when all seems quiet, to help the necromorphs hunt down any last survivors that are trying to hide."
+
+
+/datum/species/necromorph/ubermorph/get_ability_descriptions()
+	.= ""
+	. += UBERMORPH_PASSIVE
+	. += "<hr>"
+	. += UBERMORPH_REGENERATE_DESC
+	. += "<hr>"
+	. += UBERMORPH_LUNGE_DESC
+	. += "<hr>"
+	. += UBERMORPH_BATTLECRY_DESC
+	. += "<hr>"
+	. += UBERMORPH_SENSE_DESC
+
 /datum/species/necromorph/ubermorph/get_healthstring()
 	return "&#8734;"	//The ubermorph has infinite health, lets try to communicate that
 

--- a/code/modules/mob/observer/freelook/marker/necrohelp.dm
+++ b/code/modules/mob/observer/freelook/marker/necrohelp.dm
@@ -1,0 +1,29 @@
+/*
+	Necrohelp just opens a window containing text extracted from the necromorph species the player is playing
+*/
+/datum/extension/interactive/necrohelp
+	name = "Help"
+	base_type = /datum/extension/interactive/necrohelp
+	expected_type = /mob
+	flags = EXTENSION_FLAG_IMMEDIATE
+	template = "necrohelp.tmpl"
+	dimensions = new /vector2(800, 500)
+
+/datum/extension/interactive/necrohelp/generate_content_data()
+	content_data = list()
+	if (ishuman(holder))
+		var/mob/living/carbon/human/H = holder
+		var/datum/species/necromorph/N = H.get_species_datum()
+		content_data["name"] = N.name
+		content_data["desc"] = N.get_long_description()
+		title = N.name
+
+
+
+/datum/proc/help()
+	set name = "Help"
+	set category = "Abilities"
+	set desc = "Opens a window explaining your abilities"
+
+	var/datum/extension/interactive/necrohelp/NH = get_or_create_extension(src, /datum/extension/interactive/necrohelp)
+	NH.ui_interact(src)

--- a/nano/templates/necrohelp.tmpl
+++ b/nano/templates/necrohelp.tmpl
@@ -1,0 +1,22 @@
+<!--
+Title: Necrohelp
+Used In File(s): necrohelp.dm
+ -->
+<style>
+	td {border-style: solid;
+  border-width: 1px; border-color: black;}
+  body{height: 100%; line-height:135%;}
+  
+  h1 {
+    font-size: 18px; color: #e9c183;padding: 0px;
+}
+h2 {
+    font-size: 16px; color: #e9c183;padding: 0px;
+}
+h3 {
+    font-size: 14px; color: #e9c183;padding: 0px;
+}
+
+</style>
+<h1>{{:data.name}}</h1>
+{{:data.desc}}

--- a/nano/templates/necroshop.tmpl
+++ b/nano/templates/necroshop.tmpl
@@ -6,16 +6,18 @@ data.authorised ? null : 'disabled'
 <style>
 	td {border-style: solid;
   border-width: 1px; border-color: black;}
-  body{height: 100%;}
+  body{height: 100%; line-height:100%;}
   
   h1 {
-    font-size: 18px; color: #e9c183;
+    font-size: 18px; color: #e9c183;padding: 0px;
 }
 h2 {
-    font-size: 16px; color: #e9c183;
+    font-size: 16px; color: #e9c183;padding: 0px;
+}
+h3 {
+    font-size: 14px; color: #e9c183;padding: 0px;
 }
 
-}
 </style>
 <table style="width: 100%; height: 650px; margin: 0px;">
 	<tr style="height: 5vh;">


### PR DESCRIPTION
Adds a new Help ability to all necromorphs, which opens a new window explaining all their hotkeys and abilities. 

The same information is also shown in the marker's spawning menu.

Wrote toons of new text for these descriptions

Also gives necromorphs a new greeting message when a player takes control of them, telling their role and advising to check the help page for more info