### PR TITLE
Adjusts marker time, fps, corpse vanishing, damage

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -278,6 +278,7 @@
 #include "code\datums\extensions\label.dm"
 #include "code\datums\extensions\penetration.dm"
 #include "code\datums\extensions\proximity.dm"
+#include "code\datums\extensions\unseen_deletion.dm"
 #include "code\datums\extensions\wallmount.dm"
 #include "code\datums\extensions\appearance\appearance.dm"
 #include "code\datums\extensions\appearance\base_icon_state.dm"

--- a/code/_global_vars/lists/mobs.dm
+++ b/code/_global_vars/lists/mobs.dm
@@ -15,3 +15,16 @@ BP_MOUTH = BP_HEAD))
 GLOBAL_LIST_INIT(key_to_mob, list())
 
 GLOBAL_LIST_INIT(players, list())
+
+GLOBAL_LIST_EMPTY(clients)   //all clients
+GLOBAL_LIST_EMPTY(admins)    //all clients whom are admins
+GLOBAL_PROTECT(admins)
+GLOBAL_LIST_EMPTY(ckey_directory) //all ckeys with associated client
+
+
+GLOBAL_LIST_EMPTY(player_list)      //List of all mobs **with clients attached**. Excludes /mob/new_player
+GLOBAL_LIST_EMPTY(human_mob_list)   //List of all human mobs and sub-types, including clientless
+GLOBAL_LIST_EMPTY(silicon_mob_list) //List of all silicon mobs, including clientless
+GLOBAL_LIST_EMPTY(living_mob_list) //List of all alive mobs, including clientless. Excludes /mob/new_player
+GLOBAL_LIST_EMPTY(dead_mob_list)   //List of all dead mobs, including clientless. Excludes /mob/new_player
+GLOBAL_LIST_EMPTY(ghost_mob_list)   //List of all ghosts, including clientless. Excludes /mob/new_player

--- a/code/_global_vars/mobs.dm
+++ b/code/_global_vars/mobs.dm
@@ -1,15 +1,4 @@
-GLOBAL_LIST_EMPTY(clients)   //all clients
-GLOBAL_LIST_EMPTY(admins)    //all clients whom are admins
-GLOBAL_PROTECT(admins)
-GLOBAL_LIST_EMPTY(ckey_directory) //all ckeys with associated client
 
-
-GLOBAL_LIST_EMPTY(player_list)      //List of all mobs **with clients attached**. Excludes /mob/new_player
-GLOBAL_LIST_EMPTY(human_mob_list)   //List of all human mobs and sub-types, including clientless
-GLOBAL_LIST_EMPTY(silicon_mob_list) //List of all silicon mobs, including clientless
-GLOBAL_LIST_EMPTY(living_mob_list) //List of all alive mobs, including clientless. Excludes /mob/new_player
-GLOBAL_LIST_EMPTY(dead_mob_list)   //List of all dead mobs, including clientless. Excludes /mob/new_player
-GLOBAL_LIST_EMPTY(ghost_mob_list)   //List of all ghosts, including clientless. Excludes /mob/new_player
 
 
 // Visual nets

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -197,26 +197,14 @@
 */
 /turf/proc/is_seen_by_crew()
 	.=FALSE
-	for (var/mob/living/carbon/human/H in view(20, src))
-		if (!H.client)
-			//Disconnected people don't see
-			continue
-
+	for (var/mob/living/carbon/human/H as anything in get_viewers(20, /mob/living/carbon/human))
 		if (H.is_necromorph())
 			//Necromorphs don't count
 			continue
-
-		if (H.stat == DEAD)
-			continue	//The dead can't see
-
 		if (H.stat == UNCONSCIOUS)
 			//Sleeping people can see one tile around them
 			if (get_dist(src, H) >= 2)
 				continue
