### PR TITLE
Cargo Weapon Ordering

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -418,6 +418,7 @@
 #include "code\datums\supplypacks\hydroponics.dm"
 #include "code\datums\supplypacks\materials.dm"
 #include "code\datums\supplypacks\medical.dm"
+#include "code\datums\supplypacks\mining.dm"
 #include "code\datums\supplypacks\miscellaneous.dm"
 #include "code\datums\supplypacks\operations.dm"
 #include "code\datums\supplypacks\science.dm"

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(supply)
 
 	//supply points
 	var/points = 50
-	var/points_per_process = 1
+	var/points_per_process = 1.25
 	var/points_per_slip = 2
 	var/material_buy_prices = list(
 		/material/platinum = 5,

--- a/code/datums/supplypacks/mining.dm
+++ b/code/datums/supplypacks/mining.dm
@@ -1,0 +1,2 @@
+/decl/hierarchy/supply_pack/mining
+	name = "Mining"

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -123,10 +123,13 @@
 	contains = list(/obj/item/clothing/suit/space/void/security/alt,
 					/obj/item/clothing/head/helmet/space/void/security/alt,
 					/obj/item/clothing/shoes/magboots)
-	cost = 120
+	cost = 60
 	containername = "\improper Security voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_security
+
+
+
 
 /decl/hierarchy/supply_pack/security/weapons
 	name = "Weapons - Security basic"
@@ -138,32 +141,6 @@
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Weapons crate"
 	access = access_security
-
-/decl/hierarchy/supply_pack/security/egun
-	name = "Weapons - Energy sidearms"
-	contains = list(/obj/item/weapon/gun/energy/gun/secure = 4)
-	cost = 40
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Energy sidearms crate"
-	access = access_armory
-	security_level = SUPPLY_SECURITY_ELEVATED
-
-/decl/hierarchy/supply_pack/security/egun/shady
-	name = "Weapons - Energy sidearms (For disposal)"
-	contains = list(/obj/item/weapon/gun/energy/gun = 4)
-	cost = 60
-	contraband = 1
-	security_level = null
-
-/decl/hierarchy/supply_pack/security/ion
-	name = "Weapons - Electromagnetic"
-	contains = list(/obj/item/weapon/gun/energy/ionrifle = 2,
-					/obj/item/weapon/storage/box/emps)
-	cost = 50
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper Electromagnetic weapons crate"
-	access = access_armory
-	security_level = SUPPLY_SECURITY_ELEVATED
 
 /decl/hierarchy/supply_pack/security/shotgun
 	name = "Weapons - Shotgun"
@@ -206,57 +183,6 @@
 	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Beanbag shotgun shells crate"
-	access = access_security
-
-/decl/hierarchy/supply_pack/security/pdwammo
-	name = "Ammunition - 9mm top mounted"
-	contains = list(/obj/item/ammo_magazine/mc9mmt = 4)
-	cost = 40
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 9mm ammunition crate"
-	access = access_security
-	security_level = SUPPLY_SECURITY_HIGH
-
-/decl/hierarchy/supply_pack/security/pdwammorubber
-	name = "Ammunition - 9mm top mounted rubber"
-	contains = list(/obj/item/ammo_magazine/mc9mmt/rubber = 4)
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 9mm rubber ammunition crate"
-	access = access_security
-
-
-/decl/hierarchy/supply_pack/security/pdwammoflash
-	name = "Ammunition - 9mm top mounted flash"
-	contains = list(/obj/item/ammo_magazine/mc9mmt/flash = 4)
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 9mm stun ammunition crate"
-	access = access_security
-
-/decl/hierarchy/supply_pack/security/pdwammopractice
-	name = "Ammunition - 9mm top mounted practice"
-	contains = list(/obj/item/ammo_magazine/mc9mmt/practice = 8)
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 9mm practice ammunition crate"
-	access = access_security
-
-/decl/hierarchy/supply_pack/security/bullpupammo
-	name = "Ammunition - 7.62"
-	contains = list(/obj/item/ammo_magazine/a762 = 4)
-	cost = 60
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 7.62 ammunition crate"
-	access = access_security
-	security_level = SUPPLY_SECURITY_HIGH
-
-/decl/hierarchy/supply_pack/security/bullpupammopractice
-	name = "Ammunition - 7.62 practice"
-	contains = list(/obj/item/ammo_magazine/a762/practice = 8)
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure/weapon
-	containername = "\improper 7.62 practice ammunition crate"
 	access = access_security
 
 /decl/hierarchy/supply_pack/security/forensics //Not access-restricted so PIs can use it.

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -11,8 +11,8 @@
 
 /obj/structure/closet/secure_closet/guncabinet/WillContain()
 	return list(
-		/obj/item/weapon/gun/projectile/automatic/pulse_rifle,
-		/obj/item/ammo_magazine/pulse = 3
+		/obj/item/weapon/gun/projectile/automatic/pulse_rifle/empty,
+		/obj/item/ammo_magazine/pulse = 4
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/military
@@ -28,8 +28,8 @@
 
 /obj/structure/closet/secure_closet/guncabinet/military/WillContain()
 	return list(
-		/obj/item/weapon/gun/projectile/automatic/pulse_rifle,
-		/obj/item/ammo_magazine/pulse = 6,
+		/obj/item/weapon/gun/projectile/automatic/pulse_rifle/empty,
+		/obj/item/ammo_magazine/pulse = 7,
 		/obj/item/weapon/storage/belt/holster/security,
 
 

--- a/code/modules/clothing/spacesuits/rig/suits/security.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/security.dm
@@ -34,3 +34,14 @@
 
 /obj/item/clothing/head/helmet/space/rig/security
 	name = "hood"
+
+
+
+
+/decl/hierarchy/supply_pack/security/rig
+	name = "Armor - Security rig"
+	contains = list(/obj/item/weapon/rig/security)
+	cost = 120
+	containername = "\improper Security rig crate"
+	containertype = /obj/structure/closet/crate/secure/large
+	access = access_security

--- a/code/modules/projectiles/guns/ds13/contactbeam.dm
+++ b/code/modules/projectiles/guns/ds13/contactbeam.dm
@@ -42,6 +42,8 @@
 	var/datum/click_handler/contact/CHC
 	var/charge_projectile_type = /obj/item/projectile/beam/contact
 
+/obj/item/weapon/gun/energy/contact/empty
+	cell_type = null
 
 /*--------------------------------
 	Charge Handling
@@ -250,3 +252,24 @@
 
 	for (var/atom/movable/AM in oview(2, location))
 		AM.apply_push_impulse_from(location, 200, 0.3)
+
+
+
+/*
+	Acquisition
+*/
+/decl/hierarchy/supply_pack/mining/contact_energy
+	name = "Power - Contact Energy"
+	contains = list(/obj/item/weapon/cell/contact = 4)
+	cost = 80
+	containertype = /obj/structure/closet/crate
+	containername = "\improper contact energy crate"
+
+
+/decl/hierarchy/supply_pack/mining/contact_beam
+	name = "Mining Tool - C99 Supercollider Contact Beam"
+	contains = list(/obj/item/weapon/cell/contact = 2,
+	/obj/item/weapon/gun/energy/contact/empty = 1)
+	cost = 80
+	containertype = /obj/structure/closet/crate
+	containername = "\improper contact beam crate"

--- a/code/modules/projectiles/guns/ds13/divet.dm
+++ b/code/modules/projectiles/guns/ds13/divet.dm
@@ -19,6 +19,9 @@
 
 		)
 
+/obj/item/weapon/gun/projectile/divet/empty
+	magazine_type = null
+
 /obj/item/weapon/gun/projectile/divet/update_icon()
 	..()
 	if(ammo_magazine && ammo_magazine.stored_ammo.len)
@@ -47,10 +50,34 @@
 
 /obj/item/projectile/bullet/ls_slug
 	fire_sound = 'sound/weapons/gunshot/gunshot_pistol.ogg'
-	damage = 22.5
+	damage = 24
 	expiry_method = EXPIRY_FADEOUT
 	muzzle_type = /obj/effect/projectile/pulse/muzzle/light
 	fire_sound='sound/weapons/guns/fire/pulse_shot.ogg'
 	armor_penetration = 5
 	structure_damage_factor = 1.5
 	penetration_modifier = 1.1
+
+
+/*
+	Acquisition
+*/
+/decl/hierarchy/supply_pack/security/divet_ammo
+	name = "Ammunition - Divet Slugs"
+	contains = list(/obj/item/ammo_magazine/divet = 6)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper divet slug crate"
+	access = access_security
+	security_level = SUPPLY_SECURITY_ELEVATED
+
+
+/decl/hierarchy/supply_pack/security/divet
+	name = "Weapon - Divet handgun"
+	contains = list(/obj/item/ammo_magazine/divet = 3,
+	/obj/item/weapon/gun/projectile/divet/empty = 1)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper divet handgun crate"
+	access = access_security
+	security_level = SUPPLY_SECURITY_ELEVATED

--- a/code/modules/projectiles/guns/ds13/forcegun.dm
+++ b/code/modules/projectiles/guns/ds13/forcegun.dm
@@ -29,6 +29,11 @@
 
 
 	aiming_modes = list(/datum/extension/aim_mode/heavy)
+
+
+/obj/item/weapon/gun/energy/forcegun/empty
+	cell_type = null
+
 /*
 	Firemodes
 */
@@ -38,7 +43,7 @@
 /datum/firemode/forcegun
 	var/firing_cone = 80
 	var/firing_range = 4
-	var/damage = 45
+	var/damage = 59
 	var/force	=	350
 	var/falloff_factor = 0.9
 	var/effect_type = /obj/effect/effect/forceblast
@@ -47,7 +52,7 @@
 /datum/firemode/forcegun/blast
 	firing_cone = 80
 	firing_range = 4
-	damage = 45	//Bear in mind that damage values are heavily affected by falloff. Even at pointblank range, they will never be as high as this number
+	damage = 50	//Bear in mind that damage values are heavily affected by falloff. Even at pointblank range, they will never be as high as this number
 	force	=	350
 	falloff_factor = 0.7
 
@@ -57,7 +62,7 @@
 /datum/firemode/forcegun/focus
 	firing_cone = 15
 	firing_range = 8
-	damage = 75
+	damage = 80
 	force	=	500
 	falloff_factor = 0.35
 	effect_type = /obj/effect/effect/forceblast_focus_spawner
@@ -183,3 +188,26 @@
 		overlay_state = "fb-[round(percentage, 20)]"
 	if(overlay_state)
 		overlays += image('icons/obj/ammo.dmi', overlay_state)
+
+
+
+
+
+/*
+	Acquisition
+*/
+/decl/hierarchy/supply_pack/mining/force_energy
+	name = "Power - Force Energy"
+	contains = list(/obj/item/weapon/cell/force = 4)
+	cost = 80
+	containertype = /obj/structure/closet/crate
+	containername = "\improper force energy crate"
+
+
+/decl/hierarchy/supply_pack/mining/force_gun
+	name = "Mining Tool - Graviton Accelerator"
+	contains = list(/obj/item/weapon/cell/force = 2,
+	/obj/item/weapon/gun/energy/forcegun/empty = 1)
+	cost = 80
+	containertype = /obj/structure/closet/crate
+	containername = "\improper Graviton Accelerator crate"

--- a/code/modules/projectiles/guns/ds13/plasma_cutter.dm
+++ b/code/modules/projectiles/guns/ds13/plasma_cutter.dm
@@ -23,6 +23,9 @@
 	mag_remove_sound = 'sound/weapons/guns/interaction/force_magout.ogg'
 	removeable_cell = TRUE
 
+/obj/item/weapon/gun/energy/cutter/empty
+	cell_type = null
+
 /obj/item/weapon/gun/energy/cutter/plasma
 	name = "industrial plasma cutter"
 	desc = "A high power plasma cutter designed to cut through tungsten reinforced bulkheads during engineering works. Also a rather hazardous improvised weapon, capable of severing limbs in a few shots."
@@ -105,3 +108,25 @@
 
 /obj/item/weapon/cell/plasmacutter/update_icon()
 	return
+
+
+
+
+/*
+	Acquisition
+*/
+/decl/hierarchy/supply_pack/mining/plasma_energy
+	name = "Power - Plasma Energy"
+	contains = list(/obj/item/weapon/cell/plasmacutter = 4)
+	cost = 60
+	containertype = /obj/structure/closet/crate
+	containername = "\improper plasma energy crate"
+
+
+/decl/hierarchy/supply_pack/mining/mining_cutter
+	name = "Mining Tool - Mining Cutter"
+	contains = list(/obj/item/weapon/cell/plasmacutter = 2,
+	/obj/item/weapon/gun/energy/cutter/empty = 1)
+	cost = 60
+	containertype = /obj/structure/closet/crate
+	containername = "\improper mining cutter crate"

--- a/code/modules/projectiles/guns/ds13/pulse_rifle.dm
+++ b/code/modules/projectiles/guns/ds13/pulse_rifle.dm
@@ -30,6 +30,10 @@ The Pulse Rifle is the standard-issue service rifle of the Earth Defense Force a
 		list(mode_name="grenade launcher",  ammo_cost = 25, windup_time = 0.5 SECONDS, windup_sound = 'sound/weapons/guns/fire/pulse_grenade_windup.ogg', projectile_type = /obj/item/projectile/bullet/impact_grenade, fire_delay=20)
 		)
 
+
+/obj/item/weapon/gun/projectile/automatic/pulse_rifle/empty
+	magazine_type = null
+
 /*-----------------------
 	Firemode
 ------------------------*/
@@ -113,3 +117,30 @@ The Pulse Rifle is the standard-issue service rifle of the Earth Defense Force a
 	icon_state = "muzzle_pulse_light"
 	light_max_bright = 1
 	light_color = COLOR_DEEP_SKY_BLUE
+
+
+
+
+/*
+	Acquisition
+*/
+
+/decl/hierarchy/supply_pack/security/pulse_ammo
+	name = "Ammunition - Pulse Rounds"
+	contains = list(/obj/item/ammo_magazine/pulse = 6)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper pulse ammunition crate"
+	access = access_security
+	security_level = SUPPLY_SECURITY_ELEVATED
+
+
+/decl/hierarchy/supply_pack/security/pulse_rifle
+	name = "Weapon - Pulse Rifle"
+	contains = list(/obj/item/ammo_magazine/pulse = 3,
+	/obj/item/weapon/gun/projectile/automatic/pulse_rifle = 1)
+	cost = 60
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper pulse rifle crate"
+	access = access_security
+	security_level = SUPPLY_SECURITY_ELEVATED

--- a/code/modules/projectiles/guns/ds13/seeker.dm
+++ b/code/modules/projectiles/guns/ds13/seeker.dm
@@ -25,7 +25,8 @@
 		list(mode_name="semi-automatic",  fire_delay=10),
 		)
 
