### PR TITLE
Movement Optimisation

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -31,6 +31,19 @@
 	var/default_alpha = 255
 	var/default_scale = 1
 
+
+
+	/*
+		OPTIMISATION
+			If set false, this atom will never be checked to recieve collisions. Everything will move through it as if it isnt there and canpass will never be called.
+
+			It can still collide with others when itself is the one moving
+
+			This flag doesn't necessarily mean it will block any specific thing at any specific time, CanPass still handles that.
+			Set this true for anything that could ever collide at any time in its normal life
+	*/
+	var/can_block_movement	=	TRUE
+
 /atom/New(loc, ...)
 	//atom creation method that preloads variables at creation
 	if(GLOB.use_preloader && (src.type == GLOB._preloader.target_path))//in case the instanciated atom is creating other atoms in New()
@@ -78,6 +91,7 @@
 
 /atom/Destroy()
 	QDEL_NULL(reagents)
+
 	. = ..()
 
 /atom/proc/reveal_blood()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -27,8 +27,24 @@
 	//Mass is measured in kilograms. It should never be zero
 	var/mass = 1
 
+
+/atom/movable/Initialize(var/mapload)
+	if (can_block_movement && isturf(loc))
+		var/turf/T = loc
+		T.movement_blocking_atoms |= src
+
+
+	.=..()
+
 /atom/movable/Destroy()
+	if (can_block_movement)
+		var/turf/T = get_turf(src)
+		if (T)
+			T.movement_blocking_atoms -= src
+
 	. = ..()
+
+
 	for(var/atom/movable/AM in src)
 		qdel(AM)
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -84,6 +84,7 @@
 	var/other_dangerlevel = 0
 
 	var/report_danger_level = 1
+	can_block_movement = FALSE
 
 /obj/machinery/alarm/cold
 	target_temperature = T0C+4

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -37,6 +37,8 @@
 
 	var/affected_by_emp_until = 0
 
+	can_block_movement = FALSE
+
 /obj/machinery/camera/examine(mob/user)
 	. = ..()
 	if(stat & BROKEN)

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -15,6 +15,8 @@
 	var/l_inner_range = 1 //inner range of light when on, can be negative
 	var/l_outer_range = 6 //outer range of light when on, can be negative
 
+	can_block_movement = TRUE
+
 /obj/machinery/floodlight/New()
 	cell = new/obj/item/weapon/cell/crap(src)
 	..()

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -3,6 +3,7 @@
 	layer = DECAL_LAYER
 	biomass = 0	//Used for blood and other organic smears
 	anchored = TRUE	//Why was this not set true
+	can_block_movement = FALSE //On floor
 
 /obj/effect/decal/fall_damage()
 	return 0

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -13,6 +13,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	unacidable = 1//So effect are not targeted by alien acid.
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE
 
+	can_block_movement = FALSE //Incorporeal
+
 /datum/effect/effect/system
 	var/number = 3
 	var/cardinals = 0

--- a/code/game/objects/effects/force_portal.dm
+++ b/code/game/objects/effects/force_portal.dm
@@ -9,6 +9,8 @@
 	anchored = 1
 	var/boom_time = 1
 
+	can_block_movement = TRUE //Incorporeal
+
 /obj/effect/force_portal/Initialize()
 	. = ..()
 	boom_time = world.time + 30 SECONDS

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -96,6 +96,9 @@
 	// Works similarly to worn sprite_sheets, except the alternate sprites are used when the clothing/refit_for_species() proc is called.
 	var/list/sprite_sheets_obj = list()
 
+	//Items are not dense typically
+	can_block_movement = FALSE
+
 /obj/item/New()
 	if (!max_health)
 		if (w_class != ITEM_SIZE_NO_CONTAINER)	//This is infinity, would cause errors
@@ -103,6 +106,8 @@
 		else
 			max_health = 250
 	health = max_health
+
+
 	..()
 	if(randpixel && (!pixel_x && !pixel_y) && isturf(loc)) //hopefully this will prevent us from messing with mapper-set pixel_x/y
 		pixel_x = rand(-randpixel, randpixel)

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -16,6 +16,8 @@
 		'sound/effects/footstep/catwalk4.ogg',
 		'sound/effects/footstep/catwalk5.ogg')
 
