### PR TITLE
Unitologist Limits tweaking

### DIFF
--- a/code/game/gamemodes/marker/gamemodes.dm
+++ b/code/game/gamemodes/marker/gamemodes.dm
@@ -50,6 +50,7 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	votable = FALSE
 	var/marker_setup_time = 45 MINUTES
 	var/marker_active = FALSE
+	antag_scaling_coeff = 8
 
 /datum/game_mode/marker/post_setup() //Mr Gaeta. Start the clock.
 	. = ..()

--- a/code/game/gamemodes/marker/unitologist.dm
+++ b/code/game/gamemodes/marker/unitologist.dm
@@ -20,6 +20,13 @@ GLOBAL_LIST_EMPTY(unitologists_list)
 	antag_indicator = "hudunitologist"// icon_state for icons/mob/mob.dm visual indicator.
 	preference_candidacy_toggle = TRUE
 
+	// Spawn values (autotraitor and game mode)
+	//Hard cap of 6 will only be reached at really high playercounts
+	hard_cap = 6                        // Autotraitor var. Won't spawn more than this many antags.
+	hard_cap_round = 6                  // As above but 'core' round antags ie. roundstart.
+	initial_spawn_req = 0               // Gamemode using this template won't start without this # candidates.
+	initial_spawn_target = 3            // Gamemode will attempt to spawn this many antags.
+
 /datum/objective/unitologist
 	explanation_text = "Serve the marker at all costs."
 
@@ -55,6 +62,7 @@ GLOBAL_DATUM_INIT(shardbearers, /datum/antagonist/unitologist/shardbearer, new)
 	preference_candidacy_toggle = TRUE
 	id = MODE_UNITOLOGIST_SHARD
 	flags = 0
+	initial_spawn_req = 1
 	welcome_text = "While on a planetary survey team on Aegis VII below, you uncovered the Holy Marker. It spoke to you, and you followed its directions, chipping off a piece and smuggling it aboard with you. <br>\
 	The shard still speaks to you now. It tells you to hide it. Plant it somewhere in a dark, hidden corner of the Ishimura, where it will not be discovered"
 

--- a/html/changelogs/unitologists.yml
+++ b/html/changelogs/unitologists.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Nanako  
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "Reduced the number of unitologists that will be picked at roundstart, and during low population times. Increased the maximum limit for high population times."


### PR DESCRIPTION
West asked that i look into this, here's what i've done:
Reduced the number of starting unitologists in most modes, from 3 to 2
Increased the scaling coefficient from 5 to 8, thats the number of active crew players required for one antag to be added, so there will be less of them
Increased the hard-cap from 3 to 6, this allows more unitologists than before, but only at really high playercounts. To reach the limit we'd need 48 alive, active crew which is fairly unlikely

These changes should allow the unitologist section to scale with the active crew better, less overwhelming at low pop times
