### PR TITLE
Necrochat and misc fixes

### DIFF
--- a/code/game/machinery/turret/targeting_profile.dm
+++ b/code/game/machinery/turret/targeting_profile.dm
@@ -70,10 +70,10 @@
 		if(L.is_necromorph() || isalien(L)) // Xenos are dangerous
 			return PRIORITY_TARGET
 
-		if(ishuman(L))	//if the target is a human, analyze threat level
-			var/threat = source.assess_perp(L)
-			if(threat < 4)
-				return NOT_TARGET	//if threat level < 4, keep going
+		if(ishuman(L))	//if the target is a human, ignore them as long as they have an ID card
+			var/list/target_access = A.GetAccess()
+			if (LAZYLEN(target_access))
+				return NOT_TARGET
 
 		if(L.lying)		//if the perp is lying down, it's still a target but a less-important target
 			return source.lethal ? SECONDARY_TARGET : NOT_TARGET

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/blood_writing.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/blood_writing.dm
@@ -7,7 +7,7 @@
 	require_corruption = FALSE
 	autotarget_range = 0
 	LOS_block = FALSE	//This is for spooking people, we want them to see it happen
-
+	target_types = list(/turf/simulated)
 
 
 /datum/signal_ability/writing/special_check(var/turf/target)

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/runes.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/runes.dm
@@ -7,7 +7,7 @@
 	require_corruption = FALSE
 	autotarget_range = 0
 	LOS_block = FALSE	//This is for spooking people, we want them to see it happen
-
+	target_types = list(/turf/simulated)
 
 /datum/signal_ability/runes/on_cast(var/mob/user, var/atom/target, var/list/data)
 	GLOB.cult.powerless = TRUE //Just in case. This makes sure the runes don't do anything

--- a/html/changelogs/turret.yml
+++ b/html/changelogs/turret.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Pulse turrets will no longer fire at ordinary crewmen as long as they are wearing an ID"


### PR DESCRIPTION
Working on a theory that necrochat breaking is caused by runtime errors, this PR tightens up safety checks around it and eliminates bad data from the necromorph players list

Closes #471 
Closes #433 