+	can_block_movement = FALSE //It IS the floor
+
 /obj/structure/catwalk/register_zstructure(var/turf/T)
 	LAZYSET(T.zstructures, src, 1)	//Ladders have a ztransition priority of 2 to overrule other things
 

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -12,6 +12,7 @@
 	icon_opened = "wall-lockeropen"
 	storage_types = CLOSET_STORAGE_ITEMS
 	setup = 0
+	can_block_movement = FALSE
 
 //spawns endless (3 sets) amounts of breathmask, emergency oxy tank and crowbar
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -35,6 +35,9 @@
 	var/pathweight = 1          // How much does it cost to pathfind over this turf?
 	var/blessed = 0             // Has the turf been blessed?
 
+	//List of everything that could possibly block movement
+	var/list/movement_blocking_atoms = list()
+
 	var/list/decals
 
 	var/movement_delay
@@ -83,20 +86,17 @@ turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (!mover || !isturf(mover.loc) || isobserver(mover))
 		return FALSE
 
-	//First, check objects to block exit that are not on the border
-	for(var/obj/obstacle in mover.loc)
-		if(!(obstacle.atom_flags & ATOM_FLAG_CHECKS_BORDER) && (mover != obstacle) && (forget != obstacle))
+	var/turf/origin = mover.loc
+
+	//First, check objects to block exit . border or not
+	for(var/obj/obstacle in origin.movement_blocking_atoms)
+		if((mover != obstacle) && (forget != obstacle))
 			if(!obstacle.CheckExit(mover, src))
 				return obstacle
 
-	//Now, check objects to block exit that are on the border
-	for(var/obj/border_obstacle in mover.loc)
-		if((border_obstacle.atom_flags & ATOM_FLAG_CHECKS_BORDER) && (mover != border_obstacle) && (forget != border_obstacle))
-			if(!border_obstacle.CheckExit(mover, src))
-				return border_obstacle
 
 	//Next, check objects to block entry that are on the border
-	for(var/obj/border_obstacle in src)
+	for(var/obj/border_obstacle in src.movement_blocking_atoms)
 		if(border_obstacle.atom_flags & ATOM_FLAG_CHECKS_BORDER)
 			if(!border_obstacle.CanPass(mover, mover.loc, 1, 0) && (forget != border_obstacle))
 				return border_obstacle
@@ -106,7 +106,7 @@ turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 		return src
 
 	//Finally, check objects/mobs to block entry that are not on the border
-	for(var/atom/movable/obstacle in src)
+	for(var/atom/movable/obstacle in src.movement_blocking_atoms)
 		if(!(obstacle.atom_flags & ATOM_FLAG_CHECKS_BORDER))
 			if(!obstacle.CanPass(mover, mover.loc, 1, 0) && (forget != obstacle))
 				return obstacle
@@ -120,22 +120,16 @@ turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (!mover || !isturf(mover.loc) || isobserver(mover))
 		return 1
 
-	//First, check objects to block exit that are not on the border
-	for(var/obj/obstacle in mover.loc)
-		if(!(obstacle.atom_flags & ATOM_FLAG_CHECKS_BORDER) && (mover != obstacle) && (forget != obstacle))
-			if(!obstacle.CheckExit(mover, src))
-				mover.Bump(obstacle, 1)
-				return 0
+	var/turf/origin = mover.loc
 
-	//Now, check objects to block exit that are on the border
-	for(var/obj/border_obstacle in mover.loc)
-		if((border_obstacle.atom_flags & ATOM_FLAG_CHECKS_BORDER) && (mover != border_obstacle) && (forget != border_obstacle))
-			if(!border_obstacle.CheckExit(mover, src))
-				mover.Bump(border_obstacle, 1)
-				return 0
+	//First, check objects to block exit . border or not
+	for(var/obj/obstacle in origin.movement_blocking_atoms)
+		if((mover != obstacle) && (forget != obstacle))
+			if(!obstacle.CheckExit(mover, src))
+				return obstacle
 
 	//Next, check objects to block entry that are on the border
-	for(var/obj/border_obstacle in src)
+	for(var/obj/border_obstacle in src.movement_blocking_atoms)
 		if(border_obstacle.atom_flags & ATOM_FLAG_CHECKS_BORDER)
 			if(!border_obstacle.CanPass(mover, mover.loc, 1, 0) && (forget != border_obstacle))
 				mover.Bump(border_obstacle, 1)
@@ -147,7 +141,10 @@ turf/attackby(obj/item/weapon/W as obj, mob/user as mob)
 		return 0
 
 	//Finally, check objects/mobs to block entry that are not on the border
