### PR TITLE
Biomass costs rebalance

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -63,3 +63,7 @@
 
 /proc/cmp_timer(datum/timedevent/a, datum/timedevent/b)
 	return a.timeToRun - b.timeToRun
+
+
+/proc/cmp_necroshop_item(var/datum/necroshop_item/a, var/datum/necroshop_item/b)
+	return a.price - b.price

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
@@ -10,7 +10,7 @@
 	blurb = "An expendable suicide bomber, the exploder's sole purpose is to go out in a blaze of glory, and hopefully take a few people with it."
 	unarmed_types = list(/datum/unarmed_attack/bite/weak/exploder) //Bite attack is a backup if blades are severed
 	total_health = 85	//It has high health for the sake of making it a bit harder to destroy without targeting the pustule. Exploding the pustule is always an instakill
-	biomass = 45
+	biomass = 65
 	mass = 50
 
 	biomass_reclamation_time	=	4.5 MINUTES

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -17,7 +17,7 @@
 	blurb = "A long range ambusher, the leaper can leap on unsuspecting victims from afar, knock them down, and tear them apart with its bladed tail. Not good for prolonged combat though."
 	unarmed_types = list(/datum/unarmed_attack/claws) //Bite attack is a backup if blades are severed
 	total_health = 90
-	biomass = 85
+	biomass = 80
 
 	icon_template = 'icons/mob/necromorph/leaper.dmi'
 	icon_lying = "_lying"

--- a/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
@@ -4,8 +4,8 @@
 #define VIEW_OFFSET_OPEN	(WORLD_ICON_SIZE*5)
 
 #define MOVESPEED_OPEN		0.35
