### PR TITLE
Makes the marker gamemode end when most of the human crew are dead

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -549,16 +549,22 @@ proc/get_nt_opposed()
 
 //Handlers for people dying / being revived.
 /datum/game_mode/proc/on_crew_death(mob/living/carbon/human/H)
-	if(!H)
-		return
+	if(!H?.client)
+		return FALSE
+	for(var/X in dead_players) //Hacky, yes. But more consistent than locate() in whatever.
+		if(X == H.client.ckey)
+			return FALSE
 	player_count = GLOB.all_crew_records.len
-	dead_players += H
+	dead_players += H.client.ckey
 	check_finished()
+	return TRUE
 
 /datum/game_mode/proc/on_crew_revive(mob/living/carbon/human/H)
-	if(!H)
-		return
+	if(!H?.client)
+		return FALSE
 	player_count = GLOB.all_crew_records.len
-	for(var/mob/M in dead_players) //Hacky, yes. But more consistent than locate() in whatever.
-		if(M == H)
+	for(var/X in dead_players) //Hacky, yes. But more consistent than locate() in whatever.
+		if(X == H.client.ckey)
 			dead_players -= H
+	check_finished()
+	return TRUE

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -549,22 +549,22 @@ proc/get_nt_opposed()
 
 //Handlers for people dying / being revived.
 /datum/game_mode/proc/on_crew_death(mob/living/carbon/human/H)
-	if(!H?.client)
+	if(!H?.mind)
 		return FALSE
-	for(var/X in dead_players) //Hacky, yes. But more consistent than locate() in whatever.
-		if(X == H.client.ckey)
+	for(var/datum/mind/M in dead_players) //Hacky, yes. But more consistent than locate() in whatever.
+		if(M == H.mind)
 			return FALSE
 	player_count = GLOB.all_crew_records.len
-	dead_players += H.client.ckey
+	dead_players += H.mind
 	check_finished()
 	return TRUE
 
 /datum/game_mode/proc/on_crew_revive(mob/living/carbon/human/H)
-	if(!H?.client)
+	if(!H?.mind)
 		return FALSE
 	player_count = GLOB.all_crew_records.len
-	for(var/X in dead_players) //Hacky, yes. But more consistent than locate() in whatever.
-		if(X == H.client.ckey)
-			dead_players -= H
+	for(var/datum/mind/M in dead_players) //Hacky, yes. But more consistent than locate() in whatever.
+		if(M == H.mind)
+			dead_players -= H.mind
 	check_finished()
 	return TRUE

--- a/code/game/gamemodes/marker/gamemodes.dm
+++ b/code/game/gamemodes/marker/gamemodes.dm
@@ -48,8 +48,7 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	var/marker_setup_time = 45 MINUTES
 	var/marker_active = FALSE
 	antag_scaling_coeff = 8
-	var/minimum_alive_percentage = 5 //How much grace do you want to give the necros for killing people? The default value for this is 5. If we have a crew of 10 people, then you have to kill 9 of them to win as necro.
-	var/dead_players = 0
+	var/minimum_alive_percentage = 10 //How much grace do you want to give the necros for killing people? The default value for this is 5. If we have a crew of 10 people, then you have to kill 9 of them to win as necro.
 
 /datum/game_mode/marker/post_setup() //Mr Gaeta. Start the clock.
 	. = ..()
@@ -128,19 +127,10 @@ Non-critical characters like any ghost-roles you may wish to add, or even antags
 
 */
 
-//Handlers to end the game if everybody dies.
-/mob/living/carbon/human/death(gibbed,deathmessage="seizes up and falls limp...", show_dead_message = "You have died.")
-	. = ..()
-	var/datum/computer_file/report/crew_record/R = get_crewmember_record(real_name) //Try get a crew manifest for this mob
-	if(!R)
-		return FALSE //Not on the manifest? You don't exist.
-	if(istype(ticker.mode, /datum/game_mode/marker)) //Precondition: Ensure that the game mode is one of ours, we don't want to say, override traitor or anything.
-		ticker.mode.check_finished()
-
 //Method to be called when a human player dies for any reason, this will check the amount of players that should be alive, and sees if they're dead or not. We're doing it via an almost signal (bay lacks signals) to avoid processing overhead.
 /datum/game_mode/marker/check_finished()
-	var/all_mobs = GLOB.all_crew_records.len //If you're not in the manifest I don't care about your existence. Updates this every time we check a win to ensure that no new players have joined the fray.
-	dead_players ++
-	if(dead_players >= round(all_mobs-(all_mobs*((minimum_alive_percentage > 0) ? minimum_alive_percentage/100 : 0)))) //Allows the necromorphs a bit of grace so they don't have to hunt down _everyone_, as that could lead to cheese. The ? statement is there to handle a config value of 0% grace, if you decide to go for that.
+	if(!marker_active)
+		return ..()  //Change this to FALSE if you want to override all other win conditions until the marker activates.
+	if(dead_players.len >= round(player_count-(player_count*((minimum_alive_percentage > 0) ? minimum_alive_percentage/100 : 0)))) //Allows the necromorphs a bit of grace so they don't have to hunt down _everyone_, as that could lead to cheese. The ? statement is there to handle a config value of 0% grace, if you decide to go for that.
 		return TRUE //Necros win!
 	return ..() //Fallback to the default game end conditions like all antags dying, shuttles being docked, etc.