-
+/obj/item/weapon/gun/projectile/seeker/empty
+	magazine_type = null
 
 /*-----------------------
 	Ammo
@@ -99,3 +100,29 @@
 	view_range = -1
 	accuracy_mod	=	60
 	move_mod	=	-0.85
+
+
+
+
+/*
+	Acquisition
+*/
+/decl/hierarchy/supply_pack/security/seeker_ammo
+	name = "Ammunition - Seeker Shells"
+	contains = list(/obj/item/ammo_magazine/seeker = 8)
+	cost = 80
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper seeker shells crate"
+	access = access_security
+	security_level = SUPPLY_SECURITY_ELEVATED
+
+
+/decl/hierarchy/supply_pack/security/seeker_rifle
+	name = "Weapon - Seeker Rifle"
+	contains = list(/obj/item/ammo_magazine/seeker = 4,
+	/obj/item/weapon/gun/projectile/seeker/empty = 1)
+	cost = 80
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "\improper seeker rifle crate"
+	access = access_security
+	security_level = SUPPLY_SECURITY_ELEVATED

--- a/code/modules/projectiles/guns/special/ripper/ripper.dm
+++ b/code/modules/projectiles/guns/special/ripper/ripper.dm
@@ -20,7 +20,6 @@
 		)
 
 
