### PR TITLE
Tripod Tweaks and starting biomass

### DIFF
--- a/code/_helpers/check_trajectory.dm
+++ b/code/_helpers/check_trajectory.dm
@@ -131,8 +131,8 @@
 
 /obj/item/projectile/test/Process(var/turf/targloc)
 	while(!QDELETED(src)) //Loop on through!
-		if(!isnull(result))
-			return result
+		//if(!isnull(result))
+		//	return result
 		if((!( targloc ) || loc == targloc))
 			targloc = locate(min(max(x + xo, 1), world.maxx), min(max(y + yo, 1), world.maxy), z) //Finding the target turf at map edge
 
@@ -146,6 +146,9 @@
 		var/turf/newloc = location.return_turf()
 		Move(newloc)
 
+		//Check this again, our attempted move may have just set it
+		if(!isnull(result))
+			return result
 
 		var/turf/T = get_turf(src)
 		if (T == original)

--- a/code/_helpers/check_trajectory.dm
+++ b/code/_helpers/check_trajectory.dm
@@ -131,8 +131,6 @@
 
 /obj/item/projectile/test/Process(var/turf/targloc)
 	while(!QDELETED(src)) //Loop on through!
-		//if(!isnull(result))
-		//	return result
 		if((!( targloc ) || loc == targloc))
 			targloc = locate(min(max(x + xo, 1), world.maxx), min(max(y + yo, 1), world.maxy), z) //Finding the target turf at map edge
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -27,6 +27,11 @@
 		return 0
 	if(!istype(M) || (M.loc != loc) || M.buckled || M.pinned.len || (buckle_require_restraints && !M.restrained()))
 		return 0
+
+	//For now, hard restriction on buckling large mobs.
+	//In future, maybe refactoring
+	if (M.mob_size > MOB_MEDIUM)
+		return 0
 	if(ismob(src))
 		var/mob/living/carbon/C = src //Don't wanna forget the xenos.
 		if(M != src && C.incapacitated())

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -21,6 +21,7 @@
 	var/breakout = 0 //if someone is currently breaking out. mutex
 	var/storage_capacity = 2 * MOB_MEDIUM //This is so that someone can't pack hundreds of items in a locker/crate
 							  //then open it in a populated area to crash clients.
+	var/max_mob_size = MOB_MEDIUM
 	var/open_sound = 'sound/effects/closet_open.ogg'
 	var/close_sound = 'sound/effects/closet_close.ogg'
 	hitsound = 'sound/effects/grillehit.ogg'
@@ -166,6 +167,8 @@
 	. = 0
 	for(var/mob/living/M in loc)
 		if(M.buckled || M.pinned.len || M.anchored)
+			continue
+		if (M.mob_size > max_mob_size)
 			continue
 		var/mob_size = content_size(M)
 		if(CLOSET_CHECK_TOO_BIG(mob_size))

--- a/code/modules/mob/living/abilities/high_leap.dm
+++ b/code/modules/mob/living/abilities/high_leap.dm
@@ -74,6 +74,8 @@
 		user.evasion -= evasion_delta
 		evasion_delta = 0
 
+	.=..()
+
 /*----------------------------------
 	Windup
 -----------------------------------*/
@@ -105,6 +107,7 @@
 	if (results[3] != target_loc)
 		//Uh oh, there's an obstacle here
 		obstacle = results[3]	//We will crash into this later
+
 
 	target_loc = results[2]	//We'll set our target to wherever the projectile reached
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -24,7 +24,6 @@ meteor_act
 		accuracy -= organ.base_miss_chance
 
 
-	//world << "[weapon] 	[accuracy]% acc against [src]"
 
 	//For humans, we run the accuracy check twice
 	//1. To see whether we hit anything at all. Fail, and the attack misses.

--- a/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
@@ -17,7 +17,7 @@
 	name_plural =  "Tripods"
 	blurb = "A heavy skirmisher, the tripod is adept at leaping around open spaces and fighting against multiple distant targets."
 	total_health = 500
-	torso_damage_mult = 1 //Hitting centre mass is fine for tripod
+	torso_damage_mult = 0.65 //Hitting centre mass is fine for tripod
 
 	icon_template = 'icons/mob/necromorph/tripod.dmi'
 	icon_lying = "_lying"
@@ -31,6 +31,7 @@
 	biomass = 350
 	mass = 250
 	biomass_reclamation_time	=	15 MINUTES
+	marker_spawnable = TRUE
 
 
 	//Collision and bulk
@@ -62,17 +63,18 @@
 
 	unarmed_types = list(/datum/unarmed_attack/punch/tripod)
 
-	slowdown = 6 //Note, this is a terribly awful way to do speed, bay's entire speed code needs redesigned
+	slowdown = 5 //Note, this is a terribly awful way to do speed, bay's entire speed code needs redesigned
 
 	//Vision
 	view_range = 12
 
 
 	has_limbs = list(
-	BP_HEAD = list("path" = /obj/item/organ/external/arm/tentacle/tripod_tongue),
+
 	BP_CHEST =  list("path" = /obj/item/organ/external/chest/giant),
 	BP_L_ARM =  list("path" = /obj/item/organ/external/arm/giant),
-	BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/giant)
+	BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/giant),
+	BP_HEAD = list("path" = /obj/item/organ/external/arm/tentacle/tripod_tongue),
 	)
 
 	locomotion_limbs = list(BP_R_ARM, BP_L_ARM)
@@ -188,9 +190,11 @@ If performed successfully on a live crewman, it yields a bonus of 10kg biomass f
 	Organs
 --------------------------------*/
 /obj/item/organ/external/arm/tentacle/tripod_tongue
+	name = "tongue"
 	organ_tag = BP_HEAD
 	icon_name = "tongue"
 	retracted = TRUE
+	parent_organ = BP_CHEST
 
 //The tongue has a slithering noise for when it goes in and out
 /obj/item/organ/external/arm/tentacle/tripod_tongue/retract()
@@ -381,7 +385,7 @@ If performed successfully on a live crewman, it yields a bonus of 10kg biomass f
 	range = ARM_SWING_RANGE,
 	duration = 0.85 SECOND,
 	windup = 0.8 SECONDS,
-	cooldown = 3 SECONDS,
+	cooldown = 3.5 SECONDS,
 	effect_type = effect,
 	damage = 20,
 	damage_flags = DAM_EDGE,

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -18,7 +18,7 @@
 
 	//Biomass handling
 	//--------------------------
-	biomass	= 100//Current actual quantity of biomass we have stored. Start with enough to spawn a slasher
+	biomass	= 200//Current actual quantity of biomass we have stored. Start with enough to spawn a small expeditionary force
 	var/biomass_tick = 0	//Current amount of mass we're gaining each second. This shouldn't be edited as it is regularly recalculated
 	var/list/biomass_sources = list()	//A list of various sources (mostly necromorph corpses) from which we are gradually gaining biomass. These are finite
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -62,7 +62,7 @@
 		else
 			visible_message(SPAN_WARNING("[user] starts climbing into the disposal."))
 
-		if (!do_after(user, 3 SECONDS, src))
+		if (!do_after(user, 6 SECONDS, src))
 			return
 
 	//If we get here it succeeds
@@ -77,7 +77,7 @@
 	if (victim.client)
 		victim.client.perspective = EYE_PERSPECTIVE
 		victim.client.eye = src
-		victim.forceMove(src)
+	victim.forceMove(src)
 
 
 // attack by item places it in to disposal

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -28,6 +28,7 @@
 	active_power_usage = 2200	//the pneumatic pump power. 3 HP ~ 2200W
 	idle_power_usage = 100
 	atom_flags = ATOM_FLAG_CLIMBABLE
+	var/max_mob_size = MOB_MEDIUM
 
 // create a new disposal
 // find the attached trunk (if present) and init gas resvr.
@@ -49,6 +50,35 @@
 	if(trunk)
 		trunk.linked = null
 	return ..()
+
+/obj/machinery/disposal/proc/try_insert_mob(var/mob/victim, var/mob/user)
+	if (victim.mob_size > max_mob_size || victim.buckled || (user && user.incapacitated()))
+		return
+
+
+	if (user)
+		if (user != victim)
+			visible_message(SPAN_WARNING("[user] starts putting [victim] into the disposal."))
+		else
+			visible_message(SPAN_WARNING("[user] starts climbing into the disposal."))
+
+		if (!do_after(user, 3 SECONDS, src))
+			return
+
+	//If we get here it succeeds
+	insert_mob(victim)
+
+	if (user)
+		if (user != victim)
+			visible_message(SPAN_WARNING("[victim] has been placed into the disposal.by [user]"))
+			admin_attack_log(user, victim, "Placed the victim into \the [src].", "Was placed into \the [src] by the attacker.", "stuffed \the [src] with")
+
+/obj/machinery/disposal/proc/insert_mob(var/mob/victim)
+	if (victim.client)
+		victim.client.perspective = EYE_PERSPECTIVE
+		victim.client.eye = src
+		victim.forceMove(src)
+
 
 // attack by item places it in to disposal
 /obj/machinery/disposal/attackby(var/obj/item/I, var/mob/user)
@@ -105,19 +135,9 @@
 	var/obj/item/grab/G = I
 	if(istype(G))	// handle grabbed mob
 		if(ismob(G.affecting))
-			var/mob/GM = G.affecting
-			for (var/mob/V in viewers(usr))
-				V.show_message("[usr] starts putting [GM.name] into the disposal.", 3)
-			if(do_after(usr, 20, src))
-				if (GM.client)
-					GM.client.perspective = EYE_PERSPECTIVE
-					GM.client.eye = src
-				GM.forceMove(src)
-				for (var/mob/C in viewers(src))
-					C.show_message("<span class='warning'>[GM.name] has been placed in the [src] by [user].</span>", 3)
-				qdel(G)
-				admin_attack_log(usr, GM, "Placed the victim into \the [src].", "Was placed into \the [src] by the attacker.", "stuffed \the [src] with")
-		return
+			try_insert_mob(G.affecting, user)
+			return
+
 
 	if(isrobot(user))
 		return
@@ -143,17 +163,12 @@
 	if(stat & BROKEN || !CanMouseDrop(AM, user, incapacitation_flags) || AM.anchored || !isturf(user.loc))
 		return
 
-	// Animals can only put themself in
-	if(isanimal(user) && AM != user)
-		return
-
 	// Determine object type and run necessary checks
 	var/mob/M = AM
 	var/is_dangerous // To determine css style in messages
 	if(istype(M))
-		is_dangerous = TRUE
-		if(M.buckled)
-			return
+		try_insert_mob(M, user)
+		return
 	else if(istype(AM, /obj/item))
 		attackby(AM, user)
 		return

--- a/html/changelogs/Tripod.yml
+++ b/html/changelogs/Tripod.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Unknown
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed the tripod passing through solid objects."
+  - tweak: "Large mobs (Brute, Tripod, Ubermorph) can no longer be placed in lockers or disposals. They can also no longer be buckled to objects."
+  - tweak: "Slightly increased tripod's base movement speed."
+  - tweak: "Slightly increased the cooldown on tripod's arm swing."
+  - tweak: "Reduced the torso damage multiplier on tripod from 1 to 0.65 . Stop shooting necromorphs in the torso!"
+  - experiment: "Increased the Marker's starting biomass from 100 to 200, enough for a small squadron."

--- a/html/changelogs/Tripod.yml
+++ b/html/changelogs/Tripod.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: Unknown
+author: Nanako
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Bugfixes and tweaks for tripod

fixes parts 2, 3, 4, 5, and 7 on issue #391 

In addition this incorporates a highly requested change i've been meaning to do for a while. Increasing the starting biomass of the marker, so that the early parts of the round aren't just a desperate scrabble with a single slasher being bullied.

This change is intended to make the early parts of necromorph gameplay feel less silly. It's not intended to speed up the pace of the round though. Depending on how it plays, it's probable that other changes will be made to biomass reclamation times in future to compensate

changes: 
  - bugfix: "Fixed the tripod passing through solid objects."
  - tweak: "Large mobs (Brute, Tripod, Ubermorph) can no longer be placed in lockers or disposals. They can also no longer be buckled to objects."
  - tweak: "Slightly increased tripod's base movement speed."
  - tweak: "Slightly increased the cooldown on tripod's arm swing."
  - tweak: "Reduced the torso damage multiplier on tripod from 1 to 0.65 . Stop shooting necromorphs in the torso!"
  - experiment: "Increased the Marker's starting biomass from 100 to 200, enough for a small squadron."