### PR TITLE
Brute Tweaks

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -103,7 +103,6 @@
 
 	click_handlers = src.GetClickHandlers()
 
-
 	while (click_handlers.Num())
 		var/datum/click_handler/CH = click_handlers.Pop()
 		if (CH)
@@ -112,7 +111,10 @@
 
 	if(stat || paralysis || stunned || weakened)
 		return
-	face_atom(A) // change direction to face what you clicked on
+
+	//Limited arcs do their facing earlier
+	if (!limited_click_arc)
+		face_atom(A) // change direction to face what you clicked on
 	if(!canClick()) // in the year 2000...
 		return
 	if(istype(loc, /obj/mecha))
@@ -185,6 +187,10 @@
 				W.afterattack(A, src, 0, params) // 0: not Adjacent
 			else
 				RangedAttack(A, params)
+
+			//Once more with the limited arc behaviour. turn towards distant tiles we click
+			if (limited_click_arc)
+				face_atom(A)
 
 			trigger_aiming(TARGET_CAN_CLICK)
 	return 1
@@ -553,6 +559,7 @@
 	//You are allowed to click yourself and things in your own turf
 	if (user.loc == target.loc)
 		return TRUE
+
 	return (round(Vector2.FromDir(user.dir).Dot(new/vector2(target.x - user.x, target.y - user.y).Normalized()),0.000001) >= round(cos(arc),0.000001))
 
 

--- a/code/game/machinery/turret/turret.dm
+++ b/code/game/machinery/turret/turret.dm
@@ -340,6 +340,7 @@ var/list/turret_icons
 	health = 0
 	stat |= BROKEN	//enables the BROKEN bit
 	spark_system.start()	//creates some sparks because they look cool
+	last_target_check = 0	//This will force a check on the next attempt to fire
 	update_icon()
 	atom_flags |= ATOM_FLAG_CLIMBABLE // they're now climbable
 
@@ -752,7 +753,7 @@ var/list/turret_icons
 
 //Returns false if the turret has any problems that will not go away on their own. Like being turned off/broken. In future, being out of ammo too
 /obj/machinery/turret/proc/can_ever_fire()
-	if (disabled)
+	if (disabled || stat & BROKEN)
 		return FALSE
 	return TRUE
 

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -5,18 +5,18 @@ Contains helper procs for airflow, handled in /connection_group.
 mob/var/tmp/last_airflow_stun = 0
 mob/proc/airflow_stun()
 	if(stat == 2)
-		return 0
-	if(last_airflow_stun > world.time - vsc.airflow_stun_cooldown)	return 0
+		return FALSE
+	if(last_airflow_stun > world.time - vsc.airflow_stun_cooldown)	return FALSE
 
 	if(!(status_flags & CANSTUN) && !(status_flags & CANWEAKEN))
 		to_chat(src, "<span class='notice'>You stay upright as the air rushes past you.</span>")
-		return 0
+		return FALSE
 	if(buckled)
 		to_chat(src, "<span class='notice'>Air suddenly rushes past you!</span>")
-		return 0
+		return FALSE
 	if(!lying)
 		to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
-	Weaken(5)
+	Weaken(4)
 	last_airflow_stun = world.time
 
 mob/living/silicon/airflow_stun()
@@ -28,41 +28,44 @@ mob/living/carbon/slime/airflow_stun()
 mob/living/carbon/human/airflow_stun()
 	if(!slip_chance())
 		to_chat(src, "<span class='notice'>Air suddenly rushes past you!</span>")
-		return 0
+		return FALSE
 	..()
 
 atom/movable/proc/check_airflow_movable(n)
 
-	if(anchored && !ismob(src)) return 0
+	if(anchored && !ismob(src)) return FALSE
 
-	if(!isobj(src) && n < vsc.airflow_dense_pressure) return 0
+	if(!isobj(src) && n < vsc.airflow_dense_pressure) return FALSE
 
-	return 1
+	return TRUE
 
 mob/check_airflow_movable(n)
 	if(n < vsc.airflow_heavy_pressure)
-		return 0
-	return 1
+		return FALSE
+	else if (mob_size >= MOB_LARGE && n < vsc.airflow_extreme_pressure)
+		return FALSE
+
+	return TRUE
 
 mob/living/silicon/check_airflow_movable()
