### PR TITLE
Corruption Fixes

### DIFF
--- a/code/controllers/subsystems/processing/vines.dm
+++ b/code/controllers/subsystems/processing/vines.dm
@@ -3,7 +3,7 @@ PROCESSING_SUBSYSTEM_DEF(vines)
 	name = "Vines"
 	priority = SS_PRIORITY_VINES
 	runlevels = RUNLEVEL_GAME|RUNLEVEL_POSTGAME
-	wait = 80
+	wait = 30
 
 	process_proc = /obj/effect/vine/Process
 

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -55,7 +55,7 @@
 	var/spread_chance = 30
 	var/spread_distance = 4
 	var/evolve_chance = 2
-	var/mature_time		//minimum maturation time
+	var/mature_time	= 10000	//minimum maturation time
 	var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/plant
 	var/list/neighbors
 	var/can_cut = TRUE

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -24,6 +24,11 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	var/vine_scale = 1.1
 	var/datum/extension/corruption_source/source
 
+	//This contains a list of other corruption sources which might be able to support us - or new vines we create, if our main source can't
+	var/list/alternatives
+
+	var/growth_mult = 1
+
 	//This is only used for the uncommon edge case where this vine is on the border between multiple chunks
 	//Don't give it a value if unused, saves memory
 	var/list/chunks
@@ -34,6 +39,9 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 
 	//No clicking this
 	mouse_opacity = 0
+
+	//A temporary variable, set and then used just before and during the spawning of a new vine
+	var/next_source
 
 
 /obj/effect/vine/corruption/New(var/newloc, var/datum/seed/newseed, var/obj/effect/vine/corruption/newparent, var/start_matured = 0, var/datum/extension/corruption_source/newsource)
@@ -46,8 +54,6 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	seed = GLOB.corruption_seed
 
 	source = newsource
-	if (!newsource)
-		source = newparent.source
 	source.register(src)
 	.=..()
 
@@ -62,8 +68,9 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 //No calculating, we'll input all these values in the variables above
 /obj/effect/vine/corruption/calculate_growth()
 
-	mature_time = rand_between(20 SECONDS, 30 SECONDS) / source.growth_speed	//How long it takes for one tile to mature and be ready to spread into its neighbors.
-	mature_time *= 1 + (source.growth_distance_falloff * get_dist_3D(src, source.source))	//Expansion gets slower as you get farther out. Additively stacking 15% increase per tile
+	growth_mult = source.get_growthtime_multiplier(src)
+	mature_time = rand_between(30 SECONDS, 45 SECONDS) * growth_mult/// source.growth_speed	//How long it takes for one tile to mature and be ready to spread into its neighbors.
+	//mature_time *= 1 + (source.growth_distance_falloff * get_dist_3D(src, source.source))	//Expansion gets slower as you get farther out. Additively stacking 15% increase per tile
 
 	growth_threshold = max_health
 	possible_children = INFINITY
@@ -111,6 +118,12 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 
 //This proc finds any viable corruption source to use for us
 /obj/effect/vine/corruption/proc/find_corruption_host()
+	//Search our alternatives list first
+	if (LAZYLEN(alternatives))
+		var/alternative = get_viable_alternative(src)
+		if (alternative)
+			return alternative
+
 	for (var/datum/extension/corruption_source/CS in GLOB.corruption_sources)
 		if (CS.can_support(src))
 			return CS
@@ -153,9 +166,14 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 
 /obj/effect/vine/corruption/can_reach(var/turf/floor)
 	if (!QDELETED(source) && source.can_support(floor))
+		next_source = source
 		return TRUE
 
-	//Possible future todo: See if any other nodes can support it if our parent can't?
+	else
+		//If our own source can't support it, lets see if any of our alternatives can take over
+		next_source = get_viable_alternative(floor)
+		if (next_source)
+			return TRUE
 
 	return FALSE
 
@@ -170,10 +188,20 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 
 
 /obj/effect/vine/corruption/spread_to(turf/target_turf)
-	.=..()
-	var/obj/effect/vine/corruption/child = .
-	if (istype(child))
-		child.get_chunks()	//Populate the nearby chunks list, for later visual updates
+	var/obj/effect/vine/corruption/child = new type(target_turf,seed,parent, FALSE, (next_source ? next_source : source)) // This should do a little bit of animation.
+	child.update_icon()
+	child.set_dir(child.calc_dir())
+	child.wake_neighbors() //Update surrounding tiles to handle edges
+	update_icon()	//We don't need one of our edges now, update to get rid of it
+	// Some plants eat through plating.
+	if(islist(seed.chems) && !isnull(seed.chems[/datum/reagent/acid/polyacid]))
+		target_turf.ex_act(prob(80) ? 3 : 2)
+
+	//Update our neighbors list
+	update_neighbors()
+	child.get_chunks()	//Populate the nearby chunks list, for later visual updates
+	return child
+
 
 
 //Checks if this tile of corruption is supported by a valid/existing source.
@@ -190,6 +218,37 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 		return FALSE
 
 	return TRUE
