### PR TITLE
Screen debug

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -288,6 +288,7 @@
 #include "code\datums\extensions\appearance\appearance.dm"
 #include "code\datums\extensions\appearance\base_icon_state.dm"
 #include "code\datums\extensions\appearance\cardborg.dm"
+#include "code\datums\extensions\debug\screen_debug.dm"
 #include "code\datums\extensions\holster\holster.dm"
 #include "code\datums\extensions\multitool\_multitool.dm"
 #include "code\datums\extensions\multitool\multitool.dm"

--- a/code/datums/extensions/debug/screen_debug.dm
+++ b/code/datums/extensions/debug/screen_debug.dm
@@ -1,0 +1,66 @@
+/*
+	This extension is used for runtime debugging of client screens
+
+	given a target client, it presents to the user a list of elements on the client's screen, with names, typepaths, and links to delete or VV them
+*/
+/datum/extension/screen_debug
+	base_type = /datum/extension/screen_debug
+	expected_type = /client
+	flags = EXTENSION_FLAG_IMMEDIATE
+	var/client/C
+	var/mob/living/user
+
+/datum/extension/screen_debug/New(var/client/client, var/mob/living/user)
+	C = client
+	src.user = user
+
+	.=..()
+	ui_interact(user)
+
+
+
+/datum/extension/screen_debug/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+	var/list/screenobjects = list()
+	for (var/obj/O in C.screen)
+		screenobjects += list(list("name" = O.name, "ref" = "\ref[O]", "type" = O.type, "icon" = "[O.icon] | [O.icon_state]"))
+
+	var/list/data = list()
+	data["screenobjects"] = screenobjects
+
+	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, "ui_debugging.tmpl", "Spawning Menu", 800, 700, state = GLOB.interactive_state)
+		ui.set_initial_data(data)
+		ui.set_auto_update(1)
+		ui.open()
+
+/datum/extension/screen_debug/Topic(href, href_list)
+	if(..())
+		return
+	if (href_list["vv"])
+		var/datum/thing = locate(href_list["vv"])
+		if (thing && user && user.client)
+			user.client.debug_variables(thing)
+
+
+
+	if (href_list["delete"])
+		var/obj/thing = locate(href_list["delete"])
+		if (thing && C)
+			C.screen -= thing
+			qdel(thing)
+			to_chat(user, "Deleted [thing.type] | [thing.name]")
+
+
+	SSnano.update_uis(src)
+
+
+/*
+	Access
+*/
+/client/proc/debug_screen()
+	set_extension(src, /datum/extension/screen_debug, usr)
+
+/mob/proc/debug_screen()
+	if (client)
+		client.debug_screen()

--- a/nano/templates/ui_debugging.tmpl
+++ b/nano/templates/ui_debugging.tmpl
@@ -1,0 +1,55 @@
+<style>
+	div {height: 100%; width: 100%; overflow: hidden; padding: 0px; margin: 0px;}
+	td {height: 100%;}
+	a {color: #CCCCFF}
+</style>
+
+<table style="width: 100%; margin: 0px; border-collapse: collapse; ">
+	<tr style="height: 30px; border-bottom: 1px solid #FFFFFF">
+		<td >
+			<div style="width: 40px">
+			Name:
+			</div>
+		</td>
+		<td >
+			<div>
+			Type:
+			</div>
+		</td>
+		<td>
+			<div>
+			Icon/state:
+			</div>
+		</td>
+		<td>
+			<div>
+			Action:
+			</div>
+		</td>
+	</tr>
+	{{for data.screenobjects}}
+		<tr style="height: 20px;">
+			<td>
+				<div style="width: 80px;">
+					{{:value.name}}
+				</div>
+			</td>
+			<td>
+				<div style="width: 160px; overflow: auto;">
+					{{:value.type}}
+				</div>
+			</td>
+			<td>
+				<div>
+					{{:value.icon}}
+				</div>
+			</td>
+			<td>
+				<div>
+					{{:helper.link("Delete", 'circle-arrow-s', { "delete" : value.ref }, null, "linkFixed")}}
+					{{:helper.link("View Vars", 'circle-arrow-s', { "vv" : value.ref }, null, "linkFixed")}}
+				</div>
+			</td>
+		</tr>
+	{{/for}}
+</table>


### PR DESCRIPTION
Adds another live debugging proc, to execute it just call debug_screen on any client or mob-with-client.
 It opens a UI window showing all the onscreen elements so they can be selectively deleted or viewed until we figure out the problem