-	return 0
+	return FALSE
 
 
 obj/check_airflow_movable(n)
 	if(isnull(w_class))
-		if(n < vsc.airflow_dense_pressure) return 0 //most non-item objs don't have a w_class yet
+		if(n < vsc.airflow_dense_pressure) return FALSE //most non-item objs don't have a w_class yet
 	else
 		switch(w_class)
 			if(1,2)
-				if(n < vsc.airflow_lightest_pressure) return 0
+				if(n < vsc.airflow_lightest_pressure) return FALSE
 			if(3)
-				if(n < vsc.airflow_light_pressure) return 0
+				if(n < vsc.airflow_light_pressure) return FALSE
 			if(4,5)
-				if(n < vsc.airflow_medium_pressure) return 0
+				if(n < vsc.airflow_medium_pressure) return FALSE
 			if(6)
-				if(n < vsc.airflow_heavy_pressure) return 0
+				if(n < vsc.airflow_heavy_pressure) return FALSE
 			if(7 to INFINITY)
-				if(n < vsc.airflow_dense_pressure) return 0
+				if(n < vsc.airflow_dense_pressure) return FALSE
 	return ..()
 
 
@@ -73,17 +76,17 @@ obj/check_airflow_movable(n)
 /atom/movable/var/tmp/airborne_acceleration = 0
 
 /atom/movable/proc/AirflowCanMove(n)
-	return 1
+	return TRUE
 
 /mob/AirflowCanMove(n)
 	if(status_flags & GODMODE)
-		return 0
+		return FALSE
 	if(buckled)
-		return 0
+		return FALSE
 	var/obj/item/shoes = get_equipped_item(slot_shoes)
 	if(istype(shoes) && (shoes.item_flags & ITEM_FLAG_NOSLIP))
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /atom/movable/Bump(atom/A)
 	if(airflow_speed > 0 && airflow_dest)

--- a/code/modules/ZAS/ConnectionGroup.dm
+++ b/code/modules/ZAS/ConnectionGroup.dm
@@ -102,12 +102,12 @@ Class Procs:
 		if(M.last_airflow > world.time - vsc.airflow_delay) continue
 		if(M.airflow_speed) continue
 
-		//Check for knocking people over
-		if(ismob(M) && differential > vsc.airflow_stun_pressure)
-			if(M:status_flags & GODMODE) continue
-			M:airflow_stun()
-
 		if(M.check_airflow_movable(differential))
+			//Check for knocking people over
+			if(ismob(M) && differential > vsc.airflow_stun_pressure)
+				if(M:status_flags & GODMODE) continue
+				M:airflow_stun()
+
 			//Check for things that are in range of the midpoint turfs.
 			var/list/close_turfs = list()
 			for(var/turf/U in connecting_turfs)

--- a/code/modules/ZAS/Variable Settings.dm
+++ b/code/modules/ZAS/Variable Settings.dm
@@ -38,6 +38,10 @@ var/global/vs_control/vsc = new
 	var/airflow_dense_pressure_NAME = "Airflow - Dense Movement Threshold %"
 	var/airflow_dense_pressure_DESC = "Percent of 1 Atm. at which items with canisters and closets will move."
 
+	var/airflow_extreme_pressure = 120
+	var/airflow_extreme_pressure_NAME = "Airflow - Extreme Movement Threshold %"
+	var/airflow_extreme_pressure_DESC = "Percent of 1 Atm. at which large mobs will move"
+
 	var/airflow_stun_pressure = 60
 	var/airflow_stun_pressure_NAME = "Airflow - Mob Stunning Threshold %"
 	var/airflow_stun_pressure_DESC = "Percent of 1 Atm. at which mobs will be stunned by airflow."

--- a/code/modules/mob/living/abilities/brute_curl.dm
+++ b/code/modules/mob/living/abilities/brute_curl.dm
@@ -26,7 +26,7 @@
 
 	var/status = 0
 	var/force_time	=	0				//How long are we forced to stay curled up? There should always be a minimum on this to prevent spam. It shouldn't be
