### PR TITLE
Darkvision

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1709,6 +1709,7 @@
 #include "code\modules\library\manuals\manuals.dm"
 #include "code\modules\library\manuals\medical.dm"
 #include "code\modules\library\manuals\nanotrasen.dm"
+#include "code\modules\lighting\darksight.dm"
 #include "code\modules\lighting\lighting_area.dm"
 #include "code\modules\lighting\lighting_atom.dm"
 #include "code\modules\lighting\lighting_corner.dm"

--- a/code/__defines/species.dm
+++ b/code/__defines/species.dm
@@ -40,8 +40,10 @@
 // Darkvision Levels these are inverted from normal so pure white is the darkest
 // possible and pure black is none
 #define DARKTINT_NONE      "#ffffff"
-#define DARKTINT_MODERATE  "#f9f9f5"
-#define DARKTINT_GOOD      "#ebebe6"
+#define DARKTINT_POOR  		"#cccccc"
+#define DARKTINT_MODERATE      "#aaaaaa"
+#define DARKTINT_GOOD			"#8C8C8C"
+#define DARKTINT_EXCEPTIONAL	"#666666"
 
 
 

--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -46,8 +46,14 @@
 
 		if (mob)
 			mob.reload_fullscreen()
+
+			//This thing handles nightvision, it is set to a certain size and does not scale with the screen
+			//BUT, we can't allow it to be bigger than the screen, so we resize it here to the size it already is
+			//It will check our screen limit and cap itself to that
 			if (mob.l_general)//It may not exist during login
-				mob.l_general.resize(src)
+				mob.l_general.resize(mob.l_general.size, src)
+
+
 			if (isliving(mob))
 				var/mob/living/L = mob
 				L.handle_regular_hud_updates(FALSE)//Pass false here to not call update vision and avoid an infinite loop

--- a/code/modules/lighting/darksight.dm
+++ b/code/modules/lighting/darksight.dm
@@ -1,0 +1,100 @@
+/obj/lighting_general
+	plane = LIGHTING_PLANE
+	screen_loc = "CENTER"
+
+	icon = LIGHTING_ICON
+	icon_state = LIGHTING_ICON_STATE_DARK
+
+	color = "#ffffff"
+
+	blend_mode = BLEND_MULTIPLY
+
+	//What size are we currently set at? Used in screen rescaling
+	var/size = 7
+	var/cached_color
+
+/obj/lighting_general/New(var/atom/location, var/client/C)
+	. = ..()
+	var/newscale = ((C.view * 2) + 1) / C.view
+	transform *= newscale
+
+/obj/lighting_general/proc/sync(var/new_colour)
+	color = new_colour
+	cached_color = new_colour
+
+/obj/lighting_general/proc/resize(var/new_size = 2, var/client/C)
+	if (istype(C))
+		new_size = min(new_size, C.temp_view)
+	size = new_size
+	var/newscale = ((new_size * 2) + 1)
+	var/matrix/M = matrix()
+	M *= newscale
+	transform = M
+
+/mob
+	var/obj/lighting_plane/l_plane
+	var/obj/lighting_general/l_general
+
+
+/mob/proc/set_darksight_color(var/new_colour)
+	if(l_general)
+		l_general.sync(new_colour)
+
+/mob/proc/set_darksight_range(var/new_range)
+	if(l_general && client)
+		client.screen -= l_general
+		l_general.resize(new_range, client)
+		client.screen += l_general
+	else if (l_general)
+		l_general.size = new_range
+
+
+/*
+	Toggling verbs
+*/
+/mob/observer/ghost/verb/toggle_darkvision()
+	set name = "Toggle Darkvision"
+	set category = "Ghost"
+
+	if (!l_general)
+		return
+
+	//If the darkness tint isnt set to none, our nightvision is on
+	var/current_status = ((l_general.color) && (l_general.color != DARKTINT_NONE))
+
+
+	var/newcolor = DARKTINT_NONE
+	var/newstring = "disabled"
+	if (!current_status)
+		newcolor = DARKTINT_GOOD
+		newstring = "enabled"
+
+
+	set_darksight_color(newcolor)
+	to_chat(src, "Darksight is now [newstring].")
+
+
+
+/*
+	Toggling verbs
+*/
+/mob/living/carbon/human/proc/toggle_darkvision()
+	set name = "Toggle Darkvision"
+	set category = "Abilities"
+
+	if (!l_general)
+		return
+
+	//If the darkness tint isnt set to none, our nightvision is on
+	var/current_status = ((l_general.color) && (l_general.color != DARKTINT_NONE))
+
+
+	var/newcolor = DARKTINT_NONE
+	var/newstring = "disabled"
+	if (!current_status)
+		newcolor = species.darksight_tint
+		newstring = "enabled"
+
+
+	set_darksight_color(newcolor)
+	to_chat(src, "Darksight is now [newstring].")