+
+
+//Alternative Handling
+//This attempts to find an alternative source to fit a target turf
+/obj/effect/vine/corruption/proc/get_viable_alternative(var/turf/T)
+	if (!LAZYLEN(alternatives))
+		return null
+	var/best_multiplier = 9999999999999
+	var/best_source = null
+	for (var/ref in alternatives)
+		var/datum/extension/corruption_source/CS = locate(ref)
+		if (QDELETED(CS) || !istype(CS))
+			//No longer valid
+			alternatives -= ref
+			continue
+
+
+		//Its temporarily deactivated, ignore but keep it in the list
+		if (!CS.enabled)
+			continue
+
+		if (!CS.can_support(T))
+			continue
+
+		//Okay it can support us, lets see how well
+		var/mult = CS.get_growthtime_multiplier(T)
+		if (mult < best_multiplier)
+			best_multiplier = mult
+			best_source = CS
+
+	return best_source
 
 
 

--- a/code/modules/necromorph/corruption_source.dm
+++ b/code/modules/necromorph/corruption_source.dm
@@ -36,7 +36,7 @@
 	if (limit)
 		support_limit = limit
 
-	new /obj/effect/vine/corruption(get_turf(source),GLOB.corruption_seed, start_matured = 1, newsource = src)
+	new /obj/effect/vine/corruption(get_turf(source),GLOB.corruption_seed, null, start_matured = 1, newsource = src)
 
 	//Corruption tiles add vision
 	source.visualnet_range = range

--- a/code/modules/necromorph/corruption_source.dm
+++ b/code/modules/necromorph/corruption_source.dm
@@ -22,6 +22,10 @@
 	//Is this source currently active?
 	var/enabled = TRUE
 
+
+/*
+	Initialization
+*/
 /datum/extension/corruption_source/New(var/atom/holder, var/range, var/speed, var/falloff, var/limit)
 	source = holder
 	GLOB.corruption_sources |= src
@@ -36,11 +40,22 @@
 	if (limit)
 		support_limit = limit
 
-	new /obj/effect/vine/corruption(get_turf(source),GLOB.corruption_seed, null, start_matured = 1, newsource = src)
+	var/obj/effect/vine/corruption/basevine = (locate(/obj/effect/vine/corruption) in get_turf(source))
+	if (!basevine)
+		basevine = new /obj/effect/vine/corruption(get_turf(source),GLOB.corruption_seed, null, start_matured = 1, newsource = src)
+
+
+	evaluate_existing()
 
 	//Corruption tiles add vision
 	source.visualnet_range = range
 	GLOB.necrovision.add_source(source)
+
+
+
+
+
+
 
 /datum/extension/corruption_source/Destroy()
 	GLOB.corruption_sources -= src
@@ -75,6 +90,13 @@
 	needs_update = TRUE
 	applicant.update_chunks()	//Lets also update the chunk(s) the vine is in/next to
 
+
+//Removes a specified patch from its old source and registers us as the new source
+/datum/extension/corruption_source/proc/take_posession(var/obj/effect/vine/corruption/applicant)
+	if (applicant.source)
+		applicant.source.unregister(applicant)
+
+	register(applicant)
 
 //Is this source able to provide support to a specified turf or corruption vine?
 /datum/extension/corruption_source/proc/can_support(var/atom/A)
@@ -117,6 +139,50 @@
 
 
 
+
+
+
+//Existing handling
+//-------------------------
+//Called when we're first created, this examines all the existing nearby corruption vines.
+/datum/extension/corruption_source/proc/evaluate_existing()
+	for (var/obj/effect/vine/corruption/C as anything in get_reachable())
+		//We'll take control of any that lack a source
+		if (!source)
+			register(C)
+			continue
+
+		//Those that have a source, we test to see if we'd be better, and take control if so
+		var/potential_growth_mult = get_growthtime_multiplier(C)
+
+		//A lower multiplier is better
+		if (potential_growth_mult < C.growth_mult)
+			take_posession(C)
+		else
+			//If not, we add ourselves as an alternative
+			LAZYDISTINCTADD(C.alternatives,"\ref[src]")
+
+		//Make sure its awake again, however briefly
+		if (!C.is_processing)
+			C.wake_up(FALSE)
+
+
+//This finds a list of all existing corruption vines that we could possibly reach, whether they're ours or not
+/datum/extension/corruption_source/proc/get_reachable()
+	.=list()
+	for (var/turf/T in trange(range, source))
+		for (var/obj/effect/vine/corruption/C in T)
+			.+=C
+
+
+//Figures out what multiplier to apply to this applicant's growth time, based on our speed, and relative distance
+//They will apply this multiplier to their own semi-randomly generated growth time
+//It can be passed a specific vine, or a turf that vine is on
+/datum/extension/corruption_source/proc/get_growthtime_multiplier(var/atom/site)
+	var/multiplier = 1 + (growth_distance_falloff * get_dist_3D(site, source))
+	multiplier /= growth_speed
+
+	return multiplier
 
 /* Visualnet Handling */
 //-------------------


### PR DESCRIPTION
Closes #616
Closes #576
Closes #342

A package of tweaks and fixes to corruption, primarily to fix runtime errors which i believe are causing lag.

This also fixes a number of longstanding bugs with the system. No longer are nodes useless if not placed right at the edge. When a node is newly placed, it attempts to take over existing nodes if its faster, or sets itself as an alternative they can use for farther spread. This has indirectly made corruption growth faster, so the growth times have been extended a bit to compensate

And lastly, the corruption growth is now more granular. Vines process every 3 seconds, rather than every 8 seconds. This should help clear the queue faster and get them to sleep. it'll make things less frustrating overall