### PR TITLE
nerfs exploder reclamation time

### DIFF
--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
@@ -13,7 +13,7 @@
 	biomass = 40
 	mass = 50
 
-	biomass_reclamation_time	=	3 MINUTES
+	biomass_reclamation_time	=	5 MINUTES
 	view_range = 6
 
 	icon_template = 'icons/mob/necromorph/exploder.dmi'


### PR DESCRIPTION
3 minutes => 5.

Mainly to make them less spammable, fully upgraded nests pretty much make 1 exploder per 2 minutes, meaning that with two nests you'd already have an exploder each minute, that's a bit insane.