--- a/code/modules/lighting/lighting_planemaster.dm
+++ b/code/modules/lighting/lighting_planemaster.dm
@@ -17,36 +17,3 @@
 	mouse_opacity = 0    // nothing on this plane is mouse-visible
 
 
-/obj/lighting_general
-	plane = LIGHTING_PLANE
-	screen_loc = "CENTER"
-
-	icon = LIGHTING_ICON
-	icon_state = LIGHTING_ICON_STATE_DARK
-
-	color = "#ffffff"
-
-	blend_mode = BLEND_MULTIPLY
-
-/obj/lighting_general/New(var/atom/location, var/client/C)
-	. = ..()
-	var/newscale = ((C.view * 2) + 1) / C.view
-	transform *= newscale
-
-/obj/lighting_general/proc/sync(var/new_colour)
-	color = new_colour
-
-/obj/lighting_general/proc/resize(var/client/C)
-	var/newscale = ((C.view * 2) + 1) / C.view
-	var/matrix/M = matrix()
-	M *= newscale
-	transform = M
-
-/mob
-	var/obj/lighting_plane/l_plane
-	var/obj/lighting_general/l_general
-
-
-/mob/proc/change_light_colour(var/new_colour)
-	if(l_general)
-		l_general.sync(new_colour)

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -1,5 +1,7 @@
 /mob/living/carbon/human/Login()
 	..()
+
+
 	update_hud()
 	if(species) species.handle_login_special(src)
 	return

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
@@ -15,6 +15,7 @@
 
 	biomass_reclamation_time	=	4.5 MINUTES
 	view_range = 6
+	darksight_tint = DARKTINT_POOR
 
 	icon_template = 'icons/mob/necromorph/exploder.dmi'
 	icon_lying = "_lying"
@@ -28,6 +29,7 @@
 	step_volume = VOLUME_QUIET
 	step_range = 6	//We want to hear it coming
 	step_priority = 3
