### PR TITLE
Charge fixes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -124,7 +124,7 @@
 		return M.click_action(A, src)
 
 	if(restrained())
-		setClickCooldown(10)
+		set_click_cooldown(10)
 		RestrainedClickOn(A)
 		return 1
 
@@ -156,7 +156,7 @@
 				W.afterattack(A, src, 1, params) // 1 indicates adjacency
 		else
 			if(ismob(A)) // No instant mob attacking
-				setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			UnarmedAttack(A, 1)
 
 		trigger_aiming(TARGET_CAN_CLICK)
@@ -177,7 +177,7 @@
 					W.afterattack(A, src, 1, params) // 1: clicking something Adjacent
 			else
 				if(ismob(A)) // No instant mob attacking
-					setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+					set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 				UnarmedAttack(A, 1)
 
 			trigger_aiming(TARGET_CAN_CLICK)
@@ -195,11 +195,14 @@
 			trigger_aiming(TARGET_CAN_CLICK)
 	return 1
 
-/mob/proc/setClickCooldown(var/timeout)
+/mob/proc/set_click_cooldown(var/timeout)
 	next_move = max(world.time + timeout, next_move)
 
-/mob/proc/addClickCooldown(var/timeout)
+/mob/proc/add_click_cooldown(var/timeout)
 	next_move += timeout
+
+/mob/proc/reset_click_cooldown(var/timeout)
+	next_move = world.time
 
 /mob/proc/canClick()
 	if(config.no_click_cooldown || next_move <= world.time)
@@ -247,7 +250,7 @@
 	if((LASER in mutations) && a_intent == I_HURT)
 		LaserEyes(A) // moved into a proc below
 	else if(TK in mutations)