-	var/forced_cooldown = 1 MINUTE		//After an automatic curl, how long before we can be forced to do it again?
+	var/forced_cooldown = 1.5 MINUTE		//After an automatic curl, how long before we can be forced to do it again?
 	var/automatic = FALSE				//Did we curl up manually or automatically
 	var/animtime = 1 SECOND //How long the animation to curl/uncurl actually takes
 
@@ -71,14 +71,15 @@
 	cached_view_range = user.view_range
 	cached_view_offset = user.view_offset
 
-	var/matrix/M = user.transform
-	M.Turn(rotation)//The brute will tilt forward, if in a side facing
-	M.Scale(0.9) //Sprite will shrink a bit
+	user.default_rotation = rotation
+	user.default_scale = 0.9
+
+
 
 
 
 	//AAAnd do the animation
-	animate(user, transform = M, pixel_x = user.pixel_x + offset_dir.x, pixel_y = user.pixel_y + offset_dir.y, time = animtime)
+	animate(user, transform = user.get_default_transform(), pixel_x = user.pixel_x + offset_dir.x, pixel_y = user.pixel_y + offset_dir.y, time = animtime)
 
 	//Reduce the user's vision
 	user.view_range -= 1
@@ -116,7 +117,9 @@
 
 /datum/extension/curl/proc/uncurl()
 	status = CURLING //We're in an animation, so set this again
-	animate(user, transform = cached_transform, pixel_x = cached_pixels.x, pixel_y = cached_pixels.y, time = animtime)
+	user.default_rotation = 0
+	user.default_scale = 1
+	animate(user, transform = user.get_default_transform(), pixel_x = cached_pixels.x, pixel_y = cached_pixels.y, time = animtime)
 	user.view_range = cached_view_range
 	user.view_offset = cached_view_offset
 	user.reset_view()
@@ -134,7 +137,7 @@
 
 
 /datum/extension/curl/proc/notify_forced()
-	to_chat(user, SPAN_NOTICE("You can now use Curl again to uncurl and move"))
+	uncurl()
 
 //	Triggering
 //------------------------

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -7,7 +7,7 @@
 	name_plural =  "Brutes"
 	blurb = "A powerful linebreaker and assault specialist, the brute can smash through almost any obstacle, and its tough frontal armor makes it perfect for assaulting entrenched positions. \n\
 	Very vulnerable to flanking attacks"
-	total_health = 400
+	total_health = 350
 	torso_damage_mult = 1 //Hitting centre mass is fine for brute
 
 	icon_template = 'icons/mob/necromorph/brute.dmi'
@@ -38,10 +38,13 @@
 	weaken_mod = 0.3
 	paralysis_mod = 0.3
 
+	//Big targets are less vulnerable to fire and explosions
+	burn_mod = 0.85
+
 	inherent_verbs = list(/atom/movable/proc/brute_charge, /atom/movable/proc/brute_slam, /atom/movable/proc/curl_verb, /mob/living/carbon/human/proc/biobomb, /mob/proc/shout)
 	modifier_verbs = list(KEY_MIDDLE = list(/mob/living/carbon/human/proc/biobomb),
-	KEY_ALT = list(/atom/movable/proc/brute_charge),
-	KEY_CTRLALT = list(/atom/movable/proc/brute_slam),
+	KEY_CTRLALT = list(/atom/movable/proc/brute_charge),
+	KEY_ALT = list(/atom/movable/proc/brute_slam),
 	KEY_CTRLSHIFT = list(/atom/movable/proc/curl_verb))
 
 	unarmed_types = list(/datum/unarmed_attack/punch/brute)
@@ -188,16 +191,15 @@ Brute will be forced into a reflexive curl under certain circumstances, but it c
 		shake_animation(50)
 
 
-/atom/movable/proc/brute_slam()
+/atom/movable/proc/brute_slam(var/atom/A)
 	set name = "Slam"
 	set category = "Abilities"
 
-	var/A = LAZYACCESS(args, 1)
-	if (!A)
-		A = get_step(src, dir)
+	var/direction = get_dir(src, A)
+	A = get_step(src, direction)
 
 
-	.=slam_attack(A, _damage = 35, _power = 1, _cooldown = 8 SECONDS)
+	.=slam_attack(A, _damage = 35, _power = 1, _windup_time = 1.65 SECONDS,  _cooldown = 7 SECONDS)
 	if (.)
 		var/mob/living/carbon/human/H = src
 		H.play_species_audio(H, SOUND_SHOUT, VOLUME_HIGH, 1, 3)

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -84,6 +84,10 @@ var/global/list/sparring_attack_cache = list()
 		if(H.stat == DEAD)
 			return
 
