### PR TITLE
Explosion Optimisation: Round II

### DIFF
--- a/code/_onclick/click_handlers/rmb_aim.dm
+++ b/code/_onclick/click_handlers/rmb_aim.dm
@@ -9,8 +9,14 @@
 	.=..()
 	user.client.show_popup_menus = FALSE
 
+
+/datum/click_handler/rmb_aim/Exit()
+	if (user && user.client)
+		user.client.show_popup_menus = TRUE
+	.=..()
+
 /datum/click_handler/rmb_aim/Destroy()
-	if (user)
+	if (user && user.client)
 		user.client.show_popup_menus = TRUE
 	if (gun)
 		gun.disable_aiming_mode()

--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -189,7 +189,7 @@ datum/sound_token/proc/Mute()
 	status = new_status
 	PrivUpdateListeners()
 
-datum/sound_token/proc/PrivAddListener(var/atom/listener)
+/datum/sound_token/proc/PrivAddListener(var/atom/listener)
 	if(isvirtualmob(listener))
 		var/mob/observer/virtual/v = listener
 		if(!(v.abilities & VIRTUAL_ABILITY_HEAR))
@@ -206,13 +206,21 @@ datum/sound_token/proc/PrivAddListener(var/atom/listener)
 	PrivUpdateListenerLoc(listener, FALSE)
 
 /datum/sound_token/proc/PrivRemoveListener(var/atom/listener, var/sound/null_sound)
-	null_sound = null_sound || new(channel = sound.channel)
-	sound_to(listener, null_sound)
-	GLOB.moved_event.unregister(listener, src, /datum/sound_token/proc/PrivUpdateListenerLoc)
-	GLOB.destroyed_event.unregister(listener, src, /datum/sound_token/proc/PrivRemoveListener)
+	if (!QDELETED(listener))
+		null_sound = null_sound || new(channel = sound.channel)
+		sound_to(listener, null_sound)
+		GLOB.moved_event.unregister(listener, src, /datum/sound_token/proc/PrivUpdateListenerLoc)
+		GLOB.destroyed_event.unregister(listener, src, /datum/sound_token/proc/PrivRemoveListener)
 	listeners -= listener
 
 /datum/sound_token/proc/PrivUpdateListenerLoc(var/atom/listener, var/update_sound = TRUE)
+	if (QDELETED(source))
+		return
+
+	if (QDELETED(listener))
+		PrivRemoveListener(listener)
+		return
+
 	var/turf/source_turf = get_turf(source)
 	var/turf/listener_turf = get_turf(listener)
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -1,3 +1,8 @@
+//Explosion power thresholds.
+//When the power applied to a tile is at or above this value, the appropriate degree of ex_act is called
+#define POWER_DEV	8
+#define POWER_HEAVY	4
+#define POWER_LIGHT	0
 //TODO: Flash range does nothing currently
 
 proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = UP|DOWN, shaped)
@@ -6,7 +11,6 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 	var/multi_z_scalar = 0.35
 	src = null	//so we don't abort once src is deleted
 
-	var/start = world.timeofday
 	epicenter = get_turf(epicenter)
 	if(!epicenter) return
 
@@ -24,25 +28,46 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			if(HasBelow(epicenter.z) && z_transfer & DOWN)
 				explosion(GetBelow(epicenter), round(adj_dev), round(adj_heavy), round(adj_light), round(adj_flash), 0, DOWN, shaped)
 
-	var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range)
+	//This calculates roughly how far our explosion will extend. This is more correctly defined as "minimum range over empty terrain"
+	//It may be much shorter if obstacles are involved, or slightly longer if they aren't.
+	//We dont want a approximate_range of 0 or bad things happen
+	var/approximate_range = max(devastation_range, heavy_impact_range, light_impact_range, flash_range, 1)
+
 
 
 	if(adminlog)
 		message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
 		log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ")
 
-	var/approximate_intensity = (devastation_range * 3) + (heavy_impact_range * 2) + light_impact_range
+
+	//This system means that explosions are not precisely tiered as originally designed,
+	//but it creates a rough approximate of the author's intent which preserves the important details
+	//The most critical detail is the choice to have any or no tiles affected by a certain level of damage, controlling the maximum power of the epicentre
+	//Secondly, it also preserves an approximate overall radius of effect
+	//Aside from those two factors, everything else is organic and not really controllable
+	var/approximate_intensity = 1
+
+	//Note: A range of 0 for any of these values is perfectly valid, indicating a desire to target the current tile only
+	if (isnum(devastation_range) && devastation_range >= 0)
+		approximate_intensity = POWER_DEV + devastation_range	//For a range of 0 we apply the defined threshold, and we addd a flat 1 point for every range above that. Since explosions lose 1 intensity per tile
+	else if (isnum(heavy_impact_range) && heavy_impact_range >= 0)
+		approximate_intensity = POWER_HEAVY + heavy_impact_range
+	else if (isnum(light_impact_range) && light_impact_range >= 0)
+		approximate_intensity = POWER_LIGHT + light_impact_range
+
+	var/falloff = 1
+	if (approximate_intensity < approximate_range)
+		falloff = approximate_intensity / approximate_range
+
 	// Large enough explosion. For performance reasons, powernets will be rebuilt manually