-		setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		A.attack_tk(src)
 /*
 	Restrained ClickOn
@@ -497,7 +500,7 @@
 	return
 
 /mob/living/LaserEyes(atom/A)
-	setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+	set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
 	var/turf/T = get_turf(src)
 
 	var/obj/item/projectile/beam/LE = new (T)

--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -26,7 +26,7 @@
 
 /mob/observer/ghost/ClickOn(var/atom/A, var/params)
 	if(!canClick()) return
-	setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+	set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
 
 	// You are responsible for checking config.ghost_interaction when you override this function
 	// Not all of them require checking, see below

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -72,7 +72,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if(!no_attack_log)
 		admin_attack_log(user, M, "Attacked using \a [src] (DAMTYE: [uppertext(damtype)])", "Was attacked with \a [src] (DAMTYE: [uppertext(damtype)])", "used \a [src] (DAMTYE: [uppertext(damtype)]) to attack")
 	/////////////////////////
-	user.setClickCooldown(attack_cooldown + w_class)
+	user.set_click_cooldown(attack_cooldown + w_class)
 	user.do_attack_animation(M)
 	if(!user.aura_check(AURA_TYPE_WEAPON, src, user))
 		return 0

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -76,7 +76,7 @@
 	if(!..())
 		return 0
 
-	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	A.attack_generic(src,rand(5,6),"bitten")
 
 /*
@@ -99,7 +99,7 @@
 		return
 
 	//should have already been set if we are attacking a mob, but it doesn't hurt and will cover attacking non-mobs too
-	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/mob/living/M = A
 	if(!istype(M))
 		A.attack_generic(src, (is_adult ? rand(20,40) : rand(5,25)), "glomped") // Basic attack.
@@ -160,7 +160,7 @@
 			return
 		if(ckey)
 			admin_attack_log(src, A, "Has [attacktext] its victim.", "Has been [attacktext] by its attacker.", attacktext)
-	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/damage = rand(melee_damage_lower, melee_damage_upper)
 	if(A.attack_generic(src, damage, attacktext, environment_smash, damtype, defense) && loc && attack_sound)
 		playsound(loc, attack_sound, 50, 1, 1)

--- a/code/_onclick/rig.dm
+++ b/code/_onclick/rig.dm
@@ -49,6 +49,6 @@
 				return 0
 		rig.selected_module.engage(A, alert_ai)
 		if(ismob(A)) // No instant mob attacking - though modules have their own cooldowns
-			setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		return 1
 	return 0

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -105,7 +105,7 @@ var/const/tk_maxrange = 15
 	if(isobj(target) && !isturf(target.loc))
 		return
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/d = get_dist(user, target)
 	if(focus)
 		d = max(d, get_dist(user, focus)) // whichever is further

--- a/code/controllers/subsystems/processing/airflow.dm
+++ b/code/controllers/subsystems/processing/airflow.dm
@@ -93,7 +93,7 @@ PROCESSING_SUBSYSTEM_DEF(airflow)
 		step_towards(target, target.airflow_dest)
 		if (ismob(target))
 			var/mob/M = target
-			M.SetMoveCooldown(vsc.airflow_mob_slowdown)
+			M.set_move_cooldown(vsc.airflow_mob_slowdown)
 
 		if (MC_TICK_CHECK)
 			return

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -272,7 +272,7 @@
 
 	// Something with pulling things
 	var/extra_delay = HandleGrabs(direction, old_turf)
-	mob.ExtraMoveCooldown(extra_delay)
+	mob.extra_move_cooldown(extra_delay)
 
 	for (var/obj/item/grab/G in mob)
 		if (G.assailant_reverse_facing())

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -35,7 +35,7 @@
 	attackpylon(user, W.force)
 
 /obj/structure/cult/pylon/proc/attackpylon(mob/user as mob, var/damage)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(!isbroken)
 		if(prob(1+ damage * 5))
 			user.visible_message(

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -307,7 +307,7 @@
 	else if(I.force)
 		user.visible_message("<span class='notice'>\The [user] hits \the [src] with \the [I].</span>", "<span class='notice'>You hit \the [src] with \the [I].</span>")
 		take_damage(I.force)
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
 
 /obj/effect/cultwall/bullet_act(var/obj/item/projectile/Proj)
@@ -492,7 +492,7 @@
 	admin_attack_log(user, victim, "Used a blood drain rune.", "Was victim of a blood drain rune.", "used a blood drain rune on")
 	speak_incantation(user, "Yu[pick("'","`")]gular faras desdae. Havas mithum javara. Umathar uf'kal thenar!")
 	user.visible_message("<span class='warning'>Blood flows from \the [src] into \the [user]!</span>", "<span class='cult'>The blood starts flowing from \the [src] into your frail mortal body. [capitalize(english_list(heal_user(user), nothing_text = "you feel no different"))].</span>", "You hear liquid flow.")
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 
 /obj/effect/rune/drain/proc/heal_user(var/mob/living/carbon/human/user)
 	if(!istype(user))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -224,7 +224,7 @@
 			O << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", itemname, info), text("window=[]", itemname))
 
 	else if(W.damtype == BRUTE || W.damtype == BURN) //bashing cameras
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		if (W.force >= src.toughness)
 			user.do_attack_animation(src)
 			visible_message("<span class='warning'><b>[src] has been [pick(W.attack_verb)] with [W] by [user]!</b></span>")

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -337,7 +337,7 @@
 /obj/machinery/door/proc/check_force(obj/item/I as obj, mob/user as mob)
 	if(density &&  user.a_intent == I_HURT && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
 		var/obj/item/weapon/W = I
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 
 		if(W.damtype == BRUTE || W.damtype == BURN)
 			hit(user, W, W.force)

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -159,7 +159,7 @@
 	//psa to whoever coded this, there are plenty of objects that need to call attack() on doors without bludgeoning them.
 	if(src.density && istype(I, /obj/item/weapon) && user.a_intent == I_HURT && !istype(I, /obj/item/weapon/card))
 		var/obj/item/weapon/W = I
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		if(W.damtype == BRUTE || W.damtype == BURN)
 			user.do_attack_animation(src)
 			if(W.force < min_force)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -240,7 +240,7 @@
 
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
 	if(src.density && istype(I, /obj/item/weapon) && !istype(I, /obj/item/weapon/card))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		var/aforce = I.force
 		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
 		visible_message("<span class='danger'>[src] was hit by [I].</span>")

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -702,7 +702,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			O.show_message("<EM>[user.name]</EM> further abuses the shattered [src.name].")
 	else
 		if(istype(I, /obj/item/weapon) )
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			var/obj/item/weapon/W = I
 			if(W.force <15)
 				for (var/mob/O in hearers(5, src.loc))

--- a/code/game/machinery/turret/turret.dm
+++ b/code/game/machinery/turret/turret.dm
@@ -258,7 +258,7 @@ var/list/turret_icons
 
 	else
 		//if the turret was attacked with the intention of harming it:
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		take_damage(I.force * 0.5)
 		if(I.force * 0.5 > 1) //if the force of impact dealt at least 1 damage, the turret gets pissed off
 			if(!attacked && !emagged)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -805,12 +805,12 @@
 			if (hasInternalDamage(MECHA_INT_TANK_BREACH))
 				clearInternalDamage(MECHA_INT_TANK_BREACH)
 				to_chat(user, "<span class='notice'>You repair the damaged gas tank.</span>")
-				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		else
 			return
 		if(src.health<initial(src.health))
 			to_chat(user, "<span class='notice'>You repair some damage to [src.name].</span>")
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			src.health += min(10, initial(src.health)-src.health)
 		else
 			to_chat(user, "The [src.name] is at full integrity")
@@ -823,7 +823,7 @@
 	else
 		src.log_message("Attacked by [W]. Attacker - [user]")
 
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		if(deflect_hit(is_melee=1))
 			to_chat(user, "<span class='danger'>\The [W] bounces off [src.name].</span>")
 			src.log_append_to_last("Armor saved.")

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -21,7 +21,7 @@
 	return
 
 /obj/effect/spider/attackby(var/obj/item/weapon/W, var/mob/user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 
 	if(W.attack_verb.len)
 		visible_message("<span class='warning'>\The [src] have been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]</span>")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -573,7 +573,7 @@ var/list/global/slot_flags_enumeration = list(
 
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
 
 	src.add_fingerprint(user)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -60,7 +60,7 @@
 			to_chat(user, "<span class='warning'>*click* *click*</span>")
 			return
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
 
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
@@ -140,7 +140,7 @@
 		else	//can only use it  5 times a minute
 			user.show_message("<span class='warning'>*click* *click*</span>", 2)
 			return
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	flick("[initial(icon_state)]_on", src)
 	if(user && isrobot(user))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -72,7 +72,7 @@
 
 			inspect_vision(vision, user)
 
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN) //can be used offensively
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN) //can be used offensively
 			M.flash_eyes()
 	else
 		return ..()

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -14,7 +14,7 @@
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss() )
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			R.adjustBruteLoss(-15)
 			R.adjustFireLoss(-15)
 			R.updatehealth()
@@ -40,7 +40,7 @@
 			if(!S.get_damage())
 				to_chat(user, "<span class='notice'>Nothing to fix here.</span>")
 			else if(can_use(1))
-				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 				S.heal_damage(15, 15, robo_repair = 1)
 				H.updatehealth()
 				use(1)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -95,7 +95,7 @@
 	admin_attack_log(user, H, "Attempted to handcuff the victim", "Was target of an attempted handcuff", "attempted to handcuff")
 	feedback_add_details("handcuffs","H")
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(H)
 
 	user.visible_message("<span class='danger'>\The [user] has put [cuff_type] on \the [H]!</span>")

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -70,7 +70,7 @@
 	if (user && src.imp)
 		M.visible_message("<span class='warning'>[user] is attemping to implant [M].</span>")
 
-		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
 		user.do_attack_animation(M)
 
 		var/target_zone = user.zone_sel.selecting

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -29,7 +29,7 @@
 		//Playful poking is its own thing
 		user.visible_message("<span class='notice'>[user] pokes [M] with [src].</span>", "<span class='notice'>You poke [M] with [src].</span>")
 		//Consider adding a check to see if target is dead
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(M)
 		return
 	return ..()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -52,7 +52,7 @@
 /obj/item/weapon/soap/attack(mob/living/target, mob/living/user, var/target_zone)
 	if(target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_sel &&user.zone_sel.selecting == BP_MOUTH)
 		user.visible_message("<span class='danger'>\The [user] washes \the [target]'s mouth out with soap!</span>")
-		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //prevent spam
+		user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN) //prevent spam
 		return
 	..()
 

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -935,7 +935,7 @@
 				if (use_tool(user, H, WORKTIME_FAST, QUALITY_WELDING, FAILCHANCE_NORMAL, required_stat = "construction"))
 					if(S.robo_repair(15, BRUTE, "some dents", src, user))
 						//S.heal_damage(15,0,0,1)
-						user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+						user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 						user.visible_message(SPAN_NOTICE("\The [user] patches some dents on \the [H]'s [S.name] with \the [src]."))
 						return 1
 			/*

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -24,7 +24,7 @@
 		. = ..()
 
 /obj/item/weapon/tray/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	// Drop all the things. All of them.
 	overlays.Cut()
 	for(var/obj/item/I in carrying)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -13,7 +13,7 @@
 /obj/item/weapon/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
 	//if(user != M)
 	if(M.mind && LAZYLEN(M.mind.learned_spells))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -157,7 +157,7 @@
 		playsound(src, hitsound, VOLUME_MID, 1)
 		user.do_attack_animation(src)
 		take_damage(C.force, C.damtype, user, C)
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		return
 	.=..()
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -406,7 +406,7 @@
 		else if (S.strength > 0)
 			breakout_time /= 1 + (S.strength*2)
 
-	escapee.setClickCooldown(100)
+	escapee.set_click_cooldown(100)
 
 	//okay, so the closet is either welded or locked... resist!!!
 	to_chat(escapee, "<span class='warning'>You lean on the back of \the [src] and start pushing the door open. (this will take about [breakout_time*0.1] seconds)</span>")

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -94,7 +94,7 @@
 			return
 
 	if(O.force)
-		user.setClickCooldown(10)
+		user.set_click_cooldown(10)
 		attack_generic(user, O.force, "bashes")
 		return
 
@@ -105,7 +105,7 @@
 		open = 1
 		unlocked = 1
 	else
-		user.setClickCooldown(10)
+		user.set_click_cooldown(10)
 		open = !open
 		to_chat(user, "<span class='notice'>You [open ? "open" : "close"] \the [src].</span>")
 	update_icon()
@@ -120,7 +120,7 @@
 		open = 1
 		unlocked = 1
 	else
-		user.setClickCooldown(10)
+		user.set_click_cooldown(10)
 		to_chat(user, "<span class='notice'>You begin [unlocked ? "enabling" : "disabling"] \the [src]'s maglock.</span>")
 
 		if(!do_after(user, 20,src))

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -19,7 +19,7 @@
 		to_chat(user, "<span class='warning'>You need more energy to use the punching bag. Go eat something.</span>")
 	else
 		if(user.a_intent == I_HURT)
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			flick("[icon_state]_hit", src)
 			playsound(src.loc, 'sound/effects/woodhit.ogg', 25, 1, -1)
 			user.do_attack_animation(src)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -53,7 +53,7 @@
 
 /obj/structure/grille/attack_hand(mob/user as mob)
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 	user.do_attack_animation(src)
 
@@ -179,7 +179,7 @@
 //window placing end
 
 	else if(!(W.obj_flags & OBJ_FLAG_CONDUCTIBLE) || !shock(user, 70))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
 		playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
 		switch(W.damtype)

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -72,7 +72,7 @@
 	if(escapee.stat || escapee.restrained())
 		return
 
-	escapee.setClickCooldown(100)
+	escapee.set_click_cooldown(100)
 	to_chat(escapee, "<span class='warning'>You start digging your way out of \the [src] (this will take about [breakout_time] minute\s)</span>")
 	visible_message("<span class='danger'>Something is scratching its way out of \the [src]!</span>")
 

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -87,7 +87,7 @@ var/global/list/stool_cache = list() //haha stool
 /obj/item/weapon/stool/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	if (prob(5))
 		user.visible_message("<span class='danger'>[user] breaks [src] over [target]'s back!</span>")
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(target)
 		dismantle() //This deletes self.
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -144,7 +144,7 @@
 	playsound(loc, 'sound/effects/Glasshit.ogg', 50, 1)
 
 /obj/structure/window/attack_hand(mob/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(HULK in user.mutations)
 		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!"))
 		user.visible_message("<span class='danger'>[user] smashes through [src]!</span>")
@@ -176,7 +176,7 @@
 		damage = max(damage, 10)
 
 	if(istype(user))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
 	if(!damage)
 		return

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -95,7 +95,7 @@
 
 	radiate()
 	add_fingerprint(user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/rotting = (locate(/obj/effect/overlay/wallrot) in src)
 	if (HULK in user.mutations)
 		if (rotting || !prob(material.hardness))
@@ -112,7 +112,7 @@
 	if(!istype(user))
 		return
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/rotting = (locate(/obj/effect/overlay/wallrot) in src)
 	if(!damage || !wallbreaker)
 		try_touch(user, rotting)
@@ -130,7 +130,7 @@
 
 /turf/simulated/wall/attackby(obj/item/weapon/W as obj, mob/user as mob)
 
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -57,7 +57,7 @@
 	return 1
 
 /turf/attack_hand(mob/user)
-	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
 
 	if(user.restrained())
 		return 0

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -145,7 +145,7 @@
 	return 0
 
 /obj/effect/blob/attackby(var/obj/item/weapon/W, var/mob/user)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
 	playsound(loc, 'sound/effects/attackblob.ogg', 50, 1)
 	var/damage = 0

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -48,7 +48,7 @@
 				"<span class='warning'>You hear shredding and ripping.</span>")
 			unbuckle_mob()
 	else
-		user.setClickCooldown(100)
+		user.set_click_cooldown(100)
 		var/breakouttime = rand(600, 1200) //1 to 2 minutes.
 
 		user.visible_message(

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -493,7 +493,7 @@
 		to_chat(user, "You [anchored ? "wrench" : "unwrench"] \the [src].")
 
 	else if(O.force && seed)
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.visible_message("<span class='danger'>\The [seed.display_name] has been attacked by [user] with \the [O]!</span>")
 		playsound(get_turf(src), O.hitsound, 100, 1)
 		if(!dead)

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -224,7 +224,7 @@
 		user.visible_message("<span class='notice'>You open up the book and show it to [M]. </span>", \
 			"<span class='notice'> [user] opens up a book and shows it to [M]. </span>")
 		M << browse("<i>Author: [author].</i><br><br>" + "[dat]", "window=book;size=1000x550")
-		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
+		user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
 
 /*
  * Manual Base Object

--- a/code/modules/mob/living/abilities/charge.dm
+++ b/code/modules/mob/living/abilities/charge.dm
@@ -106,7 +106,7 @@
 	if (isliving(user))
 		L = user
 		L.face_atom(target)
-		L.Stun(max_lifespan()*0.1,TRUE)
+		L.disable(max_lifespan())
 		starting_locomotion_limbs = length(L.get_locomotion_limbs(FALSE))
 	//Delay handling
 	if (!delay)
@@ -172,16 +172,19 @@
 
 	user.visible_message(SPAN_DANGER("[user] [verb_action] at [target]!"))
 
-	walk_towards(holder, move_target, SPEED_TO_TICKS(speed))
+	walk_towards(holder, move_target, SPEED_TO_DELAY(speed))
 
 	nomove_timer = addtimer(CALLBACK(src, .proc/stop_peter_out), nomove_timeout, TIMER_STOPPABLE)
 
 
 
 /datum/extension/charge/proc/stop()
-	if (ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.step_interval = cached_step_interval
+	if (isliving(user))
+		if (ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.step_interval = cached_step_interval
+		L.enable()
+
 	GLOB.bump_event.unregister(holder, src, /datum/extension/charge/proc/bump)
 	GLOB.moved_event.unregister(holder, src, /datum/extension/charge/proc/moved)
 	walk(holder, 0)

--- a/code/modules/mob/living/abilities/gallop.dm
+++ b/code/modules/mob/living/abilities/gallop.dm
@@ -45,7 +45,7 @@
 
 
 		user.move_speed_factor += power
-		user.ResetMoveCooldown()//Allow nextmove immediately
+		user.reset_move_cooldown()//Allow nextmove immediately
 		GLOB.damage_hit_event.register(user, src, /datum/extension/gallop/proc/user_hit)
 		GLOB.bump_event.register(user, src, /datum/extension/gallop/proc/user_bumped)
 		GLOB.moved_event.register(user, src, /datum/extension/gallop/proc/user_moved)

--- a/code/modules/mob/living/abilities/lurker_retract.dm
+++ b/code/modules/mob/living/abilities/lurker_retract.dm
@@ -57,8 +57,8 @@
 /datum/extension/retractable_cover/proc/start_closing()
 
 	if (user)
-		user.ExtraMoveCooldown(close_time)
-		user.addClickCooldown(close_time)
+		user.extra_move_cooldown(close_time)
+		user.add_click_cooldown(close_time)
 	sleep(close_time)
 	close()
 
@@ -84,8 +84,8 @@
 */
 /datum/extension/retractable_cover/proc/start_opening()
 	if (user)
