### PR TITLE
balance tweaks

### DIFF
--- a/code/game/gamemodes/marker/evac_points.dm
+++ b/code/game/gamemodes/marker/evac_points.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/marker
 	var/evac_points = 0
 	var/evac_threshold = 100
-	var/minimum_evac_time = 60// in minutes. How soon after marker setup that evac can be called, assuming all systems remain working (they won't)
+	var/minimum_evac_time = 75// in minutes. How soon after marker setup that evac can be called, assuming all systems remain working (they won't)
 
 
 	var/last_pointgain_time	= 0

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -265,8 +265,8 @@ var/global/list/sparring_attack_cache = list()
 	Specific Types
 */
 /datum/unarmed_attack/bite
-	attack_verb = list("bit")
-	attack_verb = list("teeth")
+	attack_verb = list("bit", "gnawed", "chomped")
+	attack_noun = list("bite", "chomp")
 	attack_sound = 'sound/weapons/bite.ogg'
 	shredding = 0
 	sharp = TRUE

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/lockdown.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/lockdown.dm
@@ -6,7 +6,7 @@
 	<br>\
 	After it wears off, the same door cannot be affected again for four minutes"
 	target_string = "Any airlock with a bolting or locking mechanism"
-	energy_cost = 80
+	energy_cost = 70
 	cooldown = 60 SECONDS
 	autotarget_range = 1
 	target_types = list(/obj/machinery/door/airlock)

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/psychic_tracer.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/psychic_tracer.dm
@@ -17,7 +17,7 @@
 	<br>\
 	Casting it again on a target who already has a tracer will refresh the duration and range"
 	target_string = "any living mob or crewmember"
-	energy_cost = 120
+	energy_cost = 110
 	require_corruption = FALSE
 	require_necrovision = TRUE
 	autotarget_range = 1

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/runes.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/runes.dm
@@ -3,7 +3,7 @@
 	id = "rune"
 	desc = "Creates a spooky rune. Has no functional effects, just for decoration"
 	target_string = "a wall or floor"
-	energy_cost = 15
+	energy_cost = 16
 	require_corruption = FALSE
 	autotarget_range = 0
 	LOS_block = FALSE	//This is for spooking people, we want them to see it happen

--- a/code/modules/necromorph/corruption/bioluminescence.dm
+++ b/code/modules/necromorph/corruption/bioluminescence.dm
@@ -33,5 +33,6 @@
 /datum/signal_ability/placement/corruption/bioluminescence
 	name = "Bioluminescence"
 	id = "bioluminescence"
-	energy_cost = 40
+	energy_cost = 30
 	placement_atom = /obj/structure/corruption_node/bioluminescence
+	LOS_block	=	FALSE

--- a/code/modules/necromorph/corruption/eye.dm
+++ b/code/modules/necromorph/corruption/eye.dm
@@ -128,5 +128,5 @@
 /datum/signal_ability/placement/corruption/gaze
 	name = "Gaze"
 	id = "gaze"
-	energy_cost = 150
+	energy_cost = 120
 	placement_atom = /obj/structure/corruption_node/eye/small

--- a/code/modules/necromorph/corruption/nest.dm
+++ b/code/modules/necromorph/corruption/nest.dm
@@ -14,7 +14,7 @@
 	pixel_x = -16
 	pixel_y = -16
 
-	biomass = 30
+	biomass = 25
 	reclamation_time = 10 MINUTES
 
 	default_scale = 1.4

--- a/html/changelogs/lurker_roundtime.yml
+++ b/html/changelogs/lurker_roundtime.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako  
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Lurker armor slightly weakened against all attacks, and especially against melee. The lurker is a ranged necromorph, it's not made for close combat"
+  - tweak: "Minimum round time after marker activation increased from 60 to 75 minutes."
+  - tweak: "Slightly reduced the cost of Nest corruption nodes."
+  - tweak: "Adjusted the energy costs of various signal abilities."
+  - tweak: "Bioluminescence spell is no longer blocked by line of sight."


### PR DESCRIPTION
A package of tweaks based on observations and feedback. Extending the round time is the most significant

changes: 
  - tweak: "Lurker armor slightly weakened against all attacks, and especially against melee. The lurker is a ranged necromorph, it's not made for close combat"
  - tweak: "Minimum round time after marker activation increased from 60 to 75 minutes."
  - tweak: "Slightly reduced the cost of Nest corruption nodes."
  - tweak: "Adjusted the energy costs of various signal abilities."
  - tweak: "Bioluminescence spell is no longer blocked by line of sight."