### PR TITLE
fixes evac timer

### DIFF
--- a/code/game/gamemodes/marker/evac_points.dm
+++ b/code/game/gamemodes/marker/evac_points.dm
@@ -4,7 +4,8 @@
 	var/minimum_evac_time = 45// in minutes. How soon after marker setup that evac can be called, assuming all systems remain working (they won't)
 
 
-	var/last_pointgain	= 0
+	var/last_pointgain_time	= 0
+	var/last_pointgain_quantity = 0
 	var/pointgain_timer
 
 /datum/game_mode/marker/proc/charge_evac_points()
@@ -17,19 +18,21 @@
 	pointgain *= evac_threshold / minimum_evac_time
 
 	//And finally, we'll factor in the real time that has passed to compensate for lag and/or time dilation
-	var/minutes_passed = (world.timeofday - last_pointgain) / 600	//In ideal circumstances, this value will be 1, but it may be more than 1 if server is lagging
+	var/minutes_passed = (world.timeofday - last_pointgain_time) / 600	//In ideal circumstances, this value will be 1, but it may be more than 1 if server is lagging
 	pointgain *= minutes_passed
 
 
+	last_pointgain_quantity = pointgain
 	evac_points += pointgain
 
+	last_pointgain_time = world.timeofday
 
 	if(evac_points >= evac_threshold)
 		auto_recall_shuttle = FALSE //Allow shuttles now.
 		evac_points = evac_threshold
 		//No addtimer call here, so we'll stop gaining points now
 	else
-		pointgain_timer = addtimer(CALLBACK(src, .proc/charge_evac_points), 1 MINUTE) //Shuttle was unable to be called. Try again recursively.
+		pointgain_timer = addtimer(CALLBACK(src, .proc/charge_evac_points), 1 MINUTE, TIMER_STOPPABLE) //Shuttle was unable to be called. Try again recursively.
 	return FALSE
 
 
@@ -47,7 +50,14 @@
 	return FALSE
 
 /datum/evacuation_predicate/travel_points/can_call(var/user)
+
 	var/datum/game_mode/marker/GM = ticker.mode
 	if (GM.evac_points >= GM.evac_threshold)
 		return TRUE
+
+	if (user && GM && GM.last_pointgain_quantity)
+
+		var/time_remaining = ((GM.evac_threshold - GM.evac_points) / GM.last_pointgain_quantity) MINUTES
+		to_chat(user, SPAN_DANGER("There is no viable site within range for evacuation at the present time. ETA: [time2text(time_remaining, "mm:ss")]"))
+
 	return FALSE

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,6 +1,7 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
 	/datum/admins/proc/show_player_panel,	//shows an interface for individual players, with various links (links require additional flags,
+	/client/proc/activate_marker,		//Activates The Marker
 	/client/proc/player_panel,
 	/client/proc/secrets,
 	/client/proc/deadmin_self,			//destroys our own admin datum so we can play as a regular player,
@@ -15,6 +16,7 @@ var/list/admin_verbs_default = list(
 	/client/proc/cmd_dev_bst
 	)
 var/list/admin_verbs_admin = list(
+	/client/proc/activate_marker,		//Activates The Marker
 	/client/proc/player_panel_new,		//shows an interface for all players, with links to various panels,
 	/client/proc/invisimin,				//allows our mob to go invisible/visible,
 //	/datum/admins/proc/show_traitor_panel,	//interface which shows a mob's mind, -Removed due to rare practical use. Moved to debug verbs ~Errorage,
@@ -290,7 +292,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/getserverlog,
 	/client/proc/jumptocoord,
 	/client/proc/cmd_admin_subtle_message,
-	/client/proc/colorooc,	
+	/client/proc/colorooc,
 	/datum/admins/proc/force_mode_latespawn,
 	/datum/admins/proc/force_antag_latespawn,
 	/datum/admins/proc/toggleenter,

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -46,6 +46,8 @@
 */
 
 /obj/machinery/marker/proc/make_active()
+	if (active)
+		return
 	active = TRUE
 
 	//Any shards in the world become active
@@ -59,6 +61,12 @@
 	start_corruption()
 	update_icon()
 	set_traumatic_sight(TRUE, 5) //Marker is pretty hard to look at.
+
+	//If the marker is activated manually, tell the gamemode to activate itself too.
+	//This is a circular process, activate_marker will call this proc, hence the check for active at the start
+	var/datum/game_mode/marker/GM = ticker.mode
+	if (GM && !GM.marker_active)
+		GM.activate_marker()
 
 /obj/machinery/marker/Initialize()
 	.=..()


### PR DESCRIPTION
Evacuation minimum timer now works, abandon ship can't be called until 45 minutes after marker activation (90 mins into the round)