-		user.ExtraMoveCooldown(open_time)
-		user.addClickCooldown(open_time)
+		user.extra_move_cooldown(open_time)
+		user.add_click_cooldown(open_time)
 	sleep(open_time)
 	open()
 

--- a/code/modules/mob/living/abilities/shoot.dm
+++ b/code/modules/mob/living/abilities/shoot.dm
@@ -110,7 +110,7 @@
 			stoptime += nomove
 
 		if (stoptime)
-			L.SetMoveCooldown(stoptime)
+			L.set_move_cooldown(stoptime)
 
 	//Now lets windup the shot(s)
 	if (windup_time)

--- a/code/modules/mob/living/abilities/spray.dm
+++ b/code/modules/mob/living/abilities/spray.dm
@@ -108,7 +108,7 @@ Vars/
 		fx.start()
 
 		if (stun && user)
-			user.SetMoveCooldown(duration)
+			user.set_move_cooldown(duration)
 
 		tick()	//Start the first tick
 

--- a/code/modules/mob/living/carbon/alien/diona/nymph_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/nymph_attacks.dm
@@ -29,7 +29,7 @@
 
 /mob/living/carbon/alien/diona/UnarmedAttack(var/atom/A)
 
-	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 
 	if(istype(loc, /obj/structure/diona_gestalt))
 		var/obj/structure/diona_gestalt/gestalt = loc