-	if(!defer_powernet_rebuild && (approximate_intensity > 25))
+	if(!defer_powernet_rebuild && (approximate_range > 10))
 		defer_powernet_rebuild = 1
 
 
 	CHECK_TICK
 
 
-	//Recursive explosions are now mandatory
-	var/power = devastation_range * 2 + heavy_impact_range + light_impact_range //The ranges add up, ie light 14 includes both heavy 7 and devestation 3. So this calculation means devestation counts for 4, heavy for 2 and light for 1 power, giving us a cap of 27 power.
-	explosion_rec(epicenter, power, shaped)
+	explosion_rec(epicenter, approximate_intensity, falloff, shaped)
 
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -128,7 +128,7 @@ meteor_act
 	if(!type || !def_zone) return 0
 	if(!istype(def_zone))
 		def_zone = get_organ(check_zone(def_zone))
-	if(!def_zone)
+	if(!def_zone || !def_zone.species)
 		return 0
 	var/protection = def_zone.species.natural_armour_values ? def_zone.species.natural_armour_values[type] : 0
 	var/list/protective_gear = list(head, wear_mask, wear_suit, w_uniform, gloves, shoes)
@@ -363,7 +363,8 @@ meteor_act
 		if (O.throw_source)
 			var/distance = get_dist(O.throw_source, loc)
 			miss_chance += max(5*(distance-2), 0)
-		zone = get_zone_with_miss_chance(zone, src, miss_chance, ranged_attack=1)
+		var/accuracy = 100 - miss_chance
+		zone = get_zone_with_miss_chance(accuracy, zone, AM)
 
 		if(zone && O.thrower != src)
 			var/shield_check = check_shields(throw_damage, O, thrower, zone, "[O]")

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
@@ -13,7 +13,7 @@
 	biomass = 40
 	mass = 50
 
-	biomass_reclamation_time	=	3 MINUTES
+	biomass_reclamation_time	=	4 MINUTES
 	view_range = 6
 
 	icon_template = 'icons/mob/necromorph/exploder.dmi'
@@ -173,7 +173,9 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 	set_light(1, 1, 9, 2, COLOR_NECRO_YELLOW)
 	.=..()
 
-
+/*
+	The actual explosion!
+*/
 //A multi-level explosion using a broad variety of cool mechanics
 /obj/item/organ/external/hand/exploder_pustule/proc/explode()
 	if (exploded)
@@ -192,7 +194,8 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 
 	//A normal explosion
 	spawn()
-		explosion(T, 0, 2, 4, 6)
+		//-1 devastation range because hull breaches are not cool
+		explosion(T, -1, 3, 5, 6)
 
 	//Make sure the pustule is deleted if these explosions don't destroy it
 	spawn()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -449,7 +449,13 @@ This function completely restores a damaged organ to perfect condition.
 	if(type == BRUISE && BP_IS_BRITTLE(src))
 		damage = Floor(damage * 1.5)
 
-	if(BP_IS_CRYSTAL(src))
+
+
+	if(damage <= 0)
+		return
+
+	if (owner)
+		if(BP_IS_CRYSTAL(src))
 		// this needs to cover type == BURN because lasers don't use LASER, but with the way bodytemp
 		// damage is handled currently that isn't really possible without an infinite feedback loop.
 		if(type == LASER)
@@ -460,8 +466,15 @@ This function completely restores a damaged organ to perfect condition.
 		damage = Floor(damage * 0.8)
 		type = SHATTER
 
-	if(damage <= 0)
-		return
+
+		//Burn damage can cause fluid loss due to blistering and cook-off
+		if((type in list(BURN, LASER)) && (damage > 5 || damage + burn_dam >= 15) && !BP_IS_ROBOTIC(src))
+			var/fluid_loss_severity
+			switch(type)
+				if(BURN)  fluid_loss_severity = FLUIDLOSS_WIDE_BURN
+				if(LASER) fluid_loss_severity = FLUIDLOSS_CONC_BURN
+			var/fluid_loss = (damage/(owner.max_health - config.health_threshold_dead)) * SPECIES_BLOOD_DEFAULT * fluid_loss_severity
+			owner.remove_blood(fluid_loss)
 
 	if(loc && type == SHATTER)
 		playsound(loc, 'sound/effects/hit_on_shattered_glass.ogg', 40, 1) // Crash!
