### PR TITLE
Fixes infinite loop with observer clients

### DIFF
--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -25,7 +25,14 @@
 	return client
 
 /mob/observer/eye/get_client()
-	. = client || (owner && owner.get_client())
+	if (client)
+		return client
+
+	if (owner && owner != src)
+		return owner.get_client()
+
+/mob/observer/eye/signal/get_client()
+	return client
 
 /mob/observer/virtual/get_client()
 	return host.get_client()


### PR DESCRIPTION
Critical priority

Fixes a not-uncommon case where an infinite loop could be created when trying to get the client of a clientless signal.

This may possibly be the cause of necrochat and view sliding issues
but it is definitely the cause of a HUGE performance sink. Literally the biggest source of lag in the profiler data