### PR TITLE
Fixes all melee weapons dealing double damage

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -87,3 +87,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/apply_hit_effect(mob/living/target, mob/living/user, var/hit_zone)
 	return
 
+
+/obj/item/proc/get_strike_damage(var/datum/strike/strike)
+	strike.damage = force

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -5,7 +5,7 @@
 	icon_state = "stunbaton"
 	item_state = "baton"
 	slot_flags = SLOT_BELT
-	force = 15
+	force = 12
 	sharp = 0
 	edge = 0
 	throwforce = 7
@@ -178,6 +178,14 @@
 			H.forcesay(GLOB.hit_appends)
 
 	return 0
+
+
+/obj/item/weapon/melee/baton/get_strike_damage(var/datum/strike/strike)
+	var/mob/living/L = strike.user
+
+	if (L && L.a_intent == I_HURT)
+		return ..()
+	strike.damage = 0	//Baton only deals damage in harm intent
 
 /obj/item/weapon/melee/baton/emp_act(severity)
 	if(bcell)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -9,17 +9,16 @@
 	if(prob(blocked)) //armour provides a chance to turn sharp/edge weapon attacks into blunt ones
 		damage_flags &= ~(DAM_SHARP|DAM_EDGE)
 
-	var/datum/wound/created_wound = apply_damage(effective_force, I.damtype, hit_zone, blocked, damage_flags, used_weapon=I)
+	var/damage_dealt = apply_damage(effective_force, I.damtype, hit_zone, blocked, damage_flags, used_weapon=I)
 
 	//Melee weapon embedded object code.
-	if(!(I.item_flags & ITEM_FLAG_NO_EMBED) && istype(created_wound) && I && I.damtype == BRUTE && !I.anchored && !is_robot_module(I))
+	if(!(I.item_flags & ITEM_FLAG_NO_EMBED) && damage_dealt && I && I.damtype == BRUTE && !I.anchored && !is_robot_module(I))
 		var/weapon_sharp = (damage_flags & DAM_SHARP)
-		var/damage = effective_force //just the effective damage used for sorting out embedding, no further damage is applied here
 		if (blocked)
-			damage *= blocked_mult(blocked)
+			damage_dealt *= blocked_mult(blocked)
 
 		//blunt objects should really not be embedding in things unless a huge amount of force is involved
-		var/embed_chance = weapon_sharp? damage/I.w_class : damage/(I.w_class*3)
+		var/embed_chance = weapon_sharp? damage_dealt/I.w_class : damage_dealt/(I.w_class*3)
 		var/embed_threshold = weapon_sharp? 5*I.w_class : 15*I.w_class
 
 		//Thrown objects are FAR more likely to be embedded since there's no hand trying to hold them back
@@ -28,10 +27,10 @@
 			embed_threshold /= 2
 
 		//Sharp objects will always embed if they do enough damage.
-		if((weapon_sharp && damage > (10*I.w_class)) || (damage > embed_threshold && prob(embed_chance)))
-			src.embed(I, hit_zone, supplied_wound = created_wound)
+		if((weapon_sharp && damage_dealt > (10*I.w_class)) || (damage_dealt > embed_threshold && prob(embed_chance)))
+			src.embed(I, hit_zone)
 
-	return 1
+	return damage_dealt
 
 
 /mob/living/carbon/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0, var/def_zone = null)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -198,7 +198,7 @@ meteor_act
 	*/
 
 /mob/living/carbon/human/hit_with_weapon(var/datum/strike/implement/strike)
-	standard_weapon_hit_effects(strike.used_item, strike.user, strike.get_final_damage(), strike.blocked, strike.target_zone)
+	return standard_weapon_hit_effects(strike.used_item, strike.user, strike.get_final_damage(), strike.blocked, strike.target_zone)
 
 
 /mob/living/carbon/human/standard_weapon_hit_effects(obj/item/I, mob/living/user, var/effective_force, var/blocked, var/hit_zone)
@@ -209,14 +209,19 @@ meteor_act
 	// Handle striking to cripple.
 	if(user && user.a_intent == I_DISARM)
 		effective_force *= 0.66 //reduced effective force...
-		if(!..(I, user, effective_force, blocked, hit_zone))
-			return 0
+		.=..(I, user, effective_force, blocked, hit_zone)
+		if(!.)
+			return
 
 		//set the dislocate mult less than the effective force mult so that
 		//dislocating limbs on disarm is a bit easier than breaking limbs on harm
 		attack_joint(affecting, I, effective_force, 0.5, blocked) //...but can dislocate joints
-	else if(!..())
-		return 0
+	else
+		.=..(I, user, effective_force, blocked, hit_zone)
+		if(!.)
+			return
+
+	effective_force = .
 
 	if(effective_force > 10 || effective_force >= 5 && prob(33))
 		forcesay(GLOB.hit_appends)	//forcesay checks stat already
@@ -238,7 +243,6 @@ meteor_act
 		//Apply blood
 		attack_bloody(I, user, effective_force, hit_zone)
 
-	return 1
 
 /mob/living/carbon/human/proc/attack_bloody(obj/item/W, mob/living/attacker, var/effective_force, var/hit_zone)
 	if(W.damtype != BRUTE)

--- a/code/modules/mob/living/carbon/human/strike.dm
+++ b/code/modules/mob/living/carbon/human/strike.dm
@@ -321,14 +321,18 @@
 	CACHE_USER
 	src.used_weapon = used_weapon
 	used_item = used_weapon
+
 	damage_flags = used_weapon.damage_flags()
 	armor_penetration = used_item.armor_penetration
 
+	//The item will modify the strike
+	if (istype(used_item))
+		used_item.get_strike_damage(src)
+
+
 /datum/strike/implement/impact_mob()
-	.=..()
-	if (damage_done)
-		used_item.apply_hit_effect(target, user, target_zone)
-		L.hit_with_weapon(src)
+	used_item.apply_hit_effect(target, user, target_zone)
+	L.hit_with_weapon(src)
 
 /datum/strike/implement/show_result()
 	var/sound = get_impact_sound()


### PR DESCRIPTION
Fixes a major bug causing melee attacks with weapons to hit twice.

Also fixes stunbatons dealing damage outside of harm intent. This is a bit rough, it still makes impact sound and text feedback, but it doesn't actually hurt. Can polish in future