### PR TITLE
Chunk update buffer fix

### DIFF
--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -1,4 +1,4 @@
-#define UPDATE_BUFFER 30 // 3 seconds
+#define UPDATE_BUFFER 25 // 2.5 seconds
 
 // CHUNK
 //
@@ -181,6 +181,7 @@
 					m.owner.client.images += obfuscation_image
 
 
+	last_update = world.time
 	updating = FALSE
 
 /datum/chunk/proc/acquire_visible_turfs(var/list/visible)

--- a/html/changelogs/ChunkBuffer.yml
+++ b/html/changelogs/ChunkBuffer.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Fixed a major source of lag caused by a broken necrovision chunk update buffer"


### PR DESCRIPTION
In my last work on necrovision, i tweaked the chunk update buffer to be more responsive. 
By defaul, chunks only update once every 2.5 seconds, to batch large changes and minimise the performance costs.

I made a change to backload this delay, so that if it had been a long time since the last update, the next one would be instant.  Huge boost to responsibeness, very minor performance cost

unfortunately in the process i accidentally completely broke the update buffer, and it has been a huge source of lag recently. This fixes it to work as intended, with my responsiveness change intact. Things should run much better