-
 	//Maximum distance, in pixels, that the blade is allowed to be from the gun/user.
 	var/max_range = 100
 
@@ -221,3 +220,24 @@
 		CH = L.PushClickHandler(/datum/click_handler/sustained)
 		CH.reciever = gun //Reciever is the gun that gets the fire events
 		CH.user = L //And tell it where it is
+
+
+
+/*
+	Acquisition
+*/
+/decl/hierarchy/supply_pack/mining/ripper_blades
+	name = "Sawblades"
+	contains = list(/obj/item/ammo_magazine/sawblades = 6)
+	cost = 80
+	containertype = /obj/structure/closet/crate
+	containername = "\improper sawblade crate"
+
+
+/decl/hierarchy/supply_pack/mining/ripper
+	name = "Mining Tool - RC-DS Disc Ripper"
+	contains = list(/obj/item/ammo_magazine/sawblades = 3,
+	/obj/item/weapon/gun/projectile/ripper = 1)
+	cost = 80
+	containertype = /obj/structure/closet/crate
+	containername = "\improper Disc Ripper crate"

--- a/html/changelogs/CargoGuns.yml
+++ b/html/changelogs/CargoGuns.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Cargo can now order all of the dead space guns, ammunition, and ranged mining tools. Some of the guns require the ship to be on blue alert."
+  - tweak: "Slightly buffed the damage of Divet and Force Gun"
+  - rscdel: "Removed several defunct old guns and ammo from the cargo list."