--- a/code/game/gamemodes/marker/gamemodes.dm
+++ b/code/game/gamemodes/marker/gamemodes.dm
@@ -27,11 +27,8 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	votable = TRUE
 	antag_tags = list(MODE_UNITOLOGIST_SHARD)
 
-
 /datum/game_mode/marker/enemy_within/get_marker_location()
 	return pick(SSnecromorph.marker_spawns_aegis)
-
-
 
 /datum/game_mode/marker
 	name = "unnamed"
@@ -51,6 +48,8 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	var/marker_setup_time = 45 MINUTES
 	var/marker_active = FALSE
 	antag_scaling_coeff = 8
+	var/minimum_alive_percentage = 5 //How much grace do you want to give the necros for killing people? The default value for this is 5. If we have a crew of 10 people, then you have to kill 9 of them to win as necro.
+	var/dead_players = 0
 
 /datum/game_mode/marker/post_setup() //Mr Gaeta. Start the clock.
 	. = ..()
@@ -107,10 +106,6 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	marker_active = TRUE
 	return TRUE
 
-
-
-
-
 /client/proc/activate_marker()
 	set name = "Activate Marker"
 	set category = "Admin"
@@ -124,3 +119,28 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 		to_chat(src, "The marker is already active")
 		return
 	GM.activate_marker()
+
+/**
+
+There is probably a better way to do this, but I've added some more stringent checks to the gamemode win conditions to prevent things like:
+Admin characters being counted as crew, and on their deletion, ending the game
+Non-critical characters like any ghost-roles you may wish to add, or even antags, from counting as "dead crew" (Antags fallback to their own "are the antags dead checks"
+
+*/
+
+//Handlers to end the game if everybody dies.
+/mob/living/carbon/human/death(gibbed,deathmessage="seizes up and falls limp...", show_dead_message = "You have died.")
+	. = ..()
+	var/datum/computer_file/report/crew_record/R = get_crewmember_record(real_name) //Try get a crew manifest for this mob
+	if(!R)
+		return FALSE //Not on the manifest? You don't exist.
+	if(istype(ticker.mode, /datum/game_mode/marker)) //Precondition: Ensure that the game mode is one of ours, we don't want to say, override traitor or anything.
+		ticker.mode.check_finished()
+
+//Method to be called when a human player dies for any reason, this will check the amount of players that should be alive, and sees if they're dead or not. We're doing it via an almost signal (bay lacks signals) to avoid processing overhead.
+/datum/game_mode/marker/check_finished()
+	var/all_mobs = GLOB.all_crew_records.len //If you're not in the manifest I don't care about your existence. Updates this every time we check a win to ensure that no new players have joined the fray.
+	dead_players ++
+	if(dead_players >= round(all_mobs-(all_mobs*((minimum_alive_percentage > 0) ? minimum_alive_percentage/100 : 0)))) //Allows the necromorphs a bit of grace so they don't have to hunt down _everyone_, as that could lead to cheese. The ? statement is there to handle a config value of 0% grace, if you decide to go for that.
+		return TRUE //Necros win!
+	return ..() //Fallback to the default game end conditions like all antags dying, shuttles being docked, etc.

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -81,4 +81,8 @@
 	if(ticker && ticker.mode)
 		ticker.mode.check_win()
 	to_chat(src,"<span class='deadsay'>[show_dead_message]</span>")
-	return 1
+	var/datum/computer_file/report/crew_record/R = get_crewmember_record(real_name) //Try get a crew manifest for this mob
+	if(!R)
+		return FALSE //Not on the manifest? You don't exist.
+	ticker.mode.on_crew_death(src)
+	return FALSE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1365,6 +1365,10 @@
 			setOxyLoss(75)
 		heart.pulse = PULSE_NORM
 		heart.handle_pulse()
+	var/datum/computer_file/report/crew_record/R = get_crewmember_record(real_name) //Try get a crew manifest for this mob
+	if(!R)
+		return FALSE //Not on the manifest? You don't exist.
+	ticker.mode.on_crew_revive(src) //Congrats, you're alive again.
 
 /mob/living/carbon/human/proc/make_reagent(amount, reagent_type)
 	if(stat == CONSCIOUS)


### PR DESCRIPTION
Title. Requested by West. I have no real way to test this by myself and with my being unable to select any job locally.

Tests I ran:
-Spawn in, kill self as BST. 
-Spawn in braindead mob, kill braindead mob

This basically just looks at the crew manifest whenever someone dies, and determines whether most of the players are dead, if so, end the round as a necro win.

:cl:Kmc2000
rscadd: The marker gamemode will now end when the majority of the human crew are dead.
/:cl:
