### PR TITLE
Defense and marker balance patch

### DIFF
--- a/code/game/gamemodes/marker/evac_points.dm
+++ b/code/game/gamemodes/marker/evac_points.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/marker
 	var/evac_points = 0
 	var/evac_threshold = 100
-	var/minimum_evac_time = 45// in minutes. How soon after marker setup that evac can be called, assuming all systems remain working (they won't)
+	var/minimum_evac_time = 60// in minutes. How soon after marker setup that evac can be called, assuming all systems remain working (they won't)
 
 
 	var/last_pointgain_time	= 0

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -7,7 +7,7 @@
 	var/base_block_chance = 80
 	var/max_block = 20
 
-	max_health = 150
+	max_health = 130
 	resistance = 3
 
 
@@ -54,7 +54,7 @@
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	max_block = 25
 	base_block_chance = 100
-	max_health = 220
+	max_health = 190
 	blocksound = 'sound/effects/Glasshit.ogg'
 	resistance = 4
 
@@ -79,7 +79,7 @@
 	w_class = ITEM_SIZE_HUGE
 	matter = list(MATERIAL_PLASTEEL = 8500)
 	max_block = 30
-	max_health = 300
+	max_health = 255
 	slowdown_general = 1.5
 	resistance = 6
 	blocksound = 'sound/items/trayhit2.ogg'
@@ -97,7 +97,7 @@
 	throw_range = 6
 	matter = list(MATERIAL_STEEL = 6)
 	base_block_chance = 65
-	max_health = 100
+	max_health = 85
 	max_block = 15
 	resistance = 5
 
@@ -111,7 +111,7 @@
 	throw_range = 4
 	matter = list(MATERIAL_STEEL = 4)
 	base_block_chance = 80
-	max_health = 120
+	max_health = 90
 	max_block = 10
 	resistance = 2
 	blocksound = 'sound/items/trayhit2.ogg'
@@ -139,7 +139,7 @@
 	max_block = 45
 	var/active = 0
 	resistance = 8
-	max_health = 400
+	max_health = 340
 	blocksound = 'sound/effects/impacts/shield_impact_1.ogg'
 
 /obj/item/weapon/shield/energy/can_block()

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -3,7 +3,7 @@
 	desc = "A sleek and dangerous hardsuit for active combat."
 	icon_state = "security_rig"
 	suit_type = "combat hardsuit"
-	armor = list(melee = 80, bullet = 65, laser = 55, energy = 15, bomb = 80, bio = 100, rad = 60)
+	armor = list(melee = 70, bullet = 65, laser = 55, energy = 15, bomb = 80, bio = 100, rad = 60)
 	online_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY
@@ -62,7 +62,7 @@
 	desc = "An austere hardsuit used by paramilitary groups and real soldiers alike."
 	icon_state = "military_rig"
 	suit_type = "military hardsuit"
-	armor = list(melee = 80, bullet = 75, laser = 60, energy = 15, bomb = 80, bio = 100, rad = 30)
+	armor = list(melee = 70, bullet = 75, laser = 60, energy = 15, bomb = 80, bio = 100, rad = 30)
 	online_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = TINT_HEAVY

--- a/code/modules/clothing/spacesuits/rig/suits/engineering.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/engineering.dm
@@ -2,7 +2,7 @@
 	name = "engineering rig"
 	desc = "A lightweight and flexible armoured rig suit, designed for mining and shipboard engineering."
 	icon_state = "ds_engineering_rig"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 25, bomb = 60, bio = 100, rad = 60)
+	armor = list(melee = 45, bullet = 60, laser = 60, energy = 25, bomb = 60, bio = 100, rad = 60)
 	offline_slowdown = 4
 	online_slowdown = 2
 	acid_resistance = 1.75	//Contains a fair bit of plastic

--- a/code/modules/clothing/spacesuits/rig/suits/security.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/security.dm
@@ -2,7 +2,7 @@
 	name = "security rig"
 	desc = "A lightweight and flexible armoured rig suit, designed for riot control and shipboard disciplinary enforcement."
 	icon_state = "ds_security_rig"
