### PR TITLE
View Sliding Debug Tool

### DIFF
--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -169,3 +169,31 @@
 	//If we get here, the target is on our screen!
 	return TRUE
 
+
+
+/client/proc/remove_screen_elements()
+	var/list/types = compile_types_in_list(screen)
+
+	var/selected = input(usr, "pick a thing", "Deletion of things on screen") as null|anything in types
+	if (!selected)
+		return
+
+	var/removed = 0
+	for (var/obj/thing as anything in screen)
+		if (istype(thing, selected))
+			if (removed < 10)
+				to_chat(usr, "Removed [thing]|[thing.type]")
+
+			screen -= thing
+			qdel(thing)
+			removed++
+			if (removed == 10)
+				to_chat(usr, "and several more things...")
+
+			if (removed == 50)
+				to_chat(usr, "many more things...")
+
+			if (removed == 100)
+				to_chat(usr, "a hundred things...")
+
+	to_chat(usr, "Removed [removed] objects")

--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -173,6 +173,8 @@
 
 /client/proc/remove_screen_elements()
 	var/list/types = compile_types_in_list(screen)
+	if (!LAZYLEN(types))
+		return
 
 	var/selected = input(usr, "pick a thing", "Deletion of things on screen") as null|anything in types
 	if (!selected)
@@ -197,3 +199,5 @@
 				to_chat(usr, "a hundred things...")
 
 	to_chat(usr, "Removed [removed] objects")
+	//Recursive as long as you don't cancel
+	remove_screen_elements()

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -817,4 +817,27 @@ proc/dd_sortedTextList(list/incoming)
 		if(islist(.[i]))
 			.[i] = .(.[i])
 
+
+/*
+	Takes a list of datums
+	Returns a list which contains every unique typepath shared by the things in the first list, including parent types
+*/
+/proc/compile_types_in_list(var/list/sourcelist)
+	var/list/typeslist = list()
+	//This is a little complex
+	for (var/datum/D as anything in sourcelist)
+		//We split the path into a list of components by using / as delimiter
+
+		var/list/components = splittext("[D.type]", "/", 2)	//We start from character 2 so that it doesnt detect an empty string before the first slash
+		for (var/i = 1; i < components.len; i++)
+			var/stringpath = ""
+			for (var/j in 1 to i)
+				stringpath += "/[components[j]]"
+
+			var/typepath = text2path(stringpath)
+			typeslist |= typepath
+
+	return typeslist
+
+
 #define IS_VALID_INDEX(list, index) (list.len && index > 0 && index <= list.len)

--- a/code/modules/mob/living/abilities/execution/execution.dm
+++ b/code/modules/mob/living/abilities/execution/execution.dm
@@ -175,6 +175,12 @@ if (result == EXECUTION_CANCEL){\
 
 	try_advance_stage()
 
+/datum/extension/execution/Destroy()
+	current_stage = null
+	QDEL_NULL_LIST(all_stages)
+	entered_stages = null
+	.=..()
+
 
 /datum/extension/execution/proc/stop()
 

--- a/code/modules/mob/living/abilities/execution/execution_stage.dm
+++ b/code/modules/mob/living/abilities/execution/execution_stage.dm
@@ -26,6 +26,10 @@
 	src.host = host
 	.=..()
 
+/datum/execution_stage/Destroy()
+	host = null
+	.=..()
+
 /datum/execution_stage/proc/enter()
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
@@ -669,7 +669,7 @@ If performed successfully on a live crewman, it yields a bonus of 10kg biomass f
 
 /datum/extension/execution/tripod_kiss
 	name = "Kiss of Death"
-
+	base_type = /datum/extension/execution/tripod_kiss
 	cooldown = 1 MINUTE
 
 	reward_biomass = 10


### PR DESCRIPTION
This PR primarily includes a new tool to help fix view sliding issues during gameplay. A new proc has been added to clients, remove_screen_elements , call it using advanced proc call on the player's client.

It allows you to choose from a list of all types of things that are on their screen, and delete everything that matches that type. It is strongly advised to pick the longest typepath possible, to limit what gets deleted, and gradually narrow it down until you find which object caused the problem

I attempted to solve the view sliding bug myself, but i was unable to reproduce it. I tried everything i could think of with tripods, leapers, lurkers, wallclimbing, signals, etc. This is a problem that only seems to occur during live gameplay

This PR also includes a fix for tripod being able to start multiple executions and break its view, that was a seperate unrelated issue