+
 
 
 	has_limbs = list(

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -35,6 +35,7 @@
 	view_range = 9
 	view_offset = (WORLD_ICON_SIZE*3)	//Can see much farther than usual
 
+	darksight_tint = DARKTINT_GOOD
 
 	has_limbs = list(
 	BP_CHEST =  list("path" = /obj/item/organ/external/chest/simple),

--- a/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
@@ -51,6 +51,8 @@
 	view_offset = VIEW_OFFSET_CLOSED
 
 
+	darksight_tint = DARKTINT_GOOD
+
 	has_limbs = list(
 	BP_CHEST =  list("path" = /obj/item/organ/external/chest/simple, "height" = new /vector2(0, 0.5)),	//Half a metre high
 	BP_L_ARM =  list("path" = /obj/item/organ/external/arm/tentacle/slim/lurker1, "height" = new /vector2(0.5, 1.5)),	//Tentacles extend one metre above the body

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
@@ -34,8 +34,8 @@
 
 
 	//Vision
-	darksight_range = 5 //Decent dark vision
-
+	darksight_range = -1
+	darksight_tint = DARKTINT_MODERATE
 
 	//Sprites
 	damage_overlays = null
@@ -264,6 +264,7 @@
 
 // Used to update alien icons for aliens.
 /datum/species/necromorph/handle_login_special(var/mob/living/carbon/human/H)
+	.=..()
 	SSnecromorph.necromorph_players[H.ckey] = get_or_create_player(H.ckey)
 	to_chat(H, "You are a [name]. \n\
 	[blurb]\n\

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -13,6 +13,7 @@
 	limb_health_factor = 1	//Not as fragile as a slasher
 	virus_immune = 1
 
+
 	icon_template = 'icons/mob/necromorph/ubermorph.dmi'
 	single_icon = FALSE
 	lying_rotation = 90
@@ -41,6 +42,7 @@
 
 	//Vision
 	view_range = 9
+	darksight_tint = DARKTINT_EXCEPTIONAL	//It has psychic senses, can't hide in the dark
 
 
 	//Audio

--- a/code/modules/mob/living/carbon/human/species/outsider/random.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/random.dm
@@ -71,7 +71,7 @@
 
 	//Misc traits
 	darksight_range = rand(1,8)
-	darksight_tint = pick(DARKTINT_NONE,DARKTINT_MODERATE,DARKTINT_GOOD)
+	darksight_tint = pick(DARKTINT_NONE,DARKTINT_POOR,DARKTINT_MODERATE)
 	if(prob(40))
 		genders = list(PLURAL)
 	if(prob(10))

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -8,7 +8,7 @@
 	language = LANGUAGE_GALCOM
 	unarmed_types = list(/datum/unarmed_attack/claws/strong, /datum/unarmed_attack/bite/sharp)
 	darksight_range = 8
-	darksight_tint = DARKTINT_GOOD
+	darksight_tint = DARKTINT_MODERATE
 	siemens_coefficient = 0
 
 	blood_color = "#cccccc"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -408,7 +408,14 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	H.view_offset = view_offset
 	H.view_range = view_range
 
+	if (darksight_tint != DARKTINT_NONE)
+		H.set_darksight_color(darksight_tint)
 
+		//-1 range is a special value that means fullscreen
+		if (darksight_range == -1)
+			H.set_darksight_range(view_range)
+		else
+			H.set_darksight_range(darksight_range)
 
 
 
@@ -515,6 +522,8 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			var/list/L = modifier_verbs[hotkey]
 			H.remove_modclick_verb(hotkey, L[1])
 
+	H.verbs -= /mob/living/carbon/human/proc/toggle_darkvision
+
 /datum/species/proc/add_inherent_verbs(var/mob/living/carbon/human/H)
 	if(inherent_verbs)
 		for(var/verb_path in inherent_verbs)
@@ -532,6 +541,9 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 			//We use input_args here since we're doing voodoo with passing arguments.
 			//Modclick takes key type, function name, function priority, and a list of extra arguments
 			H.add_modclick_verb(arglist(input_args))
+
+	if (darksight_tint != DARKTINT_NONE)
+		H.verbs.Add(/mob/living/carbon/human/proc/toggle_darkvision)
 
 
 
@@ -564,6 +576,13 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 // Used to update alien icons for aliens.
 /datum/species/proc/handle_login_special(var/mob/living/carbon/human/H)
+	if (H.l_general)
+		H.set_darksight_color(darksight_tint)
+		//-1 range is a special value that means fullscreen
+		if (darksight_range == -1)
+			H.set_darksight_range(view_range)
+		else
+			H.set_darksight_range(darksight_range)
 	return
 
 // As above.
@@ -610,7 +629,9 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 /datum/species/proc/handle_vision(var/mob/living/carbon/human/H)
 	H.update_sight()
 	H.set_sight(H.sight|get_vision_flags(H)|H.equipment_vision_flags)
-	H.change_light_colour(darksight_tint)
+
+
+
 
 	if(H.stat == DEAD)
 		return 1

--- a/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human_subspecies.dm
@@ -33,7 +33,7 @@
 	brute_mod = 1.1
 	burn_mod =  1.1
 	darksight_range = 6
-	darksight_tint = DARKTINT_MODERATE
+	darksight_tint = DARKTINT_POOR
 
 	spawn_flags = SPECIES_IS_RESTRICTED | SPECIES_IS_WHITELISTED | SPECIES_NO_FBP_CONSTRUCTION
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_TONE_SPCR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR

--- a/code/modules/mob/living/carbon/human/species/station/lizard.dm
+++ b/code/modules/mob/living/carbon/human/species/station/lizard.dm
@@ -14,7 +14,7 @@
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/tail, /datum/unarmed_attack/claws, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite/sharp)
 	primitive_form = "Stok"
 	darksight_range = 3
-	darksight_tint = DARKTINT_MODERATE
+	darksight_tint = DARKTINT_POOR
 	gluttonous = GLUT_TINY
 	strength = STR_HIGH
 	slowdown = 0.5

--- a/code/modules/mob/living/carbon/human/species/station/nabber.dm
+++ b/code/modules/mob/living/carbon/human/species/station/nabber.dm
@@ -41,7 +41,7 @@
 	limb_blend = ICON_MULTIPLY
 
 	darksight_range = 8
-	darksight_tint = DARKTINT_GOOD
+	darksight_tint = DARKTINT_MODERATE
 	slowdown = -0.5
 	rarity_value = 4
 	hud_type = /datum/hud_data/nabber

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -86,7 +86,7 @@
 	default_h_style = "Tajaran Ears"
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/punch, /datum/unarmed_attack/bite/sharp)
 	darksight_range = 8
-	darksight_tint = DARKTINT_GOOD
+	darksight_tint = DARKTINT_MODERATE
 	slowdown = -0.5
 	brute_mod = 1.15
 	burn_mod =  1.15
@@ -181,7 +181,7 @@
 	body_temperature = null // cold-blooded, implemented the same way nabbers do it
 
 	darksight_range = 4
-	darksight_tint = DARKTINT_MODERATE
+	darksight_tint = DARKTINT_POOR
 
 	spawn_flags = SPECIES_IS_RESTRICTED | SPECIES_IS_WHITELISTED | SPECIES_NO_FBP_CONSTRUCTION
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_SKIN_COLOR

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -578,3 +578,5 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/mob/new_player/M = new /mob/new_player()
 	M.key = key
 	log_and_message_admins("has respawned.", M)
+
+

--- a/code/modules/mob/observer/ghost/login.dm
+++ b/code/modules/mob/observer/ghost/login.dm
@@ -5,4 +5,5 @@
 		ghost_image.appearance = src
 		ghost_image.appearance_flags = RESET_ALPHA
 	updateghostimages()
-	change_light_colour(DARKTINT_GOOD)
+	set_darksight_color(DARKTINT_MODERATE)
+	set_darksight_range(world.view)

--- a/html/changelogs/darkvision.yml
+++ b/html/changelogs/darkvision.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "All necromorphs now have partial darkvision, allowing them to see better in dark areas. This can be toggled with "Toggle Darkvision" in the abilities menu. Not all necromorphs are equal in this regard, leapers and lurkers have better darkvision, ubermorph has the best of all. Exploders get very poor darkvision, as they have their own light source."


### PR DESCRIPTION
changes: 
  - rscadd: "All necromorphs now have partial darkvision, allowing them to see better in dark areas. This can be toggled with "Toggle Darkvision" in the abilities menu. Not all necromorphs are equal in this regard, leapers and lurkers have better darkvision, ubermorph has the best of all. Exploders get very poor darkvision, as they have their own light source."