-	for(var/atom/movable/obstacle in src)
+	for(var/atom/movable/obstacle in src.movement_blocking_atoms)
+		if (QDELETED(obstacle) || obstacle.loc != src)
+			movement_blocking_atoms -= obstacle
+			continue
 		if(!(obstacle.atom_flags & ATOM_FLAG_CHECKS_BORDER))
 			if(!obstacle.CanPass(mover, mover.loc, 1, 0) && (forget != obstacle))
 				mover.Bump(obstacle, 1)
@@ -158,6 +155,9 @@ var/const/enterloopsanity = 100
 /turf/Entered(atom/atom as mob|obj)
 
 	..()
+
+	if (atom.can_block_movement)
+		movement_blocking_atoms |= atom
 
 	if(!istype(atom, /atom/movable))
 		return
@@ -186,6 +186,14 @@ var/const/enterloopsanity = 100
 					if ((thing && A) && (thing.movable_flags & MOVABLE_FLAG_PROXMOVE))
 						thing.HasProximity(A, 1)
 	return
+
+/turf/Exited(atom/atom as mob|obj)
+	if (atom.can_block_movement)
+
+		movement_blocking_atoms -= atom
+
+	.=..()
+
 
 /turf/proc/adjacent_fire_act(turf/simulated/floor/source, temperature, volume)
 	return

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -19,6 +19,8 @@
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY //connects to regular and supply pipes
 
+	can_block_movement = FALSE //Its on the floor
+
 	var/area/initial_loc
 	level = 1
 	var/area_uid

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -12,6 +12,8 @@
 
 	level = 1
 
+	can_block_movement = FALSE //Its on the floor
+
 	var/area/initial_loc
 	var/id_tag = null
 	var/frequency = 1439

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -17,6 +17,9 @@
 	buckle_lying = -1
 	var/datum/sound_token/sound_token
 
+	//These are underfloor, stop getting involved in movement calculations
+	can_block_movement = FALSE
+
 //Added by nanako, makes pipes immune to explosions.
 //They're everywhere, blowing them up is functionally irreparable damage, and one bomb ruins the game. its not worth it
 /obj/machinery/atmospherics/pipe/ex_act()

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -20,6 +20,8 @@
 
 	var/needs_update = FALSE
 
+	can_block_movement = FALSE //Its not a real object
+
 /atom/movable/lighting_overlay/Initialize()
 	// doesn't need special init
 	atom_flags |= ATOM_FLAG_INITIALIZED

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -34,6 +34,8 @@
 	can_pull_size = ITEM_SIZE_TINY
 	can_pull_mobs = MOB_PULL_NONE
 
+	can_block_movement = FALSE
+
 /mob/living/simple_animal/mouse/Life()
 	..()
 	if(!stat && prob(speak_chance))

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/wall.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/wall.dm
@@ -34,6 +34,7 @@
 
 	max_health = 60
 	resistance = 6
+	can_block_movement = TRUE
 
 //Wall has a smaller random rotation range
 /obj/structure/corruption_node/wall/get_rotation()

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -15,6 +15,7 @@ var/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 	status_flags = GODMODE
 	var/ghost_image_flag = GHOST_IMAGE_DARKNESS
 	var/image/ghost_image = null //this mobs ghost image, for deleting and stuff
+	can_block_movement = FALSE
 
 /mob/observer/New()
 	..()

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -17,6 +17,9 @@
 	broken_damage = 150
 	atom_flags = ATOM_FLAG_CLIMBABLE
 
+	//A rare case of a dense item
+	can_block_movement = TRUE
+
 /obj/item/modular_computer/console/CouldUseTopic(var/mob/user)
 	..()
 	if(istype(user, /mob/living/carbon))

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -43,6 +43,8 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	//A temporary variable, set and then used just before and during the spawning of a new vine
 	var/next_source
 
+	can_block_movement = FALSE
+
 
 /obj/effect/vine/corruption/New(var/newloc, var/datum/seed/newseed, var/obj/effect/vine/corruption/newparent, var/start_matured = 0, var/datum/extension/corruption_source/newsource)
 

--- a/code/modules/necromorph/corruption/harvester.dm
+++ b/code/modules/necromorph/corruption/harvester.dm
@@ -59,6 +59,8 @@
 	plane = LARGE_MOB_PLANE
 	layer = LARGE_MOB_LAYER
 
+	can_block_movement = TRUE
+
 
 /obj/structure/corruption_node/harvester/update_icon()
 	set waitfor = FALSE