@@ -476,17 +489,10 @@ This function completely restores a damaged organ to perfect condition.
 			internal_damage = TRUE
 		if(prob(ceil(damage/4)) && sever_tendon())
 			internal_damage = TRUE
-		if(internal_damage)
+		if(internal_damage && owner)
 			owner.custom_pain("You feel something rip in your [name]!", 50, affecting = src)
 
-	//Burn damage can cause fluid loss due to blistering and cook-off
-	if((type in list(BURN, LASER)) && (damage > 5 || damage + burn_dam >= 15) && !BP_IS_ROBOTIC(src))
-		var/fluid_loss_severity
-		switch(type)
-			if(BURN)  fluid_loss_severity = FLUIDLOSS_WIDE_BURN
-			if(LASER) fluid_loss_severity = FLUIDLOSS_CONC_BURN
-		var/fluid_loss = (damage/(owner.max_health - config.health_threshold_dead)) * SPECIES_BLOOD_DEFAULT * fluid_loss_severity
-		owner.remove_blood(fluid_loss)
+
 
 	// first check whether we can widen an existing wound
 	if(!surgical && wounds && wounds.len > 0 && prob(max(50+(number_wounds-1)*10,90)))
@@ -500,7 +506,7 @@ This function completely restores a damaged organ to perfect condition.
 			if(compatible_wounds.len)
 				var/datum/wound/W = pick(compatible_wounds)
 				W.open_wound(damage)
-				if(prob(25))
+				if(owner && prob(25))
 					if(BP_IS_CRYSTAL(src))
 						owner.visible_message("<span class='danger'>The cracks in \the [owner]'s [name] spread.</span>",\
 						"<span class='danger'>The cracks in your [name] spread.</span>",\

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -456,15 +456,15 @@ This function completely restores a damaged organ to perfect condition.
 
 	if (owner)
 		if(BP_IS_CRYSTAL(src))
-		// this needs to cover type == BURN because lasers don't use LASER, but with the way bodytemp
-		// damage is handled currently that isn't really possible without an infinite feedback loop.
-		if(type == LASER)
-			owner.bodytemperature += ceil(damage/10)
-			if(prob(25))
-				owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
-			return
-		damage = Floor(damage * 0.8)
-		type = SHATTER
+			// this needs to cover type == BURN because lasers don't use LASER, but with the way bodytemp
+			// damage is handled currently that isn't really possible without an infinite feedback loop.
+			if(type == LASER)
+				owner.bodytemperature += ceil(damage/10)
+				if(prob(25))
+					owner.visible_message("<span class='warning'>\The [owner]'s crystalline [name] shines with absorbed energy!</span>")
+				return
+			damage = Floor(damage * 0.8)
+			type = SHATTER
 
 
 		//Burn damage can cause fluid loss due to blistering and cook-off

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -17,12 +17,17 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	take_external_damage(amount)
 
 /obj/item/organ/external/proc/take_external_damage(brute, burn, damage_flags, used_weapon = null)
+	//We no longer exist, no damage allowed
+	if (QDELETED(src))
+		return
 
 	//If this limb is retracted, pass all hits directly to our parent
 	if (retracted && parent)
 		return parent.take_external_damage(brute, burn, damage_flags, used_weapon)
 
-	SET_ARGS(owner.species.handle_organ_external_damage(arglist(list(src)+args)))
+	//These may be null if the organ is taking damage while severed and lying on the ground
+	if (owner && owner.species)
+		SET_ARGS(owner.species.handle_organ_external_damage(arglist(list(src)+args)))
 	brute = round(brute * get_brute_mod(), 0.35)
 	burn = round(burn * get_burn_mod(), 0.35)
 	if((brute <= 0) && (burn <= 0))


### PR DESCRIPTION
With my last PR that optimised explosions, i made them lag free. That is still technically correct.
But i'm sure everyone noticed we had plenty of lag still. Not caused by the explosion code itself, but a variety of secondary issues.

This PR fixes most of those, and makes things far better performing overall.
The main changes:
1. Adjusted the explosion strength calculations to better match the original behaviour. Notably, this means exploders and impact grenades don't breach the floor anymore, as they don't deal the highest level of explosion damage.

2. Fixed a large number of runtime errors that explosions were causing. suddenly deleting things tends to do that, especially with organ code. I kept detonating big piles of exploders and fixing every runtime error that came up until they stopped. This alone was a major cause of lag.


There is, imo, one major issue with explosions that still needs to be fixed, namely that our floor code is awful. This is evidenced yesterday by there miraculously being space under holes in the mining outpost. At some point in future i'll likely port my work on flooring from eris to correct this.
But for now, point 1 above should mostly prevent floor breaches.

This PR obsoletes #293 , i've rolled in a change to reclamation time here, simplifies conflicts.