-#define SPINE_WINDUP	(1 SECOND)
-#define SPINE_COOLDOWN	(2.5 SECONDS)
+#define SPINE_WINDUP	(0.85 SECOND)
+#define SPINE_COOLDOWN	(2.3 SECONDS)
 /*
 	Lurker:
 
@@ -30,7 +30,7 @@
 	blurb = "Long range fire-support. The lurker is tough and hard to hit as long as its retractible armor is closed. When open it is slow and vulnerable, but fires sharp spines in waves of three."
 	unarmed_types = list(/datum/unarmed_attack/bite/lurker) //Bite attack is a backup if blades are severed
 	total_health = 60
-	biomass = 50
+	biomass = 55
 	health_doll_offset	= 50
 
 	icon_template = 'icons/mob/necromorph/lurker.dmi'
@@ -215,11 +215,11 @@ The Lurker can only fire spines while its shell is open"
 	icon = 'icons/mob/necromorph/lurker.dmi'
 	icon_state = "spine"
 	item_state = "spine"
-	throwforce = 13
+	throwforce = 14
 
 //Projectile version, higher chance of embedding
 /obj/item/projectile/bullet/spine
-	damage =	13
+	damage =	14
 	armor_penetration = 5
 	embed_mult = 1.5
 	step_delay  = 1.6

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
@@ -14,7 +14,7 @@
 	var/marker_spawnable = TRUE	//Set this to true to allow the marker to spawn this type of necro. Be sure to unset it on the enhanced version unless desired
 	biomass = 80	//This var is defined for all species
 	var/biomass_reclamation	=	1	//The marker recovers cost*reclamation
-	var/biomass_reclamation_time	=	10 MINUTES	//How long does it take for all of the reclaimed biomass to return to the marker? This is a pseudo respawn timer
+	var/biomass_reclamation_time	=	8 MINUTES	//How long does it take for all of the reclaimed biomass to return to the marker? This is a pseudo respawn timer
 	var/spawn_method = SPAWN_POINT	//What method of spawning from marker should be used? At a point or manual placement? check _defines/necromorph.dm
 	var/major_vessel = TRUE	//If true, we can fill this mob from the necroqueue
 	var/spawner_spawnable = FALSE	//If true, a nest can be upgraded to autospawn this unit

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -12,11 +12,11 @@
 	blurb = "The frontline soldier of the necromorph horde. Slow when not charging, but its blade arms make for powerful melee attacks"
 	unarmed_types = list(/datum/unarmed_attack/blades, /datum/unarmed_attack/bite/weak) //Bite attack is a backup if blades are severed
 	total_health = 75
-	biomass = 55
+	biomass = 50
 	mass = 70
 	virus_immune = 1
 
-	biomass_reclamation_time	=	7.5 MINUTES
+	biomass_reclamation_time	=	8 MINUTES
 
 	icon_template = 'icons/mob/necromorph/slasher/fleshy.dmi'
 	icon_lying = "_lying"
@@ -88,6 +88,7 @@
 /datum/species/necromorph/slasher/desiccated
 	name = SPECIES_NECROMORPH_SLASHER_DESICCATED
 	icon_template = 'icons/mob/necromorph/slasher/desiccated.dmi'
+	marker_spawnable = FALSE
 
 
 /*Roughly speaking, enhanced versions of necromorphs have:
@@ -102,7 +103,8 @@
 	unarmed_types = list(/datum/unarmed_attack/blades/strong, /datum/unarmed_attack/bite/strong)
 	total_health = 187.5
 	slowdown = 2.8
-	biomass = 150
+	biomass = 125
+	view_range = 8
 	mass = 120
 	mob_size	= MOB_LARGE
 	bump_flag 	= HEAVY
@@ -112,7 +114,7 @@
 	icon_lying = "_lying"
 	//lying_rotation = 90
 
-	biomass_reclamation_time	=	15 MINUTES
+	biomass_reclamation_time	=	12 MINUTES
 
 	limb_health_factor = 1.75
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -25,7 +25,7 @@
 	single_icon = TRUE
 	spawner_spawnable = FALSE
 	virus_immune = 1
-	biomass	=	130
+	biomass	=	120
 
 
 	slowdown = 1.5

--- a/code/modules/mob/observer/freelook/marker/necroshop.dm
+++ b/code/modules/mob/observer/freelook/marker/necroshop.dm
@@ -45,6 +45,8 @@
 		//And add it to the list
 		spawnable_necromorphs[I.name] = I
 
+	sortTim(spawnable_necromorphs, /proc/cmp_necroshop_item, TRUE)
+
 	//Corruption nodes next
 	for (var/spath in subtypesof(/obj/structure/corruption_node))
 		var/obj/structure/corruption_node/N = new spath()
@@ -64,6 +66,8 @@
 		//And add it to the list
 		spawnable_structures[I.name] = I
 		qdel(N)
+
+	sortTim(spawnable_structures, /proc/cmp_necroshop_item, TRUE)
 
 	selected_spawn = new(host, host.name)
 	possible_spawnpoints += selected_spawn

--- a/html/changelogs/biomass_costs.yml
+++ b/html/changelogs/biomass_costs.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The necromorph spawning menu is now sorted in ascending order of biomass cost."
+  - tweak: "Biomass cost of Exploder significantly increased, from 50 to 65"
+  - tweak: "Biomass cost of Leaper slightly reduced, from 85 to 80"
+  - tweak: "Lurker biomass cost increased from 50 to 55"
+  - tweak: "Lurker windup and cooldown times on spine launch slightly reduced"
+  - tweak: "Lurker spine damage slightly increased, from 13 to 14"
+  - tweak: "Base biomass reclamation time set to 8 minutes for most necromorphs"
+  - tweak: "Slasher biomass cost reduced from 55 to 50. It is now the cheapest of all necromorphs and will remain so."
+  - tweak: "Slasher biomass reclamation time slightly increased from 7.5 mins to 8 mins"
+  - tweak: "Twitcher biomass cost slightly reduced, from 130 to 120"

--- a/html/changelogs/biomass_costs.yml
+++ b/html/changelogs/biomass_costs.yml
@@ -43,3 +43,4 @@ changes:
   - tweak: "Slasher biomass cost reduced from 55 to 50. It is now the cheapest of all necromorphs and will remain so."
   - tweak: "Slasher biomass reclamation time slightly increased from 7.5 mins to 8 mins"
   - tweak: "Twitcher biomass cost slightly reduced, from 130 to 120"
+  - bugfix: "Removed ancient slasher from spawning menu. It can still spawn as a random variant of a slasher."


### PR DESCRIPTION
A broad package of incremental tweaks to biomass costs, with a few overarching aims:

First and most importantly, I miscalculated when originally designing exploder. Their low cost has made them a constantly-spammed go-to troop and is depleting the diversity of the necromorph army. While exploders still have the shortest reclamation time, their initial biomass cost has been increased, putting them on the higher end of T1 necromorphs.

Slashers were always meant to be the bulk of the necro forces, and it's become clear that people gravitate towards the cheapest options. So as a result i'm establishing a new design principle. The basic slasher now has the lowest biomass cost of all necromorphs (at least the main, humanoid ones) and should remain so. I'll balance around that principle in future, making sure that nothing is allowed to have a lower cost than the slasher.

In line with that change, lurkers have been made slightly more expensive to put them above slasher, and gotten a few small buffs to compensate for the increased cost

Slight reduction in cost for leaper and twitcher, they were both a bit underutilized, will see how it goes.

And lastly, i figured out how the timsort algorithm works, and have employed it to sort the necromorph spawning menu