-
-		//Onscreen check is the most expensive, we'll do that last, and only for conscious people
-		else if (!H.client.is_on_screen(src))
-			continue
 
 		return H
 

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1057,32 +1057,7 @@ var/list/WALLITEMS = list(
 			colour += temp_col
 	return "#[colour]"
 
-GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
-//Version of view() which ignores darkness, because BYOND doesn't have it.
-/proc/dview(var/range = world.view, var/center, var/invis_flags = 0)
-	if(!center)
-		return
-
-	GLOB.dview_mob.loc = center
-	GLOB.dview_mob.see_invisible = invis_flags
-	. = view(range, GLOB.dview_mob)
-	GLOB.dview_mob.loc = null
-
-/mob/dview
-	invisibility = 101
-	density = 0
-
-	anchored = 1
-	simulated = 0
-
-	see_in_dark = 1e6
-
-	virtual_mob = null
-
-/mob/dview/Destroy()
-	crash_with("Prevented attempt to delete dview mob: [log_info_line(src)]")
-	return QDEL_HINT_LETMELIVE // Prevents destruction
 
 /atom/proc/get_light_and_color(var/atom/origin)
 	if(origin)

--- a/code/datums/extensions/unseen_deletion.dm
+++ b/code/datums/extensions/unseen_deletion.dm
@@ -1,0 +1,58 @@
+/*
+	This extension attempts to delete an object when nobody is around to see it.
+	The target atom is periodically checked for nearby viewers
+
+	This is an expensive process, the interval is set quite long. A minute
+*/
+#define DELETE_UNSEEN(x)	set_extension(x, /datum/extension/delete_unseen)
+
+/datum/extension/delete_unseen
+	name = "delete_unseen"
+	base_type = /datum/extension/delete_unseen
+	expected_type = /atom
+	flags = EXTENSION_FLAG_IMMEDIATE
+
+	var/status
+	var/interval = 1 SECOND//MINUTE
+	var/max_range = 20
+	var/atom/subject
+
+
+	var/ongoing_timer
+
+
+
+/datum/extension/delete_unseen/New(var/atom/holder)
+	.=..()
+	subject = holder
+	if (QDELETED(subject))
+		stop()
+		return
+	start()
+
+
+/datum/extension/delete_unseen/proc/start()
+	ongoing_timer = addtimer(CALLBACK(src, /datum/extension/delete_unseen/proc/tick), interval)
+
+
+/datum/extension/delete_unseen/proc/tick()
+	//Safety check first
+	if (QDELETED(subject))
+		stop()
+		return
+
+	//Alright, lets see if anyone is looking yet
+	var/list/viewers = subject.get_viewers()
+	if (!viewers.len)
+		qdel(subject)
+		stop()
+	else
+		ongoing_timer = addtimer(CALLBACK(src, /datum/extension/delete_unseen/proc/tick), interval)
+
+
+
+/datum/extension/delete_unseen/proc/stop()
+	deltimer(ongoing_timer)
+	if (!QDELETED(subject))
+		remove_extension(holder, base_type)
+

--- a/code/game/gamemodes/marker/marker.dm
+++ b/code/game/gamemodes/marker/marker.dm
@@ -17,7 +17,7 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	votable = TRUE
 	var/evac_points = 0
 	var/evac_threshold = 85 //2 hours until you get to evac.
-	var/marker_setup_time = 25 MINUTES
+	var/marker_setup_time = 45 MINUTES
 
 
 /datum/game_mode/marker/post_setup() //Mr Gaeta. Start the clock.

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -58,3 +58,6 @@
 		View Handling
 	--------------------------------*/
 	var/view_offset_magnitude	//Cached when view offset is set
+
+	//Static framerate
+	fps = 40

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -161,7 +161,6 @@
 		preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
-	apply_fps(prefs.clientfps)
 
 	. = ..()	//calls mob.Login()
 	prefs.sanitize_preferences()
@@ -378,7 +377,3 @@ client/verb/character_setup()
 	set category = "OOC"
 	if(prefs)
 		prefs.ShowChoices(usr)
-
-/client/proc/apply_fps(var/client_fps)
-	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= CLIENT_MIN_FPS && client_fps <= CLIENT_MAX_FPS)
-		vars["fps"] = prefs.clientfps

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -1,5 +1,4 @@
 /datum/preferences
-	var/clientfps = 0
 	var/ooccolor = "#010000" //Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
 
 	var/UI_style = "Midnight"