--- a/code/modules/necromorph/corruption/nest.dm
+++ b/code/modules/necromorph/corruption/nest.dm
@@ -36,6 +36,8 @@
 	var/list/upgrade_multipliers = list(1, 0.9, 0.75)
 	var/growth_timer_handle
 
+	can_block_movement = TRUE
+
 /obj/structure/corruption_node/nest/Initialize()
 	//Add ourselves as a possible spawnpoint for the marker
 	.=..()

--- a/code/modules/necromorph/corruption_nodes.dm
+++ b/code/modules/necromorph/corruption_nodes.dm
@@ -25,6 +25,7 @@
 
 	var/processing = FALSE
 
+	can_block_movement = FALSE
 
 
 /obj/structure/corruption_node/Initialize()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -127,6 +127,8 @@
 	var/global/list/status_overlays_environ
 
 
+	can_block_movement = FALSE
+
 /obj/machinery/power/apc/updateDialog()
 	if (stat & (BROKEN|MAINT))
 		return

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -39,6 +39,9 @@ By design, d1 is the smallest direction and d2 is the highest
 	color = COLOR_MAROON
 	var/obj/machinery/power/breakerbox/breaker_box
 
+	//These are underfloor, stop getting involved in movement calculations
+	can_block_movement = FALSE
+
 
 /obj/structure/cable/drain_power(var/drain_check, var/surge, var/amount = 0)
 
@@ -229,6 +232,8 @@ By design, d1 is the smallest direction and d2 is the highest
 
 //explosion handling
 /obj/structure/cable/ex_act(severity)
+	return	//Blowing up cables and losing power is not fun
+	/*
 	switch(severity)
 		if(1.0)
 			qdel(src)
@@ -240,7 +245,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		if(3.0)
 			if (prob(25))
 				new/obj/item/stack/cable_coil(src.loc, src.d1 ? 2 : 1, color)
-				qdel(src)
+				qdel(src)*/
 
 obj/structure/cable/proc/cableColor(var/colorC)
 	var/color_n = "#dd0000"
@@ -482,7 +487,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	desc = "A coil of wiring, for delicate electronics use aswell as the more basic cable laying."
 	throwforce = 0
 	w_class = ITEM_SIZE_NORMAL
-	
+
 	throw_range = 5
 	matter = list(MATERIAL_STEEL = 50, MATERIAL_GLASS = 20)
 	obj_flags = OBJ_FLAG_CONDUCTIBLE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -28,6 +28,7 @@
 	var/stage = 1
 	var/fixture_type = /obj/machinery/light
 	var/sheets_refunded = 2
+	can_block_movement = FALSE
 
 /obj/machinery/light_construct/New(atom/newloc, var/newdir, atom/fixture = null)
 	..(newloc)
@@ -156,6 +157,7 @@
 	var/obj/item/weapon/light/lightbulb
 
 	var/current_mode = null
+	can_block_movement = FALSE
 
 // the smaller bulb light fixture
 /obj/machinery/light/small

--- a/code/modules/projectiles/effects.dm
+++ b/code/modules/projectiles/effects.dm
@@ -13,6 +13,8 @@
 
 	var/list/random_iconstate
 
+	can_block_movement = FALSE //Incorporeal
+
 /obj/effect/projectile/Initialize()
 	.= ..()
 	//We need a tiny sleep for random icons to be setup

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "bullet"
 	density = 1
+	can_block_movement = FALSE	//Projectiles don't recieve collisions usually, they move into other things
 	unacidable = 1
 	anchored = 1 //There's a reason this is here, Mport. God fucking damn it -Agouri. Find&Fix by Pete. The reason this is here is to stop the curving of emitter shots.
 	pass_flags = PASS_FLAG_TABLE


### PR DESCRIPTION
A major step in reducing movement lag:

This PR gives each turf an internal list of things it contains which could possibly block movement, based on a variable set on atoms.

Only things in that list are checked for collisions.

This saves at least one check on every tile by not trying to collide with lighting overlays. It saves many more in cases of pipes, wires, catwalks, corruption, decals etc. Things which are in every room.
And it saves vast quantities of checks in cluttered areas littered with trash, bodyparts, blood, et al.

Basically, floors that don't contain dense stuff no longer generate collision events at all

We had 48 million calls to canpass in the most recent data, this will help


Also supplemental change: Explosions no longer break power cables. This was an unfun feature to have