+		//Can't knockdown people bigger than you
+		if (H.mob_size > user.mob_size)
+			return
+
 		var/stun_chance = rand(0, 100)
 
 		if(attack_damage >= 5 && armour < 100 && !(H == user) && stun_chance <= attack_damage * 5) // 25% standard chance

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -737,7 +737,7 @@ proc/is_blind(A)
 	if (. && slow_turning)	//Only mobs with slow turning set will set their move cooldown when changing dir
 		var/turntime = movement_delay()
 		SetMoveCooldown(turntime)
-		setClickCooldown(turntime + DEFAULT_ATTACK_COOLDOWN)
+		setClickCooldown(max(turntime,DEFAULT_ATTACK_COOLDOWN))
 
 //Mobs with offset view should update it every time they turn
 /mob/set_dir(new_dir)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -2,9 +2,13 @@
 	var/moving           = FALSE
 
 /mob/proc/SelfMove(var/direction)
-
-	if (facedir(direction) && slow_turning)
-		return TRUE
+	///Mobs with slow turning take a move to turn in place.
+	//We will attempt to turn towards the target if our movement is off cooldown
+	if (slow_turning)
+		if (CheckMoveCooldown() && facedir(direction))
+			return TRUE
+		else if (!(dir & direction))
+			return FALSE
 
 	if(DoMove(direction, src) & MOVEMENT_HANDLED)
 		return TRUE // Doesn't necessarily mean the mob physically moved
@@ -41,7 +45,7 @@
 /mob/proc/CheckMoveCooldown()
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
 	if(delay)
-		return delay.MayMove()
+		return (delay.MayMove(src) == MOVEMENT_PROCEED)
 
 /client/proc/client_dir(input, direction=-1)
 	return turn(input, direction*dir2angle(dir))
@@ -134,7 +138,7 @@
 		var/vert_dir = SOUTH
 		if (direct & 1)
 			vert_dir = NORTH
-		
+
 		var/hor_dir = WEST
 		if (direct & 4)
 			hor_dir = EAST

--- a/html/changelogs/BruteTweaks.yml
+++ b/html/changelogs/BruteTweaks.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed a brute bug that was causing longer click delays than intended after rotating."
+  - tweak: "Brutes are now heavily resistant to airflow effects, and will generally not be affected by sudden rushes of wind"
+  - tweak: "Brutes are now immune to special effects (stun/knockdown/blurred vision) from human punches"
+  - bugfix: "Fixed a bug where brutes would sometimes be unable to click things on diagonally adjacent tiles"
+  - bugfix: "Fixed turrets continuing to fire after being destroyed."
+  - tweak: "Brute slam is now easier to aim, alt+clicking in a general direction will do."
+  - tweak: "Brute cost reduced from 400 to 350
+  - tweak: "Brute burn damage multiplier reduced from 1.3, to 0.85, making it more resistant to explosions."
+  - tweak: "Brute slam windup time decreased from 2 to 1.75, and cooldown decreased from 8 to 7 seconds."


### PR DESCRIPTION
Addressing various complaints about brute being underpowered and buggy, this PR is a package of fixes and balance tweaks

changes: 
  - bugfix: "Fixed a brute bug that was causing longer click delays than intended after rotating."
  - tweak: "Brutes are now heavily resistant to airflow effects, and will generally not be affected by sudden rushes of wind"
  - tweak: "Brutes are now immune to special effects (stun/knockdown/blurred vision) from human punches"
  - bugfix: "Fixed a bug where brutes would sometimes be unable to click things on diagonally adjacent tiles"
  - bugfix: "Fixed turrets continuing to fire after being destroyed."
  - tweak: "Brute slam is now easier to aim, alt+clicking in a general direction will do."
  - tweak: "Brute biomass cost reduced from 400 to 350
  - tweak: "Brute burn damage multiplier reduced from 1.3, to 0.85, making it more resistant to explosions."
  - tweak: "Brute slam windup time decreased from 2 to 1.75, and cooldown decreased from 8 to 7 seconds."