--- a/html/changelogs/CargoGuns.yml
+++ b/html/changelogs/CargoGuns.yml
@@ -35,4 +35,5 @@ delete-after: True
 changes: 
   - rscadd: "Cargo can now order all of the dead space guns, ammunition, and ranged mining tools. Some of the guns require the ship to be on blue alert."
   - tweak: "Slightly buffed the damage of Divet and Force Gun"
+  - tweak: "Cargo passive supply point generation increased from 1 to 1.25 per 20 second interval"
   - rscdel: "Removed several defunct old guns and ammo from the cargo list."


### PR DESCRIPTION
We have a major problem that has been stewing for a while. Content access. Or more apppropriately, lack of access. Some of our players have never even seen the Seeker Rifle

Quite a lot of things - including many of the cool things we've made - are rare or impossible to find ingame. As a result, players are only getting to play with a relatively narrow slice of the available content.  This problem has become more pressing as uptime is getting more regular, and i felt compelled to make a start on the problem. 

In the long run, I would like to add the shop machines and the credits system to buy things. But that's a bit away yet. For now, we need to make the most of existing systems. One in particular is the subject of this PR: Cargo

This PR makes it possible to order all of the dead space guns we've created, along with their ammo. 
All except the bullpup that is, I believe snype wants that to remain unitology-exclusive.
For each of those guns, you can order a gun + some ammo, or a crate containing twice as much ammo with no gun. The latter for resupplying existing weapons. One of the big reasons crew are calling evac so early is that they've exhausted all their ammo and have no way to get more, so this will help with that problem too

In addition, this increases the passive gain of cargo points for ordering things. The original values were balanced for baystation - an environment with more secondary cargo point sources than we have. So probably a significant increase is warranted, but as is standard practise, this should be done incrementally. 25% increase to start, and we'll see how it plays

This certainly won't be the last PR of this type. more will be needed to increase the availability of other things like uncommon tools, tool mods, rigs, etc