@@ -75,7 +75,7 @@
 
 /mob/living/carbon/alien/diona/RangedAttack(atom/A)
 	if((a_intent == I_HURT || a_intent == I_GRAB) && holding_item)
-		setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		visible_message("<span class='danger'>\The [src] spits \a [holding_item] at \the [A]!</span>")
 		var/atom/movable/temp = holding_item
 		unEquip(holding_item)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1124,7 +1124,7 @@
 	if(!isliving(usr) || !usr.canClick())
 		return
 
-	usr.setClickCooldown(20)
+	usr.set_click_cooldown(20)
 
 	if(usr.stat > 0)
 		to_chat(usr, "You are unconcious and cannot do that!")

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -174,6 +174,7 @@ Brute will be forced into a reflexive curl under certain circumstances, but it c
 	Brute charge: Slower but more powerful due to mob size.
 	Shorter windup time making it deadly at close range
 	Inertia is enabled, it will keep going til it faceplants into a wall
+	Unlike other mobs, the brute's charge has no autotargeting
 */
 /atom/movable/proc/brute_charge(var/atom/A)
 	set name = "Charge"

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -192,15 +192,18 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 
 	//Leap autotargets enemies within one tile of the clickpoint
 	if (!isliving(A))
-		A = autotarget_enemy_mob(A, 1, src, 999)
+		A = autotarget_enemy_mob(A, 2, src, 999)
 
 	var/mob/living/carbon/human/H = src
