### PR TITLE
Gun text and fixes

### DIFF
--- a/code/_onclick/click_handlers/target.dm
+++ b/code/_onclick/click_handlers/target.dm
@@ -32,6 +32,7 @@
 /datum/click_handler/target/proc/stop()
 	if (!stopped)
 		stopped = TRUE
-		if (user && user.client)
-			user.client.show_popup_menus = TRUE
-		user.RemoveClickHandler(src)
+		if (user)
+			if (user.client)
+				user.client.show_popup_menus = TRUE
+			user.RemoveClickHandler(src)

--- a/code/modules/clothing/spacesuits/rig/modules/ds13/kinesis/kinesis.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ds13/kinesis/kinesis.dm
@@ -752,7 +752,7 @@
 
 	if (subject && holder && holder.wearer)
 		//Lets see if the clickpoint has actually changed
-		if (global_clickpoint.x != target.x || global_clickpoint.y != target.y)
+		if (!target || global_clickpoint.x != target.x || global_clickpoint.y != target.y)
 			//It has! Set the new target, and if we were at rest, we start moving again
 			target = global_clickpoint
 			var/vector2/userloc = holder.wearer.get_global_pixel_loc()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -429,7 +429,7 @@
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
 		if(H.species.can_shred(H))
-			visible_message("<span class='warning'>[user.name] smashed the light!</span>", 3, "You hear a tinkle of breaking glass")
+			visible_message("<span class='warning'>[user.name] smashed the light!</span>", "You hear a tinkle of breaking glass", range = 3)
 			broken()
 			return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -18,7 +18,7 @@
 	matter = list(MATERIAL_STEEL = 2000)
 	w_class = ITEM_SIZE_NORMAL
 	throwforce = 5
-	
+
 	throw_range = 5
 	force = 5
 	origin_tech = list(TECH_COMBAT = 1)
@@ -384,13 +384,8 @@
 				"<span class='reflex_shoot'>You fire \the [src] by reflex!</span>",
 				"You hear a [fire_sound_text]!"
 			)
-		else
-			user.visible_message(
-				"<span class='danger'>\The [user] fires \the [src][pointblank ? " point blank at \the [target]":""]!</span>",
-				"<span class='warning'>You fire \the [src]!</span>",
-				"You hear a [fire_sound_text]!"
-				)
 
+	/*
 	if(one_hand_penalty)
 		if(!src.is_held_twohanded(user))
 			switch(one_hand_penalty)
@@ -414,7 +409,7 @@
 					to_chat(user, "<span class='warning'>You have trouble holding \the [src] steady.</span>")
 				if(4 to INFINITY)
 					to_chat(user, "<span class='warning'>You struggle to hold \the [src] steady!</span>")
-
+	*/
 	if(screen_shake)
 		spawn()
 			shake_camera(user, screen_shake+1, screen_shake)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -156,6 +156,10 @@
 	update_icon()
 
 /obj/machinery/disposal/MouseDrop_T(atom/movable/AM, mob/user)
+	//People frequently drag turfs onto this, was causing runtime errors
+	if (!istype(AM))
+		return
+
 	var/incapacitation_flags = INCAPACITATION_DEFAULT
 	if(AM == user)
 		incapacitation_flags &= ~INCAPACITATION_RESTRAINED

--- a/html/changelogs/guntext.yml
+++ b/html/changelogs/guntext.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako  
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Guns no longer create text spam when firing."


### PR DESCRIPTION
Big change here: guns no longer create a message in chat when firing. This is a relic from ancient days of text based combat, its unnecessary when there's visual and audio effects. With rapid weapons like the pulse rifle, it just creates spam and drowns out meaningful information

Also some bugfixes:
Closes #623
Closes #602
Closes #621
Closes #617