### PR TITLE
Marker Shard tweaks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2606,6 +2606,7 @@
 #include "code\modules\recycling\conveyor2.dm"
 #include "code\modules\recycling\disposal-construction.dm"
 #include "code\modules\recycling\disposal.dm"
+#include "code\modules\recycling\helpers.dm"
 #include "code\modules\recycling\sortingmachinery.dm"
 #include "code\modules\research\circuitprinter.dm"
 #include "code\modules\research\designs.dm"

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -55,7 +55,7 @@
 	var/spread_chance = 30
 	var/spread_distance = 4
 	var/evolve_chance = 2
-	var/mature_time	= 10000	//minimum maturation time
+	var/mature_time	= 30 SECONDS	//minimum maturation time
 	var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/plant
 	var/list/neighbors
 	var/can_cut = TRUE

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -78,3 +78,30 @@
 	if(drowsy)		apply_effect(drowsy,    DROWSY, blocked)
 	if(agony)		apply_effect(agony,     PAIN, blocked)
 	return 1
+
+
+// heal ONE external organ, organ gets randomly selected from damaged ones.
+/mob/living/proc/heal_organ_damage(var/brute, var/burn)
+	adjustBruteLoss(-brute)
+	adjustFireLoss(-burn)
+	src.updatehealth()
+
+// damage ONE external organ, organ gets randomly selected from damaged ones.
+/mob/living/proc/take_organ_damage(var/brute, var/burn, var/emp=0)
+	if(status_flags & GODMODE)	return 0	//godmode
+	adjustBruteLoss(brute)
+	adjustFireLoss(burn)
+	src.updatehealth()
+
+// heal MANY external organs, in random order
+/mob/living/proc/heal_overall_damage(var/brute, var/burn)
+	adjustBruteLoss(-brute)
+	adjustFireLoss(-burn)
+	src.updatehealth()
+
+// damage MANY external organs, in random order
+/mob/living/proc/take_overall_damage(var/brute, var/burn, var/used_weapon = null)
+	if(status_flags & GODMODE)	return 0	//godmode
+	adjustBruteLoss(brute)
+	adjustFireLoss(burn)
+	src.updatehealth()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -374,31 +374,7 @@ default behaviour is:
 	return def_zone
 
 
-// heal ONE external organ, organ gets randomly selected from damaged ones.
-/mob/living/proc/heal_organ_damage(var/brute, var/burn)
-	adjustBruteLoss(-brute)
-	adjustFireLoss(-burn)
-	src.updatehealth()
 
-// damage ONE external organ, organ gets randomly selected from damaged ones.
-/mob/living/proc/take_organ_damage(var/brute, var/burn, var/emp=0)
-	if(status_flags & GODMODE)	return 0	//godmode
-	adjustBruteLoss(brute)
-	adjustFireLoss(burn)
-	src.updatehealth()
-
-// heal MANY external organs, in random order
-/mob/living/proc/heal_overall_damage(var/brute, var/burn)
-	adjustBruteLoss(-brute)
-	adjustFireLoss(-burn)
-	src.updatehealth()
-
-// damage MANY external organs, in random order
-/mob/living/proc/take_overall_damage(var/brute, var/burn, var/used_weapon = null)
-	if(status_flags & GODMODE)	return 0	//godmode
-	adjustBruteLoss(brute)
-	adjustFireLoss(burn)
-	src.updatehealth()
 
 /mob/living/proc/restore_all_organs()
 	return

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -286,6 +286,10 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 		T.update_chunk(FALSE)
 
 
+
+
+
+
 /* The seed */
 //-------------------
 /datum/seed/corruption

--- a/code/modules/necromorph/corruption_source.dm
+++ b/code/modules/necromorph/corruption_source.dm
@@ -12,6 +12,7 @@
 	var/growth_distance_falloff = 0.15	//15% added to growth time for each tile of distance from the source
 	var/support_limit = null
 	var/atom/source
+	var/turf/sourceturf
 	var/list/corruption_vines = list()	//A list of all the vines we're currently supporting
 
 	//What tiles are revealed to the visualnet by our corruption vines?
@@ -28,6 +29,7 @@
 */
 /datum/extension/corruption_source/New(var/atom/holder, var/range, var/speed, var/falloff, var/limit)
 	source = holder
+	sourceturf = get_turf(source)
 	GLOB.corruption_sources |= src
 	GLOB.moved_event.register(source, src, /datum/extension/corruption_source/proc/source_moved)
 	GLOB.destroyed_event.register(source, src, /datum/extension/corruption_source/proc/source_deleted)
@@ -110,7 +112,7 @@
 			return FALSE
 
 	var/turf/T = get_turf(A)
-	var/distance = get_dist_3D(get_turf(source), T)
+	var/distance = get_dist_3D(sourceturf, T)
 	//We check distance fist, it's quick and efficient
 	if (distance > range)
 		return FALSE
@@ -124,6 +126,7 @@
 
 
 /datum/extension/corruption_source/proc/source_moved(var/atom/movable/mover, var/old_loc, var/new_loc)
+	sourceturf = get_turf(source)
 	update_vines()
 
 /datum/extension/corruption_source/proc/source_deleted()
@@ -170,7 +173,7 @@
 //This finds a list of all existing corruption vines that we could possibly reach, whether they're ours or not
 /datum/extension/corruption_source/proc/get_reachable()
 	.=list()
-	for (var/turf/T in trange(range, source))
+	for (var/turf/T in trange(range, sourceturf))
 		for (var/obj/effect/vine/corruption/C in T)
 			.+=C
 
@@ -179,7 +182,7 @@
 //They will apply this multiplier to their own semi-randomly generated growth time
 //It can be passed a specific vine, or a turf that vine is on
 /datum/extension/corruption_source/proc/get_growthtime_multiplier(var/atom/site)
-	var/multiplier = 1 + (growth_distance_falloff * get_dist_3D(site, source))
+	var/multiplier = 1 + (growth_distance_falloff * get_dist_3D(site, sourceturf))
 	multiplier /= growth_speed
 
 	return multiplier

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -119,18 +119,7 @@
 				qdel(src)
 			return
 
-	if(istype(I, /obj/item/weapon/melee/energy/blade))
-		to_chat(user, "You can't place that item inside the disposal unit.")
-		return
 
-	if(istype(I, /obj/item/weapon/storage/bag/trash))
-		var/obj/item/weapon/storage/bag/trash/T = I
-		to_chat(user, "<span class='notice'>You empty the bag.</span>")
-		for(var/obj/item/O in T.contents)
-			T.remove_from_storage(O,src)
-		T.update_icon()
-		update_icon()
-		return
 
 	var/obj/item/grab/G = I
 	if(istype(G))	// handle grabbed mob
@@ -144,6 +133,9 @@
 	if(!I)
 		return
 
+	if (!I.attempt_dispose(src, user))
+		return
+
 	if(!user.unEquip(I, src))
 		return
 
@@ -155,6 +147,7 @@
 
 	update_icon()
 
+
 /obj/machinery/disposal/MouseDrop_T(atom/movable/AM, mob/user)
 	//People frequently drag turfs onto this, was causing runtime errors
 	if (!istype(AM))
@@ -165,6 +158,9 @@
 		incapacitation_flags &= ~INCAPACITATION_RESTRAINED
 
 	if(stat & BROKEN || !CanMouseDrop(AM, user, incapacitation_flags) || AM.anchored || !isturf(user.loc))
+		return
+
+	if (!AM.attempt_dispose(src, user))
 		return
 
 	// Determine object type and run necessary checks
@@ -482,6 +478,8 @@
 		if(istype(I, /obj/item/projectile))
 			return
 		if(prob(75))
+			if (!mover.attempt_dispose(src, mover.thrower))
+				return
 			I.forceMove(src)
 			for(var/mob/M in viewers(src))
 				M.show_message("\The [I] lands in \the [src].", 3)

--- a/code/modules/recycling/helpers.dm
+++ b/code/modules/recycling/helpers.dm
@@ -1,0 +1,14 @@
+//Called when the user attempts to put this atom into disposal D
+//Return false to prevent it from going in
+/atom/proc/attempt_dispose(var/obj/machinery/disposal/D, var/mob/user)
+	return TRUE
+
+
+//Trashbag is emptied in, but doesnt go in itself
+/obj/item/weapon/storage/bag/trash/attempt_dispose(var/obj/machinery/disposal/D, var/mob/user)
+	to_chat(user, "<span class='notice'>You empty the bag.</span>")
+	for(var/obj/item/O in contents)
+		if (O.attempt_dispose(D, user))
+			remove_from_storage(O,D)
+	D.update_icon()
+	return FALSE

--- a/html/changelogs/markershards.yml
+++ b/html/changelogs/markershards.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Attempting to place a marker shard into a disposal now causes interesting results!"
+  - tweak: "Marker shards now deploy as soon as the marker activates, if they've been still long enough"
+  - bugfix: "Fixed shards inside objects not growing corruption properly."


### PR DESCRIPTION
Closes #673

changes: 
  - rscadd: "Attempting to place a marker shard into a disposal now causes interesting results!"
  - tweak: "Marker shards now deploy as soon as the marker activates, if they've been still long enough"
  - bugfix: "Fixed shards inside objects not growing corruption properly."