+
+	if (!H.can_charge(A))
+		return
 
 	//Do a chargeup animation. Pulls back and then launches forwards
 	//The time is equal to the windup time of the attack, plus 0.5 seconds to prevent a brief stop and ensure launching is a fluid motion
 	var/vector2/pixel_offset = Vector2.DirectionBetween(src, A) * -16
 	var/vector2/cached_pixels = new /vector2(src.pixel_x, src.pixel_y)
-	animate(src, pixel_x = src.pixel_x + pixel_offset.x, pixel_y = src.pixel_y + pixel_offset.y, time = 1.7 SECONDS, easing = BACK_EASING, flags = ANIMATION_PARALLEL)
+	animate(src, pixel_x = src.pixel_x + pixel_offset.x, pixel_y = src.pixel_y + pixel_offset.y, time = 1.5 SECONDS, easing = BACK_EASING, flags = ANIMATION_PARALLEL)
 	animate(pixel_x = cached_pixels.x, pixel_y = cached_pixels.y, time = 0.3 SECONDS)
 
 	//Long shout when targeting mobs, normal when targeting objects
@@ -209,7 +212,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	else
 		H.play_species_audio(H, SOUND_SHOUT, 100, 1, 3)
 
-	return leap_attack(A, _cooldown = 6 SECONDS, _delay = 1.5 SECONDS, _speed = 6, _maxrange = 11,_lifespan = 8 SECONDS, _maxrange = 20)
+	return leap_attack(A, _cooldown = 6 SECONDS, _delay = 1.3 SECONDS, _speed = 7, _maxrange = 11,_lifespan = 8 SECONDS, _maxrange = 20)
 
 
 /atom/movable/proc/leaper_leap_enhanced(var/mob/living/A)
@@ -234,7 +237,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	else
 		H.play_species_audio(H, SOUND_SHOUT, 100, 1, 3)
 
-	return leap_attack(A, _cooldown = 4 SECONDS, _delay = 1 SECONDS, _speed = 6, _maxrange = 11, _lifespan = 8 SECONDS, _maxrange = 20)
+	return leap_attack(A, _cooldown = 4 SECONDS, _delay = 1 SECONDS, _speed = 8, _maxrange = 11, _lifespan = 8 SECONDS, _maxrange = 20)
 
 
 //Special effects for leaper impact, its pretty powerful if it lands on the primary target mob, but it backfires if it was blocked by anything else

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -226,10 +226,10 @@ Dodge is a skill that requires careful timing, but if used correctly, it can all
 
 	//Charge autotargets enemies within one tile of the clickpoint
 	if (!isliving(A))
-		A = autotarget_enemy_mob(A, 1, src, 999)
+		A = autotarget_enemy_mob(A, 2, src, 999)
 
 
-	.= charge_attack(A, _delay = 1 SECONDS, _speed = 5.5, _lifespan = 6 SECONDS)
+	.= charge_attack(A, _delay = 1 SECONDS, _speed = 5.0, _lifespan = 6 SECONDS)
 	if (.)
 		var/mob/H = src
 		if (istype(H))
