### PR TITLE
Lurker, Barricades, Healthbar

### DIFF
--- a/code/__defines/weapons.dm
+++ b/code/__defines/weapons.dm
@@ -13,14 +13,14 @@
 
 //Resistance values, used on floors, windows, airlocks, girders, and similar hard targets
 //Reduces the damage they take by flat amounts
-#define RESISTANCE_FRAGILE 				4
-#define RESISTANCE_AVERAGE 				8
-#define RESISTANCE_IMPROVED 			12
-#define RESISTANCE_TOUGH 				15
-#define RESISTANCE_ARMOURED 			20
-#define RESISTANCE_HEAVILY_ARMOURED 	25
-#define RESISTANCE_VAULT 				30
-#define RESISTANCE_UNBREAKABLE 			100
+#define RESISTANCE_FRAGILE 				3
+#define RESISTANCE_AVERAGE 				5
+#define RESISTANCE_IMPROVED 			8
+#define RESISTANCE_TOUGH 				12
+#define RESISTANCE_ARMOURED 			16
+#define RESISTANCE_HEAVILY_ARMOURED 	22
+#define RESISTANCE_VAULT 				28
+#define RESISTANCE_UNBREAKABLE 			40
 
 
 //Structure damage values: Multipliers on base damage for attacking hard targets

--- a/code/datums/craft/recipes/fortification.dm
+++ b/code/datums/craft/recipes/fortification.dm
@@ -38,7 +38,7 @@
 	result = /obj/structure/barricade/wood
 	steps = list(
 		list(CRAFT_MATERIAL, MATERIAL_WOOD, 3),
-		list(CRAFT_TOOL, QUALITY_SAWING, 10, 80))
+		list(CRAFT_TOOL, QUALITY_SAWING, 10, 60))
 
 
 /datum/craft_recipe/fortification/metal_barricade
@@ -48,8 +48,8 @@
 	desc = "A sturdy barricade made of welded steel. Tougher than wood, but requires more time, resources, tools and effort to construct. <br>\
 	Barricades can be upgraded with the addition of metal rods, adding spikes which will harm attackers and turn it into a hazard."
 	steps = list(
-		list(CRAFT_MATERIAL, MATERIAL_STEEL, 4),
-		list(CRAFT_TOOL, QUALITY_BOLT_TURNING, 10, 70),
-		list(CRAFT_MATERIAL, MATERIAL_STEEL, 4),
-		list(CRAFT_TOOL, QUALITY_WELDING, 10, 100),
+		list(CRAFT_MATERIAL, MATERIAL_STEEL, 2),
+		list(CRAFT_TOOL, QUALITY_BOLT_TURNING, 10, 50),
+		list(CRAFT_MATERIAL, MATERIAL_STEEL, 3),
+		list(CRAFT_TOOL, QUALITY_WELDING, 10, 50),
 	)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -504,6 +504,7 @@ its easier to just keep the beam vertical.
 	return 0
 
 /atom/proc/do_climb(var/mob/living/user)
+	. = FALSE
 	if (!can_climb(user))
 		return
 
@@ -523,6 +524,7 @@ its easier to just keep the beam vertical.
 
 	if (get_turf(user) == get_turf(src))
 		user.visible_message("<span class='warning'>\The [user] climbs onto \the [src]!</span>")
+		.= TRUE
 	climbers -= user
 
 /atom/proc/object_shaken()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -11,6 +11,7 @@
 	anchored = 1
 	density = 1
 	obj_flags = OBJ_FLAG_ANCHORABLE
+	atom_flags = ATOM_FLAG_CLIMBABLE
 	clicksound = "button"
 	clickvol = 40
 
@@ -212,6 +213,8 @@
 	return
 
 /obj/machinery/vending/MouseDrop_T(var/obj/item/I as obj, var/mob/user as mob)
+	if (I == user)
+		return ..()
 	if(!CanMouseDrop(I, user) || (I.loc != user))
 		return
 	return attempt_to_stock(I, user)

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -25,7 +25,8 @@
 	name = "[material.display_name] barricade"
 	desc = "This space is blocked off by a barricade made of [material.display_name]."
 	color = material.icon_colour
-	max_health = material.integrity
+	max_health = material.integrity*1.35
+	resistance = material.resistance
 	health = max_health
 	.=..()
 
@@ -35,7 +36,7 @@
 /obj/structure/barricade/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/stack/rods) && !spiky)
 		var/obj/item/stack/rods/R = W
