### PR TITLE
Medical Adjustments

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -307,6 +307,7 @@
 		dat += "<span class='danger'>Severe blood loss detected.</span>"
 	dat += "<b>Blood pressure:</b> [H.get_blood_pressure()] ([H.get_blood_oxygenation()]% blood oxygenation)"
 	dat += "<b>Blood volume:</b> [H.vessel.get_reagent_amount(/datum/reagent/blood)]/[H.species.blood_volume]u"
+	dat += "<b>Blood type:</b> [H.b_type]"
 
 	// Body temperature.
 	dat += "<b>Body temperature:</b> [H.bodytemperature-T0C]&deg;C ([H.bodytemperature*1.8-459.67]&deg;F)"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -886,7 +886,7 @@
 					/obj/item/weapon/reagent_containers/ivbag/blood/APlus = 5, /obj/item/weapon/reagent_containers/ivbag/blood/AMinus = 5,
 					/obj/item/weapon/reagent_containers/ivbag/blood/BPlus = 5, /obj/item/weapon/reagent_containers/ivbag/blood/BMinus = 5,
 					/obj/item/weapon/reagent_containers/ivbag/blood/OPlus = 5, /obj/item/weapon/reagent_containers/ivbag/blood/OMinus = 5,
-					/obj/item/weapon/storage/box/bloodpacks = 5, /obj/item/weapon/reagent_containers/ivbag/blood = 5)
+					/obj/item/weapon/reagent_containers/ivbag = 5, /obj/item/weapon/reagent_containers/ivbag/blood = 5)
 	idle_power_usage = 211
 
 //This one's from bay12

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -886,7 +886,7 @@
 					/obj/item/weapon/reagent_containers/ivbag/blood/APlus = 5, /obj/item/weapon/reagent_containers/ivbag/blood/AMinus = 5,
 					/obj/item/weapon/reagent_containers/ivbag/blood/BPlus = 5, /obj/item/weapon/reagent_containers/ivbag/blood/BMinus = 5,
 					/obj/item/weapon/reagent_containers/ivbag/blood/OPlus = 5, /obj/item/weapon/reagent_containers/ivbag/blood/OMinus = 5,
-					/obj/item/weapon/reagent_containers/ivbag = 5, /obj/item/weapon/reagent_containers/ivbag/blood = 5)
+					/obj/item/weapon/reagent_containers/ivbag = 5, /obj/item/weapon/reagent_containers/ivbag/blood = 15)
 	idle_power_usage = 211
 
 //This one's from bay12

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -153,6 +153,7 @@ REAGENT SCANNER
 		if(H.get_blood_volume() <= 70)
 			dat += "<span class='scan_danger'>Severe blood loss detected.</span>"
 		dat += "[b]Blood pressure:[endb] [H.get_blood_pressure()] ([H.get_blood_oxygenation()]% blood oxygenation)"
+		dat += "[b]Blood type:[endb] [H.b_type]"
 	else
 		dat += "[b]Blood pressure:[endb] N/A"
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -36,7 +36,7 @@
 
 /datum/reagent/bicaridine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(6 * removed, 0)
+		M.heal_organ_damage(4.5 * removed, 0)
 		M.add_chemical_effect(CE_PAINKILLER, 10)
 
 /datum/reagent/bicaridine/overdose(var/mob/living/carbon/M, var/alien)
@@ -60,7 +60,7 @@
 
 /datum/reagent/kelotane/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 6 * removed)
+		M.heal_organ_damage(0, 4.5 * removed)
 
 /datum/reagent/dermaline
 	name = "Dermaline"
@@ -75,7 +75,7 @@
 
 /datum/reagent/dermaline/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(0, 12 * removed)
+		M.heal_organ_damage(0, 9 * removed)
 
 /datum/reagent/dylovene
 	name = "Dylovene"
@@ -96,7 +96,7 @@
 	M.adjust_hallucination(-9 * removed)
 	M.add_up_to_chemical_effect(CE_ANTITOX, 1)
 
-	var/removing = (4 * removed)
+	var/removing = (3 * removed)
 	for(var/datum/reagent/R in M.ingested.reagent_list)
 		if(istype(R, /datum/reagent/toxin) || (R.type in remove_toxins))
 			M.ingested.remove_reagent(R.type, removing)
@@ -121,7 +121,7 @@
 		M.adjustToxLoss(removed * 6)
 	else if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_OXYGENATED, 1)
-	holder.remove_reagent(/datum/reagent/lexorin, 2 * removed)
+	holder.remove_reagent(/datum/reagent/lexorin, 1.5 * removed)
 
 /datum/reagent/dexalinp
 	name = "Dexalin Plus"
@@ -138,7 +138,7 @@
 		M.adjustToxLoss(removed * 9)
 	else if(alien != IS_DIONA)
 		M.add_chemical_effect(CE_OXYGENATED, 2)
-	holder.remove_reagent(/datum/reagent/lexorin, 3 * removed)
+	holder.remove_reagent(/datum/reagent/lexorin, 2.25 * removed)
 
 /datum/reagent/tricordrazine
 	name = "Tricordrazine"
@@ -153,7 +153,7 @@
 
 /datum/reagent/tricordrazine/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(5 * removed, 5 * removed)