-	armor = list(melee = 55, bullet = 55, laser = 55, energy = 25, bomb = 60, bio = 100, rad = 60)
+	armor = list(melee = 50, bullet = 55, laser = 55, energy = 25, bomb = 60, bio = 100, rad = 60)
 	offline_slowdown = 4
 	online_slowdown = 2
 	acid_resistance = 1.75	//Contains a fair bit of plastic

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -154,7 +154,7 @@
 	suit_type = "engineering hardsuit"
 	desc = "An advanced hardsuit that protects against hazardous, low pressure environments. Shines with a high polish. Appears compatible with the physiology of most species."
 	icon_state = "ce_rig"
-	armor = list(melee = 40, bullet = 25, laser = 30, energy = 25, bomb = 40, bio = 100, rad = 100)
+	armor = list(melee = 45, bullet = 25, laser = 30, energy = 25, bomb = 40, bio = 100, rad = 100)
 	online_slowdown = 0
 	offline_slowdown = 0
 	offline_vision_restriction = TINT_HEAVY

--- a/code/modules/clothing/spacesuits/rig/suits/vintage.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vintage.dm
@@ -2,7 +2,7 @@
 	name = "antique CEC suit"
 	desc = "An extremely bulky, durable vintage suit that has mostly been replaced by sleeker modern designs. Some collectors still value the good old days though."
 	icon_state = "vintage_rig"
-	armor = list(melee = 70, bullet = 70, laser = 70, energy = 25, bomb = 90, bio = 100, rad = 70)
+	armor = list(melee = 65, bullet = 70, laser = 70, energy = 25, bomb = 90, bio = 100, rad = 70)
 	offline_slowdown = 5
 	online_slowdown = 3.5
 

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -5,7 +5,7 @@
 	icon_state = "deathsquad"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/tank)
-	armor = list(melee = 80, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 100, rad = 100)
+	armor = list(melee = 70, bullet = 60, laser = 60,energy = 25, bomb = 50, bio = 100, rad = 100)
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	siemens_coefficient = 0.6
 

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -10,7 +10,7 @@
 		slot_l_hand_str = "eng_helm",
 		slot_r_hand_str = "eng_helm",
 		)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 35, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
 
 /obj/item/clothing/suit/space/void/engineering
 	name = "engineering voidsuit"
@@ -20,7 +20,7 @@
 		slot_l_hand_str = "eng_voidsuit",
 		slot_r_hand_str = "eng_voidsuit",
 	)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
+	armor = list(melee = 35, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 80)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/toolbox,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/weapon/rcd)
 
 /obj/item/clothing/suit/space/void/engineering/New()
@@ -52,7 +52,7 @@
 		slot_l_hand_str = "mining_voidsuit",
 		slot_r_hand_str = "mining_voidsuit",
 	)
-	armor = list(melee = 50, bullet = 5, laser = 20,energy = 5, bomb = 55, bio = 100, rad = 20)
+	armor = list(melee = 45, bullet = 5, laser = 20,energy = 5, bomb = 55, bio = 100, rad = 20)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/stack/flag,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/ore,/obj/item/device/t_scanner,/obj/item/weapon/tool/pickaxe, /obj/item/weapon/rcd)
 
 /obj/item/clothing/suit/space/void/mining/prepared
@@ -107,7 +107,7 @@
 		slot_l_hand_str = "sec_voidsuit",
 		slot_r_hand_str = "sec_voidsuit",
 	)
-	armor = list(melee = 60, bullet = 10, laser = 30, energy = 5, bomb = 45, bio = 100, rad = 10)
+	armor = list(melee = 50, bullet = 10, laser = 30, energy = 5, bomb = 45, bio = 100, rad = 10)
 	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/melee/baton)
 	siemens_coefficient = 0.7
 
@@ -125,7 +125,7 @@
 		slot_l_hand_str = "atmos_helm",
 		slot_r_hand_str = "atmos_helm",
 		)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
+	armor = list(melee = 35, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
 
@@ -137,7 +137,7 @@
 		slot_l_hand_str = "atmos_voidsuit",
 		slot_r_hand_str = "atmos_voidsuit",
 	)
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
+	armor = list(melee = 35, bullet = 5, laser = 20,energy = 5, bomb = 35, bio = 100, rad = 50)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/toolbox,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/weapon/rcd)
 