@@ -249,9 +249,9 @@ Dodge is a skill that requires careful timing, but if used correctly, it can all
 
 	//Charge autotargets enemies within one tile of the clickpoint
 	if (!isliving(A))
-		A = autotarget_enemy_mob(A, 1, src, 999)
+		A = autotarget_enemy_mob(A, 2, src, 999)
 
-	.= charge_attack(A, _delay = 0.75 SECONDS, _speed = 6.5, _lifespan = 6 SECONDS)
+	.= charge_attack(A, _delay = 0.75 SECONDS, _speed = 5.5, _lifespan = 6 SECONDS)
 	if (.)
 		var/mob/H = src
 		if (istype(H))

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -141,7 +141,7 @@ All of these properties combined make Step Strike tricky and disorienting to use
 
 	//Charge autotargets enemies within one tile of the clickpoint
 	if (!isliving(A))
-		A = autotarget_enemy_mob(A, 1, src, 999)
+		A = autotarget_enemy_mob(A, 2, src, 999)
 
 
 	.= charge_attack(A, _delay = 1.3 SECONDS, _speed = 7, _cooldown = 6 SECONDS)

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -228,7 +228,7 @@ Best used near the end, when all seems quiet, to help the necromorphs hunt down 
 
 	//Charge autotargets enemies within one tile of the clickpoint
 	if (!isliving(A))
-		A = autotarget_enemy_mob(A, 1, src, 999)
+		A = autotarget_enemy_mob(A, 2, src, 999)
 
 	var/dist = get_dist(src, A)
 	if (dist < 1) //This is changed from <= , A distance of 1 is allowed

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -189,7 +189,7 @@ var/global/list/sparring_attack_cache = list()
 		if(world.time < last_attack + u_attack.delay)
 			return 0
 		last_attack = world.time
-		setClickCooldown(u_attack.delay)
+		set_click_cooldown(u_attack.delay)
 		var/damage_done = target.hit(src, null, u_attack.damage*u_attack.structure_damage_mult) //TODO Later: Add in an attack flag for ignoring resistance?
 		u_attack.show_attack(src, target, null, damage_done)
 		return TRUE
@@ -251,7 +251,7 @@ var/global/list/sparring_attack_cache = list()
 			to_chat(src, "<span class='notice'>You can't attack again so soon.</span>")
 			return 0
 		last_attack = world.time
-		setClickCooldown(u_attack.delay)
+		set_click_cooldown(u_attack.delay)
 		var/damage_done = u_attack.damage*u_attack.structure_damage_mult
 		if (target.take_damage(damage_done, BRUTE, src, u_attack))
 			u_attack.show_attack(src, target, null, damage_done-target.resistance)

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -38,7 +38,7 @@
 
 	//This line represent a significant buff to grabs...
 	// We don't have to check the click cooldown because /mob/living/verb/resist() has done it for us, we can simply set the delay
-	setClickCooldown(100)
+	set_click_cooldown(100)
 
 	if(can_break_cuffs()) //Don't want to do a lot of logic gating here.
 		break_handcuffs()
@@ -114,7 +114,7 @@
 		buckled.user_unbuckle_mob(src)
 
 /mob/living/carbon/escape_buckle()
-	setClickCooldown(100)
+	set_click_cooldown(100)
 	if(!buckled) return
 
 	if(!restrained())
@@ -140,7 +140,7 @@
 		N.escape_net(src) //super snowflake but is literally used NOWHERE ELSE.-Luke
 		return
 
-	setClickCooldown(100)
+	set_click_cooldown(100)
 	if(!buckled) return
 
 	if(!restrained())

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -511,7 +511,7 @@
 			return
 
 		if (W.use_tool(user, src, WORKTIME_NORMAL, QUALITY_WELDING, FAILCHANCE_NORMAL))
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			adjustBruteLoss(-30)
 			updatehealth()
 			add_fingerprint(user)
@@ -527,7 +527,7 @@
 			return
 		var/obj/item/stack/cable_coil/coil = W
 		if (coil.use(1))
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			adjustFireLoss(-30)
 			updatehealth()
 			for(var/mob/O in viewers(user, null))

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -96,7 +96,7 @@
 		return 1
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
-	setClickCooldown(attack_delay)
+	set_click_cooldown(attack_delay)
 	if(!Adjacent(target_mob))
 		return
 	if(isliving(target_mob))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -858,8 +858,12 @@
 
 //Like stun, but doesn't set the stun var. Just sets move and click cooldowns
 /mob/proc/disable(stoptime)
-	SetMoveCooldown(stoptime)
-	setClickCooldown(stoptime)
+	set_move_cooldown(stoptime)
+	set_click_cooldown(stoptime)
+
+/mob/proc/enable()
+	reset_move_cooldown()
+	reset_click_cooldown()
 
 /mob/proc/Stun(amount)
 	if(status_flags & CANSTUN)
@@ -966,7 +970,7 @@
 
 	if(!isliving(usr) || !usr.canClick())
 		return
-	usr.setClickCooldown(20)
+	usr.set_click_cooldown(20)
 
 	if(usr.stat == 1)
 		to_chat(usr, "You are unconcious and cannot do that!")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -749,8 +749,8 @@ proc/is_blind(A)
 		buckled.set_dir(ndir)
 	if (. && slow_turning)	//Only mobs with slow turning set will set their move cooldown when changing dir
 		var/turntime = movement_delay()