@@ -15,21 +14,18 @@
 	S["UI_style_color"]	>> pref.UI_style_color
 	S["UI_style_alpha"]	>> pref.UI_style_alpha
 	S["ooccolor"]		>> pref.ooccolor
-	S["clientfps"]		>> pref.clientfps
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
 	S["UI_style"]		<< pref.UI_style
 	S["UI_style_color"]	<< pref.UI_style_color
 	S["UI_style_alpha"]	<< pref.UI_style_alpha
 	S["ooccolor"]		<< pref.ooccolor
-	S["clientfps"]		<< pref.clientfps
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style		= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
 	pref.UI_style_color	= sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
 	pref.UI_style_alpha	= sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
 	pref.ooccolor		= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
-	pref.clientfps	    = sanitize_integer(pref.clientfps, CLIENT_MIN_FPS, CLIENT_MAX_FPS, initial(pref.clientfps))
 
 /datum/category_item/player_setup_item/player_global/ui/content(var/mob/user)
 	. += "<b>UI Settings</b><br>"
@@ -43,7 +39,6 @@
 			. += "<a href='?src=\ref[src];select_ooc_color=1'><b>Using Default</b></a><br>"
 		else
 			. += "<a href='?src=\ref[src];select_ooc_color=1'><b>[pref.ooccolor]</b></a> <table style='display:inline;' bgcolor='[pref.ooccolor]'><tr><td>__</td></tr></table> <a href='?src=\ref[src];reset=ooc'>reset</a><br>"
-	. += "<b>Client FPS:</b> <a href='?src=\ref[src];select_fps=1'><b>[pref.clientfps]</b></a><br>"
 
 /datum/category_item/player_setup_item/player_global/ui/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["select_style"])
@@ -70,20 +65,6 @@
 			pref.ooccolor = new_ooccolor
 			return TOPIC_REFRESH
 
-	else if(href_list["select_fps"])
-		var/version_message
-		if (user.client && user.client.byond_version < 511)
-			version_message = "\nYou need to be using byond version 511 or later to take advantage of this feature, your version of [user.client.byond_version] is too low"
-		if (world.byond_version < 511)
-			version_message += "\nThis server does not currently support client side fps. You can set now for when it does."
-		var/new_fps = input(user, "Choose your desired fps.[version_message]\n(0 = synced with server tick rate (currently:[world.fps]))", "Global Preference") as num|null
-		if (isnum(new_fps) && CanUseTopic(user))
-			pref.clientfps = Clamp(new_fps, CLIENT_MIN_FPS, CLIENT_MAX_FPS)
-
-			var/mob/target_mob = preference_mob()
-			if(target_mob && target_mob.client)
-				target_mob.client.apply_fps(pref.clientfps)
-			return TOPIC_REFRESH
 
 	else if(href_list["reset"])
 		switch(href_list["reset"])

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
@@ -66,7 +66,7 @@
 	//Defense
 	total_health = 80
 	healing_factor = 0	//Necromorphs don't naturally heal, but they will be able to heal through certain situational effects
-	limb_health_factor = 0.65	//Limbs easier to cut off
+	limb_health_factor = 0.60	//Limbs easier to cut off
 	wound_remnant_time = 0 //No cuts sitting around forever
 	burn_mod = 1.3	//Takes more damage from burn attacks
 	weaken_mod = 0.75	//Get back up faster
@@ -83,7 +83,7 @@
 			Damage to the chest and groin is treated as being multiplied by this,
 	*/
 