-		if(R.get_amount() < 5)
+		if(R.get_amount() < 4)
 			to_chat(user, "<span class='warning'>You need more rods to build a cheval de frise.</span>")
 			return
 		visible_message("<span class='notice'>\The [user] begins to work on \the [src].</span>")
@@ -103,7 +104,7 @@
 	rod_material = get_material_by_name(MATERIAL_STEEL)
 	SetName("cheval-de-frise")
 	desc = "A rather simple [material.display_name] barrier. It menaces with spikes of [rod_material.display_name]."
-	damage = (rod_material.hardness * 0.2)
+	damage = (rod_material.hardness * 0.45)
 	overlays += overlay_image(icon, spike_overlay, color = rod_material.icon_colour, flags = RESET_COLOR)
 
 /obj/structure/barricade/spike/Bumped(mob/living/victim)
@@ -129,8 +130,18 @@
 
 
 /obj/structure/barricade/spike/attack_hand(var/mob/user)
-	impale_victim(user, 0.4)	//Touching it with your hands hurts, but less than walking into it
+	impale_victim(user, 0.5)	//Touching it with your hands hurts, but less than walking into it
 	.=..()
+
+//Attempting to climb spiked barricades is a bad idea.
+/obj/structure/barricade/spike/do_climb(var/mob/living/user)
+	//First of all, we stab them once while mounting
+	impale_victim(user, 1.5)
+	.=..()	//Then call parent
+	//If the parent returns false, it means they aborted their climbing. We'll let them go
+	//If it returns true, they kept going and finished the climb, we will stab them again to punish this persistence
+	if (.)
+		impale_victim(user, 1.5)
 
 /obj/structure/barricade/spike/proc/impale_victim(var/mob/living/victim, var/damage_mult = 1)
 

--- a/code/modules/clothing/spacesuits/rig/modules/ds13/healthbar.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ds13/healthbar.dm
@@ -13,6 +13,10 @@
 	var/mob/living/carbon/human/user
 	process_with_rig = FALSE
 
+	suit_overlay_layer = EYE_GLOW_LAYER
+	suit_overlay_plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	suit_overlay_flags = KEEP_APART
+
 
 /obj/item/rig_module/healthbar/proc/register_user(var/mob/newuser)
 	user = newuser

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -46,6 +46,9 @@
 	var/suit_overlay_active             // If set, drawn over icon and mob when effect is active.
 	var/suit_overlay_inactive           // As above, inactive.
 	var/suit_overlay_used               // As above, when engaged.
+	var/suit_overlay_layer	=	HUMAN_LAYER
+	var/suit_overlay_plane	=	HUMAN_PLANE
+	var/suit_overlay_flags = 0
 
 	//Display fluff
 	var/interface_name = "hardsuit upgrade"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -530,7 +530,9 @@
 		if(equipment_overlay_icon && LAZYLEN(installed_modules))
 			for(var/obj/item/rig_module/module in installed_modules)
 				if(module.suit_overlay)
-					var/image/overlay = image("icon" = equipment_overlay_icon, "icon_state" = "[module.suit_overlay]", "dir" = SOUTH)
+					var/image/overlay = image("icon" = equipment_overlay_icon, "icon_state" = "[module.suit_overlay]", "dir" = SOUTH, layer = module.suit_overlay_layer)
+					overlay.plane = module.suit_overlay_plane
+					overlay.appearance_flags = module.suit_overlay_flags
 					if (chest)
 						//Some rigs dont have a chestpiece
 						chest.overlays += overlay
@@ -553,7 +555,10 @@
 	if(equipment_overlay_icon && LAZYLEN(installed_modules))
 		for(var/obj/item/rig_module/module in installed_modules)
 			if(module.suit_overlay)
-				ret.overlays += image("icon" = equipment_overlay_icon, "icon_state" = "[module.suit_overlay]")
+				var/image/overlay = image("icon" = equipment_overlay_icon, "icon_state" = "[module.suit_overlay]", layer = module.suit_overlay_layer)
+				overlay.plane = module.suit_overlay_plane
+				overlay.appearance_flags = module.suit_overlay_flags
+				ret.overlays += overlay
 	return ret
 
 /obj/item/weapon/rig/proc/check_suit_access(var/mob/living/carbon/human/user)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -114,6 +114,7 @@ var/list/name_to_material
 	// Damage values.
 	var/hardness = 60            // Prob of wall destruction by hulk, used for edge damage in weapons.
 	var/weight = 20              // Determines blunt damage/throwforce for weapons.
