### PR TITLE
Pain and burn Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -879,6 +879,7 @@
 	species = all_species[new_species]
 	species.handle_pre_spawn(src)
 
+	species.setup_defense(src)
 	species.setup_interaction(src)
 	species.setup_movement(src)
 	species.setup_vision(src)
@@ -918,7 +919,7 @@
 	species.create_organs(src)
 	species.handle_post_spawn(src)
 
-	max_health = species.total_health
+
 
 	default_pixel_x = initial(pixel_x) + species.pixel_offset_x
 	default_pixel_y = initial(pixel_y) + species.pixel_offset_y

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -858,65 +858,7 @@
 	if(mind && mind.changeling)
 		mind.changeling.regenerate()
 
-/mob/living/carbon/human/proc/handle_shock()
-	..()
-	if(status_flags & GODMODE)	return 0	//godmode
-	if(!can_feel_pain())
-		shock_stage = 0
-		return
 
-	if(is_asystole())
-		shock_stage = max(shock_stage + 1, 61)
-	var/traumatic_shock = get_shock()
-	if(traumatic_shock >= max(30, 0.8*shock_stage))
-		shock_stage += 1
-	else if (!is_asystole())
-		shock_stage = min(shock_stage, 160)
-		var/recovery = 1
-		if(traumatic_shock < 0.5 * shock_stage) //lower shock faster if pain is gone completely
-			recovery++
-		if(traumatic_shock < 0.25 * shock_stage)
-			recovery++
-		shock_stage = max(shock_stage - recovery, 0)
-		return
-	if(stat) return 0
-
-	if(shock_stage == 10)
-		// Please be very careful when calling custom_pain() from within code that relies on pain/trauma values. There's the
-		// possibility of a feedback loop from custom_pain() being called with a positive power, incrementing pain on a limb,
-		// which triggers this proc, which calls custom_pain(), etc. Make sure you call it with nohalloss = TRUE in these cases!
-		custom_pain("[pick("It hurts so much", "You really need some painkillers", "Dear god, the pain")]!", 10, nohalloss = TRUE)
-
-	if(shock_stage >= 30)
-		if(shock_stage == 30) visible_message("<b>[src]</b> is having trouble keeping \his eyes open.")
-		if(prob(30))
-			eye_blurry = max(2, eye_blurry)
-			stuttering = max(stuttering, 5)
-
-	if(shock_stage == 40)
-		custom_pain("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!", 40, nohalloss = TRUE)
-	if (shock_stage >= 60)
-		if(shock_stage == 60) visible_message("<b>[src]</b>'s body becomes limp.")
-		if (prob(2))
-			custom_pain("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!", shock_stage, nohalloss = TRUE)
-			Weaken(10)
-
-	if(shock_stage >= 80)
-		if (prob(5))
-			custom_pain("[pick("The pain is excruciating", "Please, just end the pain", "Your whole body is going numb")]!", shock_stage, nohalloss = TRUE)
-			Weaken(20)
-
-	if(shock_stage >= 120)
-		if (prob(2))
-			custom_pain("[pick("You black out", "You feel like you could die any moment now", "You're about to lose consciousness")]!", shock_stage, nohalloss = TRUE)
-			Paralyse(5)
-
-	if(shock_stage == 150)
-		visible_message("<b>[src]</b> can no longer stand, collapsing!")
-		Weaken(20)
-
-	if(shock_stage >= 150)
-		Weaken(20)
 
 /*
 	Called by life(), instead of having the individual hud items update icons each tick and check for status changes

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -103,6 +103,7 @@
 	var/max_heal_threshold	=	0.5			//Wounds can only autoheal if the damage is less than this * max_damage
 	var/wound_remnant_time = 10 MINUTES	//How long fully-healed wounds stay visible before vanishing
 	var/limb_health_factor	=	1	//Multiplier on max health of limbs
+	var/pain_shock_threshold	=	50	//The mob starts going into shock when total pain reaches this value
 
 	// Combat vars.
 	var/list/unarmed_types = list(           // Possible unarmed attacks that the mob will use in combat,
@@ -367,6 +368,33 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		var/obj/item/organ/limb_path = organ_data["path"]
 		organ_data["descriptor"] = initial(limb_path.name)
 
+
+
+/*
+	Setup Procs:
+	Copying over vars to the mob, and doing any initial calculations
+*/
+/datum/species/proc/setup_defense(var/mob/living/carbon/human/H)
+	H.pain_shock_threshold = pain_shock_threshold
+	H.max_health = total_health
+
+/datum/species/proc/setup_interaction(var/mob/living/carbon/human/H)
+	H.limited_click_arc = limited_click_arc
+	H.opacity = opacity
+
+/datum/species/proc/setup_movement(var/mob/living/carbon/human/H)
+	H.slow_turning = slow_turning
+	H.evasion = evasion
+
+/datum/species/proc/setup_vision(var/mob/living/carbon/human/H)
+	H.view_offset = view_offset
+	H.view_range = view_range
+
+
+
+
+
+
 /datum/species/proc/sanitize_name(var/name)
 	return sanitizeName(name)
 
@@ -481,17 +509,7 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			//Modclick takes key type, function name, function priority, and a list of extra arguments
 			H.add_modclick_verb(arglist(input_args))
 
-/datum/species/proc/setup_interaction(var/mob/living/carbon/human/H)
-	H.limited_click_arc = limited_click_arc
-	H.opacity = opacity
 
-/datum/species/proc/setup_movement(var/mob/living/carbon/human/H)
-	H.slow_turning = slow_turning
-	H.evasion = evasion
-
-/datum/species/proc/setup_vision(var/mob/living/carbon/human/H)
-	H.view_offset = view_offset
-	H.view_range = view_range
 
 /datum/species/proc/handle_post_spawn(var/mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.
 	add_inherent_verbs(H)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -5,6 +5,7 @@
 	//Health and life related vars
 	var/max_health = 100 //Maximum health that should be possible.
 	var/health = 100 	//A mob's health
+	var/pain_shock_threshold = 30	//Pain above this threshold will cause the mob to start going into shock
 
 	var/biomass = 1	//How much biomass is this mob worth when absorbed
 

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -68,7 +68,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 			createwound(BURN, burn)
 
 	//Initial pain spike
-	add_pain(0.6*burn + 0.4*brute)
+	add_pain(0.5*burn + 0.4*brute)
 
 	//Disturb treated burns
 	if(brute > 5)
@@ -80,7 +80,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 				disturbed += W.damage
 		if(disturbed)
 			to_chat(owner,"<span class='warning'>Ow! Your burns were disturbed.</span>")
-			add_pain(0.5*disturbed)
+			add_pain(0.3*disturbed)
 
 	//If there are still hurties to dispense
 	if (spillover)

--- a/code/modules/reagents/Chemistry-Reagents/acid.dm
+++ b/code/modules/reagents/Chemistry-Reagents/acid.dm
@@ -99,8 +99,8 @@
 	taste_description = "acid"
 	reagent_state = LIQUID
 	color = NECROMORPH_ACID_COLOR
-	metabolism = 0.75
-	touch_met = 0.75
+	metabolism = 0.5
+	touch_met = 0.5	//Slow burn
 	power = NECROMORPH_ACID_POWER
 	meltdose = 30 // How much is needed to melt
 

--- a/html/changelogs/burnpain.yml
+++ b/html/changelogs/burnpain.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Increased human minimum pain threshold to start going into shock, from 30 to 50. This is a modest reduction in human susceptibility to pain, allowing more to be endured."
+  - tweak: "Reduced the burn pain multiplier, from 0.6 to 0.5"
+  - tweak: "Reduced the disturbed burn wound pain multiplier, from 0.5 to 0.3"
+  - tweak: "Reduced metabolisation rate of necromorph acid, from 0.75 to 0.5, so it will deal damage more slowly"


### PR DESCRIPTION
A few changes to reduce the effect of pain, and make it take a bit longer for humans to go into paincrit

changes: 
  - tweak: "Increased human minimum pain threshold to start going into shock, from 30 to 50. This is a modest reduction in human susceptibility to pain, allowing more to be endured."
  - tweak: "Reduced the burn pain multiplier, from 0.6 to 0.5"
  - tweak: "Reduced the disturbed burn wound pain multiplier, from 0.5 to 0.3"
  - tweak: "Reduced metabolisation rate of necromorph acid, from 0.75 to 0.5, so it will deal damage more slowly"


Closes #256 