-	var/dismember_mult = 1.4
+	var/dismember_mult = 1.3
 	/*
 		For the purpose of determining whether or not the necromorph has taken enough damage to be killed:
 			A limb which is completely severed counts as its max damage multiplied by this

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -11,7 +11,7 @@
 	mob_type = /mob/living/carbon/human/necromorph/slasher
 	blurb = "The frontline soldier of the necromorph horde. Slow when not charging, but its blade arms make for powerful melee attacks"
 	unarmed_types = list(/datum/unarmed_attack/blades, /datum/unarmed_attack/bite/weak) //Bite attack is a backup if blades are severed
-	total_health = 70
+	total_health = 75
 	biomass = 60
 	mass = 70
 
@@ -77,7 +77,7 @@
 	marker_spawnable = TRUE 	//Enable this once we have sprites for it
 	mob_type = /mob/living/carbon/human/necromorph/slasher/enhanced
 	unarmed_types = list(/datum/unarmed_attack/blades/strong, /datum/unarmed_attack/bite/strong)
-	total_health = 175
+	total_health = 187.5
 	slowdown = 2.8
 	biomass = 175
 	mass = 120

--- a/code/modules/mob/observer/freelook/marker/biomass.dm
+++ b/code/modules/mob/observer/freelook/marker/biomass.dm
@@ -79,9 +79,19 @@
 /datum/biomass_source/reclaim
 
 
+
+//Once we've completely absorbed our source, make the body quietly vanish when nobody is looking
+/datum/biomass_source/reclaim/mass_exhausted()
+	var/mob/M = locate(source)
+	if (!QDELETED(M))
+		DELETE_UNSEEN(M)
+
+
+
 //Absorbing dead humans
 //------------------------
 /datum/biomass_source/convergence
+
 
 //Todo here: Check if the human body is near enough to the marker, or some sort of corruption-corpse-deposit node
 //If its too far away, return pause

--- a/code/modules/mob/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal.dm
@@ -95,6 +95,10 @@
 		to_chat(src, SPAN_DANGER("That can't be possessed!"))
 		return
 
+	if (L.stat == DEAD)
+		to_chat(src, SPAN_DANGER("That vessel is damaged beyond usefulness"))
+		return
+
 	if (!L.is_necromorph())
 		to_chat(src, SPAN_DANGER("You can only possess necromorph units."))
 		return

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -232,7 +232,7 @@ ALLOW_HOLIDAYS
 TICKLAG 0.7
 
 ##Defines world FPS. Defaults to 20.
-# FPS 20
+FPS 20
 
 ## Whether the server will talk to other processes through socket_talk
 SOCKET_TALK 0

--- a/html/changelogs/Markertime.yml
+++ b/html/changelogs/Markertime.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "The Marker's activation time has been delayed. It will now activate somewhere in the region of 38 to 51 minutes into the round"
+  - rscdel: "Necromorph corpses will now vanish when they have been fully reclaimed by the marker. But only when noone is looking...."
+  - tweak: "Slightly buffed max health of Slasher from 70 to 75"
+  - tweak: "Severed limb damage multiplier reduced from 1.4 to 1.3"
+  - tweak: "Necromorph limb health factor reduced from 0.65 to 0.6"
+  - tweak: "Client framerate is now set to 40 fps (was 14)"
+  - tweak: "Server framerate is now set to 20 fps (was 14)"
+  - bugfix: "Possess no longer works on dead necromorphs"


### PR DESCRIPTION
A package of miscellaneous changes that all seemed too small for their own PR

Marker activation time increased to 45 minutes, at west's direction

For the sake of clutter and lag reduction, adds a new little feature. Necromorph corpses now disappear once fully reclaimed.
However, for the sake of immersion and roleplay value, players are not allowed to see this happen. I've added a new unseen deletion functionality, which will make an object be deleted only when no player is looking at it (even ghosts).

Server framerate set to 20 (was 14.) I don't know why it was ever not 20, 20 is the default used by most servers, and also in the config, where it was commented out. 

Client framerate locked to 40 fps, and client framerate setting removed. This one needs a little explanation;
First of all, for smooth movement in the future, it is necessary to lock framerate. The glide timings won't work right if client framerate can be variable.
Secondly, selecting the specific value, a bit of research turned up statements from byond's own developers that the client runs best at framerates which divide evenly into 1000. They recommended 40 or 50 fps specifically for this. of those two, 40 is more attainable.

Lastly, some very minor damage tweaks based on community feedback. Slightly more slasher health, limb health and damage multiplier reduced, so there should be a little more opportunity to dismember things before they die. As always, balance adjustments are done in small increments so i can see how they play out in live testing