+		M.heal_organ_damage(3.75 * removed, 3.75 * removed)
 
 /datum/reagent/cryoxadone
 	name = "Cryoxadone"
@@ -170,7 +170,7 @@
 	if(M.bodytemperature < 170)
 		M.adjustCloneLoss(-100 * removed)
 		M.add_chemical_effect(CE_OXYGENATED, 1)
-		M.heal_organ_damage(10 * removed, 10 * removed)
+		M.heal_organ_damage(7.5 * removed, 7.5 * removed)
 		M.add_chemical_effect(CE_PULSE, -2)
 
 /datum/reagent/clonexadone
@@ -188,7 +188,7 @@
 	if(M.bodytemperature < 170)
 		M.adjustCloneLoss(-300 * removed)
 		M.add_chemical_effect(CE_OXYGENATED, 2)
-		M.heal_organ_damage(30 * removed, 30 * removed)
+		M.heal_organ_damage(22.5 * removed, 22.5 * removed)
 		M.add_chemical_effect(CE_PULSE, -2)
 
 /* Painkillers */

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -201,5 +201,5 @@
 	if(hasHUD(user, HUD_SCIENCE))
 		var/prec = user.skill_fail_chance(SKILL_MEDICAL, 10)
 		to_chat(user, "<span class='notice'>The [src] contains: [reagents.get_reagents(precision = prec)].</span>")
-	else if((loc == user) && user.skill_check(SKILL_MEDICAL, SKILL_EXPERT))
-		to_chat(user, "<span class='notice'>Using your chemistry knowledge, you indentify the following reagents in \the [src]: [reagents.get_reagents(!user.skill_check(SKILL_MEDICAL, SKILL_PROF), 5)].</span>")
+	else if((loc == user) && user.skill_check(SKILL_MEDICAL, SKILL_PROF))
+		to_chat(user, "<span class='notice'>Using your chemistry knowledge, you indentify the following reagents in \the [src]: [reagents.get_reagents(0, 5)].</span>")

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -7,6 +7,7 @@
 /obj/item/weapon/reagent_containers/ivbag
 	name = "\improper IV bag"
 	desc = "Flexible bag for IV injectors."
+	var/written_info
 	icon = 'icons/obj/bloodpack.dmi'
 	icon_state = "empty"
 	w_class = ITEM_SIZE_SMALL
@@ -29,7 +30,13 @@
 	else
 		w_class = ITEM_SIZE_SMALL
 
-/obj/item/weapon/reagent_containers/attackby(obj/item/weapon/W as obj, mob/user as mob)
+/obj/item/weapon/reagent_containers/ivbag/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/pen))
+		written_info = sanitize(input("Notes: ", text("IV Bag")))
+		if(written_info)
+			desc = "Flexible bag for IV injectors.\nA note is scribbled on the bag. \"[written_info]\""
+		else
+			desc = "Flexible bag for IV injectors."
 
 /obj/item/weapon/reagent_containers/ivbag/update_icon()
 	overlays.Cut()

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -37,6 +37,8 @@
 			desc = "Flexible bag for IV injectors.\nA note is scribbled on the bag. \"[written_info]\""
 		else
 			desc = "Flexible bag for IV injectors."
+		return TRUE
+	. = ..()
 
 /obj/item/weapon/reagent_containers/ivbag/update_icon()
 	overlays.Cut()

--- a/html/changelogs/SleepySquidd-PR-332.yml
+++ b/html/changelogs/SleepySquidd-PR-332.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: SleepySquidd
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Reduced healing values by 25% for the following medicines: Bicaridine, Kelotane, Dermaline, Dylovene, Dexalin, Dexalin Plus, Tricordrazine, Cryoxadone, Clonexadone"

--- a/html/changelogs/SleepySquidd-PR-332.yml
+++ b/html/changelogs/SleepySquidd-PR-332.yml
@@ -34,3 +34,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - tweak: "Reduced healing values by 25% for the following medicines: Bicaridine, Kelotane, Dermaline, Dylovene, Dexalin, Dexalin Plus, Tricordrazine, Cryoxadone, Clonexadone"
+  - tweak: "Blood types now show in body scanners & health analyzers"
+  - rscadd: "IV/Blood bags can now be written on"

--- a/html/changelogs/SleepySquidd-PR-332.yml
+++ b/html/changelogs/SleepySquidd-PR-332.yml
@@ -33,6 +33,8 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
+  - rscadd: "IV/Blood bags can now be written on"
   - tweak: "Reduced healing values by 25% for the following medicines: Bicaridine, Kelotane, Dermaline, Dylovene, Dexalin, Dexalin Plus, Tricordrazine, Cryoxadone, Clonexadone"
   - tweak: "Blood types now show in body scanners & health analyzers"
-  - rscadd: "IV/Blood bags can now be written on"
+  - tweak: "Blood Banks now carry 15 empty blood packs instead of 5 blood pack boxes"
+  - tweak: "Professional level in medicine is now required to view reagents in containers instead of expert"


### PR DESCRIPTION
Blood bags can be written on with any pen variants
Blood types now show up with health analyzer and body scanner
Medicine heals 25% less for the following types:
- Bicaridine
- Kelotane
- Dermaline
- Dylovene
- Dexalin
- Dexalin Plus
- Tricordrazine
- Cryoxadone
- Clonexadone