@@ -153,14 +153,14 @@
 	desc = "A heavy, radiation-shielded voidsuit helmet with a surprisingly comfortable interior."
 	icon_state = "rig0-engineeringalt"
 	item_state = "engalt_helm"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 45, bio = 100, rad = 100)
+	armor = list(melee = 35, bullet = 5, laser = 20,energy = 5, bomb = 45, bio = 100, rad = 100)
 	light_overlay = "helmet_light_dual"
 
 /obj/item/clothing/suit/space/void/engineering/alt
 	name = "reinforced engineering voidsuit"
 	desc = "A bulky industrial voidsuit. It's a few generations old, but a reliable design and radiation shielding make up for the lack of climate control."
 	icon_state = "rig-engineeringalt"
-	armor = list(melee = 40, bullet = 5, laser = 20,energy = 5, bomb = 45, bio = 100, rad = 100)
+	armor = list(melee = 35, bullet = 5, laser = 20,energy = 5, bomb = 45, bio = 100, rad = 100)
 
 /obj/item/clothing/suit/space/void/engineering/alt/New()
 	..()
@@ -223,7 +223,7 @@
 	icon_state = "rig-secalt"
 	name = "riot security voidsuit"
 	desc = "A heavily armored voidsuit, designed to intimidate people who find black intimidating. Surprisingly slimming."
-	armor = list(melee = 70, bullet = 20, laser = 30, energy = 5, bomb = 35, bio = 100, rad = 10)
+	armor = list(melee = 60, bullet = 20, laser = 30, energy = 5, bomb = 35, bio = 100, rad = 10)
 	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/melee/baton)
 
 /obj/item/clothing/suit/space/void/security/alt/prepared
@@ -304,7 +304,7 @@
 	name = "pilot voidsuit helmet"
 	icon_state = "rig0_pilot"
 	item_state = "pilot_helm"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100, rad = 50)
+	armor = list(melee = 35, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100, rad = 50)
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
 
@@ -313,7 +313,7 @@
 	icon_state = "rig-pilot"
 	item_state = "rig-pilot"
 	name = "pilot voidsuit"
-	armor = list(melee = 40, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100, rad = 50)
+	armor = list(melee = 35, bullet = 5, laser = 15,energy = 5, bomb = 5, bio = 100, rad = 50)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/storage/toolbox,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/weapon/rcd)
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -19,7 +19,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	heat_protection = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 50, bullet = 40, laser = 50, energy = 20, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 45, bullet = 40, laser = 50, energy = 20, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/vest/old/security
 	name = "security armor"
@@ -35,7 +35,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	heat_protection = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 50, bullet = 40, laser = 50, energy = 0, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 45, bullet = 40, laser = 50, energy = 0, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/vest/ds_jacket
 	name = "stylish security jacket"
@@ -52,7 +52,7 @@
 	desc = "An armoured jacket with silver rank pips and livery."
 	icon_state = "warden_jacket"
 	//item_state = "armor"
-	armor = list(melee = 50, bullet = 40, laser = 50, energy = 20, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 45, bullet = 40, laser = 50, energy = 20, bomb = 25, bio = 0, rad = 0)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|ARMS
@@ -62,7 +62,7 @@
 	desc = "An armored vest of uncertain quality. Provides a good protection against physical damage, for piece of crap."
 	icon_state = "hm_armorvest"
 	item_state = "hm_armorvest"
