### PR TITLE
Removes Actor Verb

### DIFF
--- a/code/game/antagonist/outsider/actors.dm
+++ b/code/game/antagonist/outsider/actors.dm
@@ -33,7 +33,7 @@ GLOBAL_DATUM_INIT(actor, /datum/antagonist/actor, new)
 	player.equip_to_slot_or_del(C,slot_wear_id)
 
 	return 1
-
+/*
 /client/verb/join_as_actor()
 	set category = "IC"
 	set name = "Join as Actor"
@@ -54,3 +54,4 @@ GLOBAL_DATUM_INIT(actor, /datum/antagonist/actor, new)
 		return
 
 	to_chat(usr, "You must be observing or be a new player to spawn as an actor.")
+*/


### PR DESCRIPTION
Fixes #159 
Removes the Join as Actor verb for ghosts as it doesn't apply to this setting and the map isn't set up to support it.