### PR TITLE
fixes acid doing no damage to people in voidsuits

### DIFF
--- a/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
@@ -158,6 +158,7 @@ Best used for harassment, skirmishing and initiating fights from afar against un
 	On impact, the damage is applied immediately as burn, and the victim is doused in enough acid to deal that same amount of damage again over time.
 	The effectiveness of the acid component is heavily dependant on worn equipment
 */
+//This probably shouldn't be defined here, all acid projectiles are a child of this one, and it's not a logical place to look to find the parent. Perhaps a necro_projectiles.dm?
 /obj/item/projectile/bullet/acid
 	name = "acid bolt"
 	icon_state = "acid_small"
@@ -165,7 +166,7 @@ Best used for harassment, skirmishing and initiating fights from afar against un
 	damage = 15
 	damage_type = BURN
 	nodamage = 0
-	check_armour = "bio"
+	check_armour = "laser"
 	embed = FALSE
 	sharp = FALSE
 	penetration_modifier = 0


### PR DESCRIPTION
Changes the armor to check for on acid from bio to laser.
Laser armor tends to be 20-30% on most voidsuits, probably will need to be increased later. Bio is used for viruses, and is set to 100 for any kind of air-tight suits.

Bullet would make more sense, but is incredibly low on most suits so you might as well be unarmored.

Likely just add a new damage type called acid to armors later.