-	armor = list(melee = 40, bullet = 35, laser = 30, energy = 15, bomb = 15, bio = 0, rad = 0)
+	armor = list(melee = 35, bullet = 35, laser = 30, energy = 15, bomb = 15, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/swat/officer
 	name = "officer jacket"
@@ -83,7 +83,7 @@
 	//item_state = "armor"
 	blood_overlay_type = "armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
-	armor = list(melee = 50, bullet = 40, laser = 50, energy = 20, bomb = 25, bio = 0, rad = 0)
+	armor = list(melee = 45, bullet = 40, laser = 50, energy = 20, bomb = 25, bio = 0, rad = 0)
 
 
 //Reactive armor
@@ -191,7 +191,7 @@
 	icon_state = "kellion_grunt"
 	item_state = "armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	armor = list(melee = 60, bullet = 60, laser = 0, energy = 0, bomb = 20, bio = 0, rad = 0)
+	armor = list(melee = 55, bullet = 60, laser = 0, energy = 0, bomb = 20, bio = 0, rad = 0)
 
 //Commander
 /obj/item/clothing/suit/armor/vest/ert
@@ -200,7 +200,7 @@
 	icon_state = "ertarmor_cmd"
 	item_state = "armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 40, bomb = 20, bio = 0, rad = 0)
+	armor = list(melee = 55, bullet = 60, laser = 60, energy = 40, bomb = 20, bio = 0, rad = 0)
 
 //Security
 /obj/item/clothing/suit/armor/vest/ert/security
@@ -256,7 +256,7 @@
 	name = "webbed armor vest"
 	desc = "A synthetic armor vest. This one has added webbing and ballistic plates."
 	icon_state = "webvest"
-	armor = list(melee = 40, bullet = 40, laser = 40, energy = 25, bomb = 30, bio = 0, rad = 0)
+	armor = list(melee = 35, bullet = 40, laser = 40, energy = 25, bomb = 30, bio = 0, rad = 0)
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 	allowed = list(/obj/item/weapon/gun/energy,/obj/item/device/radio,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/handcuffs,/obj/item/weapon/gun/magnetic)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
@@ -292,14 +292,14 @@
 	desc = "A heavy armored vest in a fetching tan. It is surprisingly flexible and light, even with the extra webbing and advanced ceramic plates."
 	icon_state = "tacwebvest"
 	item_state = "tacwebvest"
-	armor = list(melee = 40, bullet = 40, laser = 60, energy = 35, bomb = 30, bio = 0, rad = 0)
+	armor = list(melee = 35, bullet = 40, laser = 60, energy = 35, bomb = 30, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/storage/vest/merc
 	name = "heavy combat armor"
 	desc = "A high-quality armored vest made from a hard synthetic material. It is surprisingly flexible and light, despite formidable armor plating."
 	icon_state = "mercwebvest"
 	item_state = "mercwebvest"
-	armor = list(melee = 60, bullet = 60, laser = 60, energy = 40, bomb = 40, bio = 0, rad = 0)
+	armor = list(melee = 55, bullet = 60, laser = 60, energy = 40, bomb = 40, bio = 0, rad = 0)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS //now covers legs with new sprite
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -18,7 +18,7 @@
 
 	//Biomass handling
 	//--------------------------
-	biomass	= 200//Current actual quantity of biomass we have stored. Start with enough to spawn a small expeditionary force
+	biomass	= 250//Current actual quantity of biomass we have stored. Start with enough to spawn a small expeditionary force
 	var/biomass_tick = 0	//Current amount of mass we're gaining each second. This shouldn't be edited as it is regularly recalculated
 	var/list/biomass_sources = list()	//A list of various sources (mostly necromorph corpses) from which we are gradually gaining biomass. These are finite
 

--- a/html/changelogs/shieldarmorhealth.yml
+++ b/html/changelogs/shieldarmorhealth.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   admin
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Reduced the health of all shields by 15%"
+  - tweak: "Increased the marker's starting biomass, from 200 to 250, enabling a bit more earlygame power for necromorphs."
+  - tweak: "Increased the minimum delay before evac can be called from 45 minutes to 60 minutes after marker activation."
+  - tweak: "Slightly reduced the melee protection of most kinds of armor, generally by 5 percentage points."


### PR DESCRIPTION
As predicted, the recent defense overhaul did make humans a bit too durable, so this part of rebalancing that slightly. As well as helping with some necromorph pacing issues we're seeing in rounds
A series of incremental balance tweaks based on recent feedback. 

I was sorely tempted to set the evac delay to 75 minutes, and thus make rounds an even two hours. We certainly will do that someday eventually, but we might not be ready for it yet, so smaller increment for now to see how it goes

changes: 
  - tweak: "Reduced the health of all shields by 15%"
  - tweak: "Increased the marker's starting biomass, from 200 to 250, enabling a bit more earlygame power for necromorphs."
  - tweak: "Increased the minimum delay before evac can be called from 45 minutes to 60 minutes after marker activation."
  - tweak: "Slightly reduced the melee protection of most kinds of armor, generally by 5 percentage points."