-		SetMoveCooldown(turntime)
-		setClickCooldown(max(turntime,DEFAULT_ATTACK_COOLDOWN))
+		set_move_cooldown(turntime)
+		set_click_cooldown(max(turntime,DEFAULT_ATTACK_COOLDOWN))
 
 //Mobs with offset view should update it every time they turn
 /mob/set_dir(new_dir)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -31,17 +31,17 @@
 
 
 //Sets next move time to now, so a mob can move immediately
-/mob/proc/ResetMoveCooldown(var/timeout)
+/mob/proc/reset_move_cooldown()
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
 	if(delay)
-		delay.ResetDelay(timeout)
+		delay.ResetDelay()
 
-/mob/proc/SetMoveCooldown(var/timeout)
+/mob/proc/set_move_cooldown(var/timeout)
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
 	if(delay)
 		delay.SetDelay(timeout)
 
-/mob/proc/ExtraMoveCooldown(var/timeout)
+/mob/proc/extra_move_cooldown(var/timeout)
 	var/datum/movement_handler/mob/delay/delay = GetMovementHandler(/datum/movement_handler/mob/delay)
 	if(delay)
 		delay.AddDelay(timeout)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -290,8 +290,8 @@
 
 	last_safety_check = world.time
 	var/shoot_time = (burst - 1)* burst_delay
-	user.setClickCooldown(shoot_time+windup_time) //no clicking on things while shooting
-	user.SetMoveCooldown(shoot_time+windup_time) //no moving while shooting either
+	user.set_click_cooldown(shoot_time+windup_time) //no clicking on things while shooting
+	user.set_move_cooldown(shoot_time+windup_time) //no moving while shooting either
 	next_fire_time = world.time + shoot_time + windup_time
 
 	var/held_twohanded = is_held_twohanded(user)
@@ -336,8 +336,8 @@
 		if (current_firemode)	current_firemode.on_fire(target, user, clickparams, pointblank, reflex, TRUE, projectile)//Tell the firemode that we successfully fired
 
 	//update timing
-	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
-	user.SetMoveCooldown(move_delay)
+	user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
+	user.set_move_cooldown(move_delay)
 	next_fire_time = world.time + fire_delay
 
 //obtains the next projectile to fire

--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -23,7 +23,7 @@
 		to_chat(owner, "<span class='warning'>You fumble with the gun, throwing your aim off!</span>")
 		owner.stop_aiming(aiming_with)
 		return
-	owner.setClickCooldown(DEFAULT_QUICK_COOLDOWN) // Spam prevention, essentially.
+	owner.set_click_cooldown(DEFAULT_QUICK_COOLDOWN) // Spam prevention, essentially.
 	owner.visible_message("<span class='danger'>\The [owner] pulls the trigger reflexively!</span>")
 	var/obj/item/weapon/gun/G = aiming_with
 	if(istype(G))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -125,7 +125,7 @@
 					to_chat(user, "<span class='warning'>\The [blocked] is in the way!</span>")
 					return
 
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN) //puts a limit on how fast people can eat/drink things
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN) //puts a limit on how fast people can eat/drink things
 			self_feed_message(user)
 			reagents.trans_to_mob(user, issmall(user) ? ceil(amount_per_transfer_from_this/2) : amount_per_transfer_from_this, CHEM_INGEST)
 			feed_sound(user)
@@ -144,7 +144,7 @@
 
 			other_feed_message_start(user, target)
 
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			if(!do_mob(user, target))
 				return
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -93,7 +93,7 @@
 					to_chat(user, "<span class='warning'>\The [blocked] is in the way!</span>")
 					return
 
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)//puts a limit on how fast people can eat/drink things
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)//puts a limit on how fast people can eat/drink things
 			if (fullness <= 50)
 				to_chat(C, "<span class='danger'>You hungrily chew out a piece of [src] and gobble it!</span>")
 			if (fullness > 50 && fullness <= 150)
@@ -115,7 +115,7 @@
 				user.visible_message("<span class='danger'>[user] cannot force anymore of [src] down [M]'s throat.</span>")
 				return 0
 
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 			if(!do_mob(user, M)) return
 
 			var/contained = reagentlist()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -44,7 +44,7 @@
 			to_chat(user, "<span class='danger'>You cannot inject a robotic limb.</span>")
 			return
 
-	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
 	user.do_attack_animation(M)
 	to_chat(user, "<span class='notice'>You inject [M] with [src].</span>")
 	to_chat(M, "<span class='notice'>You feel a tiny prick!</span>")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -36,7 +36,7 @@
 			return
 
 		user.visible_message("<span class='warning'>[user] attempts to force [M] to swallow \the [src].</span>")
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		if(!do_mob(user, M))
 			return
 		user.visible_message("<span class='warning'>[user] forces [M] to swallow \the [src].</span>")

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -40,7 +40,7 @@
 
 	Spray_at(A, user, proximity)
 
-	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
 
 	if(reagents.has_reagent(/datum/reagent/acid))
 		message_admins("[key_name_admin(user)] fired sulphuric acid from \a [src].")

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -158,7 +158,7 @@
 				return
 
 			injtime *= user.skill_delay_mult(SKILL_MEDICAL)
-			user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+			user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
 			user.do_attack_animation(target)
 
 			if(!do_mob(user, target, injtime))
@@ -236,7 +236,7 @@
 		else
 			user.visible_message("<span class='warning'>\The [user] is trying to inject [target] with [visible_name]!</span>")
 
-		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_QUICK_COOLDOWN)
 		user.do_attack_animation(trackTarget)
 
 		if(!user.do_skilled(injtime, SKILL_MEDICAL, trackTarget))

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -202,7 +202,7 @@
 
 // Attacks with hand tools. Blocked by Hyperkinetic flag.
 /obj/effect/shield/attackby(var/obj/item/weapon/I as obj, var/mob/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
 
 	if(gen.check_flag(MODEFLAG_HYPERKINETIC))

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -56,7 +56,7 @@
 	check_failure()
 	set_opacity(1)
 	spawn(20) if(!QDELETED(src)) set_opacity(0)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 
 	..()
 

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -297,7 +297,7 @@
 	var/obj/machinery/shieldwallgen/G = prob(50) ? gen_primary : gen_secondary
 	G.storedpower -= I.force*2500
 	user.visible_message("<span class='danger'>\The [user] hits \the [src] with \the [I]!</span>")
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(src)
 	playsound(loc, 'sound/weapons/smash.ogg', 75, 1)
 

--- a/code/modules/spells/general/mark_recall.dm
+++ b/code/modules/spells/general/mark_recall.dm
@@ -76,7 +76,7 @@
 
 /obj/effect/cleanable/wizard_mark/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/weapon/nullrod) || istype(I, /obj/item/weapon/spellbook))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		src.visible_message("\The [src] fades away!")
 		qdel(src)
 		return

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -45,9 +45,9 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	if(hand_spell.cast_hand(A,user))
 		next_spell_time = world.time + hand_spell.spell_delay
 		if(hand_spell.move_delay)
-			user.ExtraMoveCooldown(hand_spell.move_delay)
+			user.extra_move_cooldown(hand_spell.move_delay)
 		if(hand_spell.click_delay)
-			user.setClickCooldown(hand_spell.move_delay)
+			user.set_click_cooldown(hand_spell.move_delay)
 
 /obj/item/magic_hand/afterattack(var/atom/A, var/mob/user, var/proximity)
 	if(hand_spell)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -91,14 +91,14 @@
 		if(health < max_health && W.use_tool(user, src, WORKTIME_NORMAL, QUALITY_WELDING, FAILCHANCE_NORMAL))
 			if(open)
 				health = min(max_health, health+10)
-				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+				user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 				user.visible_message("<span class='warning'>\The [user] repairs \the [src]!</span>","<span class='notice'>You repair \the [src]!</span>")
 			else
 				to_chat(user, "<span class='notice'>Unable to repair with the maintenance panel closed.</span>")
 		else
 			to_chat(user, "<span class='notice'>[src] does not need a repair.</span>")
 	else if(hasvar(W,"force") && hasvar(W,"damtype"))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN)
 		switch(W.damtype)
 			if("fire")
 				health -= W.force * fire_dam_coeff

--- a/code/modules/ventcrawl/ventcrawl_atmospherics.dm
+++ b/code/modules/ventcrawl/ventcrawl_atmospherics.dm
@@ -42,7 +42,7 @@
 			user.remove_ventcrawl()
 			user.forceMove(src.loc)
 			user.visible_message("You hear something squeezing through the pipes.", "You climb out the ventilation system.")
-	user.SetMoveCooldown(user.movement_delay())
+	user.set_move_cooldown(user.movement_delay())
 
 /obj/machinery/atmospherics/proc/can_crawl_through()
 	return 1

--- a/html/changelogs/charge.yml
+++ b/html/changelogs/charge.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experimental: "Fixed a major calculation bug that was causing necromorph charge attacks to move at roughly half of their intended speed. Some of the speeds have been tweaked to compensate, but overall charging necromorphs move significantly faster now."
+  - bugfix: "Fixed charge attacks being broken"
+  - tweak: "Reduced windup time and increased flight speed on leaper leap."
+  - tweak: "Charge attacks with autotargeting now pick targets from a 2 tile radius around the clickpoint( previously 1 tile)"

--- a/html/changelogs/charge.yml
+++ b/html/changelogs/charge.yml
@@ -33,7 +33,7 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - experimental: "Fixed a major calculation bug that was causing necromorph charge attacks to move at roughly half of their intended speed. Some of the speeds have been tweaked to compensate, but overall charging necromorphs move significantly faster now."
+  - experiment: "Fixed a major calculation bug that was causing necromorph charge attacks to move at roughly half of their intended speed. Some of the speeds have been tweaked to compensate, but overall charging necromorphs move significantly faster now."
   - bugfix: "Fixed charge attacks being broken"
   - tweak: "Reduced windup time and increased flight speed on leaper leap."
   - tweak: "Charge attacks with autotargeting now pick targets from a 2 tile radius around the clickpoint( previously 1 tile)"


### PR DESCRIPTION
changes: 
  - experiment: "Fixed a major calculation bug that was causing necromorph charge attacks to move at roughly half of their intended speed. Some of the speeds have been tweaked to compensate, but overall charging necromorphs move significantly faster now."
  - bugfix: "Fixed charge attacks being broken"
  - tweak: "Reduced windup time and increased flight speed on leaper leap."
  - tweak: "Charge attacks with autotargeting now pick targets from a 2 tile radius around the clickpoint( previously 1 tile)"