+	var/resistance = RESISTANCE_FRAGILE			 // Damage reduction vs attacks
 
 	// Noise when someone is faceplanted onto a table made of this material.
 	var/tableslam_noise = 'sound/weapons/tablehit1.ogg'
@@ -274,6 +275,7 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 	conductive = 0
 	construction_difficulty = 2
+	resistance = RESISTANCE_UNBREAKABLE
 
 /material/diamond/crystal
 	name = MATERIAL_CRYSTAL
@@ -294,11 +296,13 @@ var/list/name_to_material
 				/datum/reagent/gold = 20
 				)
 	construction_difficulty = 1
+	resistance = RESISTANCE_IMPROVED
 
 /material/gold/bronze //placeholder for ashtrays
 	name = MATERIAL_BRONZE
 	icon_colour = "#edd12f"
 	construction_difficulty = 1
+	resistance = RESISTANCE_IMPROVED
 
 /material/silver
 	name = MATERIAL_SILVER
@@ -313,6 +317,7 @@ var/list/name_to_material
 				/datum/reagent/silver = 20
 				)
 	construction_difficulty = 1
+	resistance = RESISTANCE_IMPROVED
 
 /material/phoron
 	name = MATERIAL_PHORON
@@ -373,6 +378,7 @@ var/list/name_to_material
 	sheet_plural_name = "bricks"
 	conductive = 0
 	construction_difficulty = 1
+	resistance = RESISTANCE_IMPROVED
 
 /material/stone/marble
 	name = MATERIAL_MARBLE
@@ -396,6 +402,7 @@ var/list/name_to_material
 				/datum/reagent/iron = 15,
 				/datum/reagent/carbon = 5
 				)
+	resistance = RESISTANCE_IMPROVED
 
 /material/steel/holographic
 	name = "holo" + MATERIAL_STEEL
@@ -421,6 +428,7 @@ var/list/name_to_material
 	composite_material = list(MATERIAL_STEEL = SHEET_MATERIAL_AMOUNT*0.5, MATERIAL_PLATINUM = SHEET_MATERIAL_AMOUNT*0.5) //todo
 	hitsound = 'sound/weapons/smash.ogg'
 	construction_difficulty = 1
+	resistance = RESISTANCE_TOUGH
 
 /material/plasteel/titanium
 	name = MATERIAL_TITANIUM
@@ -435,6 +443,7 @@ var/list/name_to_material
 	icon_colour = "#d1e6e3"
 	icon_reinf = "reinf_metal"
 	construction_difficulty = 1
+	resistance = RESISTANCE_TOUGH
 
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
@@ -32,6 +32,7 @@
 	total_health = 60
 	biomass = 55
 	health_doll_offset	= 50
+	torso_damage_mult = 0.75
 
 	//Normal necromorph flags plus no slip
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_POISON  | SPECIES_FLAG_NO_BLOCK | SPECIES_FLAG_NO_SLIP
@@ -199,6 +200,10 @@ The Lurker can only fire spines while its shell is open"
 	retracted = TRUE
 
 
+/obj/item/organ/external/chest/simple/lurker
+	max_damage = 360
+	min_broken_damage = 180
+	limb_flags = ORGAN_FLAG_HEALS_OVERKILL
 
 
 //Special death condition: Lurkers die if they lose all three tentacles

--- a/html/changelogs/lurkerbarricadehealthbar.yml
+++ b/html/changelogs/lurkerbarricadehealthbar.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Lurkers are no longer unkillable"
+  - tweak: "Significantly buffed barricades of all kinds. They are tougher, cheaper and faster to build, and spiked barricades deal significantly more damage"
+  - tweak: "Spiked barricades now hurt mobs who try to climb over them. Once on starting a climb, and again if they don't abort the climbing before it finishes."
+  - tweak: "RIG healthbars now glow in the dark
+  - tweak: "Vending machines can now be climbed over."


### PR DESCRIPTION
A package of requested balance and tweaks

changes: 
  - bugfix: "Lurkers are no longer unkillable"
  - tweak: "Significantly buffed barricades of all kinds. They are tougher, cheaper and faster to build, and spiked barricades deal significantly more damage"
  - tweak: "Spiked barricades now hurt mobs who try to climb over them. Once on starting a climb, and again if they don't abort the climbing before it finishes."
  - tweak: "RIG healthbars now glow in the dark
  - tweak: "Vending machines can now be climbed over."


Closes #676
Closes #675