### PR TITLE
Contact AEG

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -189,7 +189,7 @@
 	name = "contact energy"
 	id = "contact_energy"
 	req_tech = list(TECH_POWER = 3, TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 700, MATERIAL_GLASS = 70)
+	materials = list(MATERIAL_STEEL = 1250, MATERIAL_GLASS = 250, "uranium" = 125)
 	build_path = /obj/item/weapon/cell/contact
 	sort_string = "DAAAA"
 
@@ -584,17 +584,11 @@
 	name = "C99 Supercollider Contact Beam"
 	id = "contactbeam"
 	req_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 3)
-	materials = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 1000, MATERIAL_DIAMOND = 2000)
+	materials = list(MATERIAL_STEEL = 5000, MATERIAL_GLASS = 1000, "uranium" = 500)
 	build_path = /obj/item/weapon/gun/energy/contact
 	sort_string = "TAEAA"
 
-/datum/design/item/weapon/nuclear_gun
-	name = "WH-9 Prototype Pistol"
-	id = "nuclear_gun"
-	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
-	materials = list(MATERIAL_STEEL = 5000, MATERIAL_GLASS = 1000, "uranium" = 500)
-	build_path = /obj/item/weapon/gun/energy/gun/nuclear
-	sort_string = "TAEAA"
+
 
 
 /datum/design/item/weapon/grenadelauncher

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -583,7 +583,7 @@
 /datum/design/item/weapon/contactbeam
 	name = "C99 Supercollider Contact Beam"
 	id = "contactbeam"
-	req_tech = list(TECH_MATERIAL = 4, TECH_PHORON = 3, TECH_ENGINEERING = 3)
+	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 5, TECH_POWER = 3)
 	materials = list(MATERIAL_STEEL = 5000, MATERIAL_GLASS = 1000, "uranium" = 500)
 	build_path = /obj/item/weapon/gun/energy/contact
 	sort_string = "TAEAA"

--- a/html/changelogs/contactprotolathe.yml
+++ b/html/changelogs/contactprotolathe.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The Contact Beam is now more affordable in science, replacing the advanced energy gun."
+  - rscdel: "Advanced energy gun removed from the game, it was a baycode holdover that doesn't belong in the dead space universe."


### PR DESCRIPTION
Removes the Advanced Energy Gun from the game, it is often complained about, unbalanced. And more importantly, its a silly holdover from baycode which doesn't fit in the dead space universe.

Its position in the protolathe is replaced by the contact beam, which has had its costs reduced to match

Closes #320 