### PR TITLE
Acid improvements

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2048,7 +2048,6 @@
 #include "code\modules\mob\observer\freelook\marker\biomass.dm"
 #include "code\modules\mob\observer\freelook\marker\marker.dm"
 #include "code\modules\mob\observer\freelook\marker\master.dm"
-#include "code\modules\mob\observer\freelook\marker\necrochat.dm"
 #include "code\modules\mob\observer\freelook\marker\necrohelp.dm"
 #include "code\modules\mob\observer\freelook\marker\necroshop.dm"
 #include "code\modules\mob\observer\freelook\marker\necrovision.dm"

--- a/code/__defines/necromorph.dm
+++ b/code/__defines/necromorph.dm
@@ -2,7 +2,7 @@
 #define SPAWN_POINT		1	//The thing is spawned in a random clear tile around a specified spawnpoint
 #define SPAWN_PLACE		2	//The thing is manually placed by the user on a viable corruption tile
 
-#define NECROMORPH_ACID_POWER	4	//Damage per unit of necromorph organic acid, used by many things
+#define NECROMORPH_ACID_POWER	3.5	//Damage per unit of necromorph organic acid, used by many things
 #define NECROMORPH_FRIENDLY_FIRE_FACTOR	0.5	//All damage dealt by necromorphs TO necromorphs, is multiplied by this
 #define NECROMORPH_ACID_COLOR	"#946b36"
 

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -23,6 +23,8 @@
 
 #define isclient(A) istype(A, /client)
 
+#define isclothing(A)	istype(A, /obj/item/clothing)
+
 #define iscorgi(A) istype(A, /mob/living/simple_animal/corgi)
 
 #define is_drone(A) istype(A, /mob/living/silicon/robot/drone)

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -18,8 +18,7 @@
 	w_class = ITEM_SIZE_LARGE
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "brace_open"
-	var/cur_health
-	var/max_health = 450
+	max_health = 450
 	var/obj/machinery/door/airlock/airlock = null
 	var/obj/item/weapon/airlock_electronics/brace/electronics
 
@@ -53,7 +52,7 @@
 
 /obj/item/weapon/airlock_brace/New()
 	..()
-	cur_health = max_health
+	health = max_health
 	electronics = new/obj/item/weapon/airlock_electronics/brace(src)
 	update_access()
 
@@ -100,20 +99,20 @@
 		return
 
 	if(isWelder(W))
-		if(cur_health == max_health)
+		if(health == max_health)
 			to_chat(user, "\The [src] does not require repairs.")
 			return
 		if(W.use_tool(user, src, WORKTIME_NORMAL, QUALITY_WELDING, FAILCHANCE_NORMAL))
-			cur_health = min(cur_health + rand(80,120), max_health)
-			if(cur_health == max_health)
+			health = min(health + rand(80,120), max_health)
+			if(health == max_health)
 				to_chat(user, "You repair some dents on \the [src]. It is in perfect condition now.")
 			else
 				to_chat(user, "You repair some dents on \the [src].")
 
 
-/obj/item/weapon/airlock_brace/proc/take_damage(var/amount)
-	cur_health = between(0, cur_health - amount, max_health)
-	if(!cur_health)
+/obj/item/weapon/airlock_brace/take_damage(var/amount)
+	health = between(0, health - amount, max_health)
+	if(!health)
 		if(airlock)
 			airlock.visible_message("<span class='danger'>\The [src] breaks off of \the [airlock]!</span>")
 		unlock_brace(null)
@@ -137,7 +136,7 @@
 /obj/item/weapon/airlock_brace/proc/health_percentage()
 	if(!max_health)
 		return 0
-	return (cur_health / max_health) * 100
+	return (health / max_health) * 100
 
 /obj/item/weapon/airlock_brace/proc/update_access()
 	if(!electronics)

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -1,6 +1,7 @@
 /obj/effect/decal
 	plane = ABOVE_TURF_PLANE
 	layer = DECAL_LAYER
+	anchored = TRUE	//Why was this not set true
 
 
 /obj/effect/decal/fall_damage()

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -639,6 +639,9 @@
 /*********************
 	Resource Consumption
 **********************/
+
+
+
 /obj/proc/consume_resources(var/timespent, var/user)
 	return
 
@@ -984,3 +987,8 @@
 							QUALITY_CUTTING = 100)
 
 
+
+//Tools take heavy damage from being soaked in acid
+/obj/item/weapon/tool/acid_act(var/datum/reagent/acid/acid, var/volume)
+	var/acid_damage = acid.power * volume
+	unreliability += rand_between(0, degradation*acid_damage)

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -9,6 +9,7 @@
 	desc = "A hood that protects the head and face from biological comtaminants."
 	permeability_coefficient = 0
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
+	acid_resistance = 8	//These plastic suits are very resistant to corrosion
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHAIR
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	body_parts_covered = HEAD|FACE|EYES
@@ -31,6 +32,7 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	siemens_coefficient = 0.9
+	acid_resistance = 8	//These plastic suits are very resistant to corrosion
 
 /obj/item/clothing/suit/bio_suit/New()
 	..()

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -11,6 +11,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0)
 	valid_accessory_slots = list(ACCESSORY_SLOT_ARMBAND)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_ARMBAND)
+	acid_resistance = 4	//Made for working with chemicals
 
 /obj/item/clothing/suit/storage/toggle/labcoat/cmo
 	name = "chief medical officer's labcoat"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -502,19 +502,19 @@ meteor_act
 		if(C.permeability_coefficient == 1 || !C.body_parts_covered)
 			continue
 		if(C.body_parts_covered & HEAD)
-			perm_by_part["head"] *= C.permeability_coefficient
+			perm_by_part["head"] *= C.get_permeability()
 		if(C.body_parts_covered & UPPER_TORSO)
-			perm_by_part["upper_torso"] *= C.permeability_coefficient
+			perm_by_part["upper_torso"] *= C.get_permeability()
 		if(C.body_parts_covered & LOWER_TORSO)
-			perm_by_part["lower_torso"] *= C.permeability_coefficient
+			perm_by_part["lower_torso"] *= C.get_permeability()
 		if(C.body_parts_covered & LEGS)
-			perm_by_part["legs"] *= C.permeability_coefficient
+			perm_by_part["legs"] *= C.get_permeability()
 		if(C.body_parts_covered & FEET)
-			perm_by_part["feet"] *= C.permeability_coefficient
+			perm_by_part["feet"] *= C.get_permeability()
 		if(C.body_parts_covered & ARMS)
-			perm_by_part["arms"] *= C.permeability_coefficient
+			perm_by_part["arms"] *= C.get_permeability()
 		if(C.body_parts_covered & HANDS)
-			perm_by_part["hands"] *= C.permeability_coefficient
+			perm_by_part["hands"] *= C.get_permeability()
 
 	for(var/part in perm_by_part)
 		perm += perm_by_part[part]

--- a/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
@@ -203,7 +203,7 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 		shake_animation(30)
 	spawn(20)
 		play_species_audio(src, SOUND_SHOUT_LONG, VOLUME_HIGH, 1, 3)
-	.= spray_ability(A , angle = vangle, length = vlength, chemical = /datum/reagent/acid/necromorph, volume = 4.5, tick_delay = 0.2 SECONDS, stun = TRUE, duration = 3 SECONDS, cooldown = 12 SECONDS, windup = 2 SECOND)
+	.= spray_ability(A , angle = vangle, length = vlength, chemical = /datum/reagent/acid/necromorph, volume = 5.5, tick_delay = 0.2 SECONDS, stun = TRUE, duration = 3 SECONDS, cooldown = 12 SECONDS, windup = 2 SECOND)
 
 
 
@@ -234,7 +234,7 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 	360, //Angle
 	1.5, //Range
 	/datum/reagent/acid/necromorph, //Chem
-	15, //Volume
+	20, //Volume
 	0.1, //Tickdelay
 	FALSE,	//Stun
 	0.8 SECOND,	//Duration

--- a/code/modules/modular_computers/computers/modular_computer/damage.dm
+++ b/code/modules/modular_computers/computers/modular_computer/damage.dm
@@ -16,7 +16,7 @@
 			H.take_damage(rand(10,30))
 	qdel(src)
 
-/obj/item/modular_computer/proc/take_damage(var/amount, var/component_probability, var/damage_casing = 1, var/randomize = 1)
+/obj/item/modular_computer/take_damage(var/amount, var/component_probability, var/damage_casing = 1, var/randomize = 1)
 	if(!modifiable)
 		return
 

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -83,7 +83,7 @@
 		to_chat(user, "It seems to be slightly damaged.")
 
 // Damages the component. Contains necessary checks. Negative damage "heals" the component.
-/obj/item/weapon/computer_hardware/proc/take_damage(var/amount)
+/obj/item/weapon/computer_hardware/take_damage(var/amount)
 	damage += round(amount) 					// We want nice rounded numbers here.
 	damage = between(0, damage, max_damage)		// Clamp the value.
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -24,6 +24,7 @@
 	origin_tech = list(TECH_COMBAT = 1)
 	attack_verb = list("struck", "hit", "bashed")
 	zoomdevicename = "scope"
+	unacidable = TRUE	//Guns melting is too powerful
 
 	var/burst = 1
 	var/fire_delay = 6 	//delay after shooting before the gun can be used again

--- a/code/modules/projectiles/guns/special/ripper/sawblade.dm
+++ b/code/modules/projectiles/guns/special/ripper/sawblade.dm
@@ -376,10 +376,9 @@
 	if (!QDELETED(A))
 		grind_atoms += list(list(A, EX3_TOTAL, EX2_TOTAL, EX1_TOTAL))
 
-/obj/item/projectile/sawblade/proc/updatehealth()
-	if (health <= 0)
-		if (launcher && launcher.blade == src)
-			launcher.stop_firing()
+/obj/item/projectile/sawblade/zero_health()
+	if (launcher && launcher.blade == src)
+		launcher.stop_firing()
 
 //Override this so it doesn't delete itself when touching anything
 /obj/item/projectile/sawblade/Bump(atom/A as mob|obj|turf|area, forced=0)

--- a/html/changelogs/acid.yml
+++ b/html/changelogs/acid.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Necromorph acid can now damage clothing. Any acid that doesn't reach the skin will splash onto worn equipment instead, gradually eating through it. As equipment takes damage, it lets more chemicals through. Items can also be damaged enough to be completely destroyed. This effect applies to all sources of acid. Puker, Spitter, Cysts"
+  - tweak: "Biosuits and labcoats are now extremely resistant to acid."
+  - tweak: "Guns are now immune to acid, and won't melt."
+  - tweak: "Tools now take damage from acid instead of just melting outright."
+  - tweak: "Acid patches on the ground now only cause damage above a certain visibility. No more taking damage from acid you can hardly see. Examining the patch will tell whether or not its safe to walk on."
+  - bugfix: "Fixed puker acid patches not drying up over time"
+  - bugfix: "Acid pools can no longer be pulled around."


### PR DESCRIPTION
changes: 
  - rscadd: "Necromorph acid can now damage clothing. Any acid that doesn't reach the skin will splash onto worn equipment instead, gradually eating through it. As equipment takes damage, it lets more chemicals through. Items can also be damaged enough to be completely destroyed. This effect applies to all sources of acid. Puker, Spitter, Cysts"
  - tweak: "Biosuits and labcoats are now extremely resistant to acid."
  - tweak: "Guns are now immune to acid, and won't melt."
  - tweak: "Tools now take damage from acid instead of just melting outright."
  - tweak: "Acid patches on the ground now only cause damage above a certain visibility. No more taking damage from acid you can hardly see. Examining the patch will tell whether or not its safe to walk on."
  - bugfix: "Fixed puker acid patches not drying up over time"
  - bugfix: "Acid pools can no longer be pulled around."

Closes #218 
Closes #215 
Closes #216 
Closes #175 

Also includes a bunch of tweaks to how acid performs generally. Total balance is about the same though