### PR TITLE
Vector Pooling

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2960,6 +2960,7 @@
 #include "lib\vector2\CommonVectors.dm"
 #include "lib\vector2\Vector2.dm"
 #include "lib\vector2\Vector2Matrix.dm"
+#include "lib\vector2\vectorpool.dm"
 #include "lib\viewporttoworldpoint\ViewportToWorldPoint.dm"
 #include "maps\_map_include.dm"
 #include "maps\away\away_sites.dm"

--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -149,6 +149,8 @@
 	var/vector2/BL = bound_offsets["BL"]
 	if (delta.x < BL.x || delta.y < BL.y)
 		//Its offscreen
+		release_vector(delta)
+		release_vector_assoc_list(bound_offsets)
 		return
 
 
@@ -156,13 +158,14 @@
 	var/vector2/TR = bound_offsets["TR"]
 	if (delta.x > TR.x || delta.y > TR.y)
 		//Its offscreen
+		release_vector(delta)
+		release_vector_assoc_list(bound_offsets)
 		return
 
 
 
 	release_vector(delta)
-	release_vector(BL)
-	release_vector(TR)
+	release_vector_assoc_list(bound_offsets)
 	//If we get here, the target is on our screen!
 	return TRUE
 

--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -77,7 +77,7 @@
 		var/saccade_distance = sqrt((get_view_length()**2)*2)	//Pythagoras helps us find the distance of the saccade. Hypotenuse = square root of A squared + B squared
 		saccade_time *= saccade_distance
 		animate(src, pixel_x = offset.x, pixel_y = offset.y, time = saccade_time, easing = SINE_EASING)
-
+	release_vector(offset)
 
 
 
@@ -143,7 +143,7 @@
 
 	//Lets get how far the screen extends around the origin
 	var/list/bound_offsets = get_tile_bounds(FALSE) //Cut off partial tiles or they might stretch the screen
-	var/vector2/delta = new /vector2(A.x - origin.x, A.y - origin.y)	//Lets get the position delta from origin to target
+	var/vector2/delta = get_new_vector(A.x - origin.x, A.y - origin.y)	//Lets get the position delta from origin to target
 	//Now check whether or not that would put it onscreen
 	//Bottomleft first
 	var/vector2/BL = bound_offsets["BL"]
@@ -159,6 +159,10 @@
 		return
 
 
+
+	release_vector(delta)
+	release_vector(BL)
+	release_vector(TR)
 	//If we get here, the target is on our screen!
 	return TRUE
 

--- a/code/_helpers/geometry/angle.dm
+++ b/code/_helpers/geometry/angle.dm
@@ -7,6 +7,7 @@
 	direction = direction.Normalized()
 	var/angle = direction.AngleFrom(Vector2.North)
 	angle = round(angle, 90)
+	release_vector(direction)
 	return turn(NORTH, angle)
 
 //duplicated code for speed
@@ -18,4 +19,5 @@
 	var/angle = direction.AngleFrom(Vector2.North)
 	angle = round(angle, 90)
 	var/stepdir = turn(NORTH, -angle)	//Minus angle because turn rotates counterclockwise
+	release_vector(direction)
 	return get_step(A, stepdir)

--- a/code/_helpers/geometry/angle.dm
+++ b/code/_helpers/geometry/angle.dm
@@ -4,7 +4,7 @@
 	var/vector2/direction = get_new_vector(B.x - A.x, B.y - A.y)
 	if (!direction.NonZero())	//Error!
 		return SOUTH	//Default value in case of emergencies
-	direction = direction.Normalized()
+	direction.SelfNormalize()
 	var/angle = direction.AngleFrom(Vector2.North)
 	angle = round(angle, 90)
 	release_vector(direction)
@@ -15,7 +15,7 @@
 	var/vector2/direction = get_new_vector(B.x - A.x, B.y - A.y)
 	if (!direction.NonZero())	//Error!
 		return get_step(A, SOUTH)	//Default value in case of emergencies
-	direction = direction.Normalized()
+	direction.SelfNormalize()
 	var/angle = direction.AngleFrom(Vector2.North)
 	angle = round(angle, 90)
 	var/stepdir = turn(NORTH, -angle)	//Minus angle because turn rotates counterclockwise

--- a/code/_helpers/geometry/angle.dm
+++ b/code/_helpers/geometry/angle.dm
@@ -1,7 +1,7 @@
 //Returns the direction from A to B, rounded to the nearest cardinal
 //Doing this repeatedly can be used to trace a stair-pattern path towards diagonal objects
 /proc/get_cardinal_dir(atom/A, atom/B)
-	var/vector2/direction = new /vector2(B.x - A.x, B.y - A.y)
+	var/vector2/direction = get_new_vector(B.x - A.x, B.y - A.y)
 	if (!direction.NonZero())	//Error!
 		return SOUTH	//Default value in case of emergencies
 	direction = direction.Normalized()
@@ -11,7 +11,7 @@
 
 //duplicated code for speed
 /proc/get_cardinal_step_towards(atom/A, atom/B)
-	var/vector2/direction = new /vector2(B.x - A.x, B.y - A.y)
+	var/vector2/direction = get_new_vector(B.x - A.x, B.y - A.y)
 	if (!direction.NonZero())	//Error!
 		return get_step(A, SOUTH)	//Default value in case of emergencies
 	direction = direction.Normalized()

--- a/code/_helpers/geometry/cone.dm
+++ b/code/_helpers/geometry/cone.dm
@@ -70,6 +70,8 @@
 
 		subcone_direction = subcone_direction.Turn(subcone_angle)
 
+	//We only release vectors we created, not those we were given
+	release_vector(subcone_direction)
 	return subcones
 
 //Runs get cone and then picks a random tile from it

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -960,9 +960,9 @@ proc/generate_image(var/tx as num, var/ty as num, var/tz as num, var/range as nu
 
 /atom/proc/get_icon_size()
 	var/icon/I = new(icon)
-	return new /vector2(I.Width(), I.Height())
+	return get_new_vector(I.Width(), I.Height())
 
 
 /mob/living/carbon/human/get_icon_size()
 	var/icon/I = new(species.icon_template)
-	return new /vector2(I.Width(), I.Height())
+	return get_new_vector(I.Width(), I.Height())

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -228,6 +228,9 @@ Checks if a list has the same entries and values as an element of big.
 		return picked
 	return null
 
+//Macro version of pop, no safety checks, ultra fast. Pass in list, and variable to recieve the function
+#define macropop(L, A)	A = L[length(L)];L.len--;
+
 //Returns the bottom(first) element from the list and removes it from the list (typical stack function)
 /proc/antipop(list/listfrom)
 	if (listfrom.len > 0)

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -232,8 +232,8 @@
 
 	var/vector2/endpoint = origin + ray
 
-	var/vector2/linemin = new /vector2(min(origin.x, endpoint.x), min(origin.y, endpoint.y))
-	var/vector2/linemax = new /vector2(max(origin.x, endpoint.x), max(origin.y, endpoint.y))
+	var/vector2/linemin = get_new_vector(min(origin.x, endpoint.x), min(origin.y, endpoint.y))
+	var/vector2/linemax = get_new_vector(max(origin.x, endpoint.x), max(origin.y, endpoint.y))
 	ray = linemax - linemin
 
 

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -216,7 +216,9 @@
 
 	//This gets us the centre of the turf
 	var/vector2/LL = target.get_global_pixel_loc()
-	var/vector2/UR = new (LL)	//Copy it
+	var/vector2/UR = get_new_vector(LL.x, LL.y)	//Copy it
+
+
 	//We subtract 16 from X and Y to get to the lowerleft corner
 	LL.x -= WORLD_ICON_SIZE / 2
 	LL.y -= WORLD_ICON_SIZE / 2
@@ -268,6 +270,13 @@
 	var/vector2/exit = linemin + (ray * max_intersect)
 
 	var/list/intersections = list(entry, exit)
+
+	//Oof, this is way too many vectors to be working with
+	release_vector(LL)
+	release_vector(UR)
+	release_vector(endpoint)
+	release_vector(linemin)
+	release_vector(linemax)
 
 	return intersections
 

--- a/code/_helpers/matrices.dm
+++ b/code/_helpers/matrices.dm
@@ -29,11 +29,11 @@
 
 /atom/proc/custom_shake_animation(var/rotation = 15, var/offset = 3, var/time = 10, var/y_offset = TRUE, var/parallel = TRUE)
 	var/initial_transform = new/matrix(transform)
-	var/vector2/init_px = new /vector2(pixel_x, pixel_y)
+	var/vector2/init_px = get_new_vector(pixel_x, pixel_y)
 
 	var/shake_dir = pick(-1, 1)
 
-	var/vector2/newpix = new /vector2(init_px.x, init_px.y)
+	var/vector2/newpix = get_new_vector(init_px.x, init_px.y)
 	newpix.x += offset * pick(-1, 1)
 	if (y_offset)
 		newpix.y += offset * pick(-1, 1)
@@ -57,7 +57,7 @@
 
 		var/px_y = rand(0, strength*world.icon_size) * pick(-1, 1)
 		var/px_x = rand(0, strength*world.icon_size) * pick(-1, 1)
-		var/vector2/init_px = new /vector2(M.client.pixel_x, M.client.pixel_y)
+		var/vector2/init_px = get_new_vector(M.client.pixel_x, M.client.pixel_y)
 		animate(M.client, pixel_x=init_px.x + px_x, pixel_y=init_px.y + px_y, time=1,flags = ANIMATION_PARALLEL)
 		animate(pixel_x=init_px.x, pixel_y=init_px.y, time=duration, easing=ELASTIC_EASING)
 
@@ -162,9 +162,9 @@
 //Speed is in metres (tiles) per second
 //Client lag is a divisor on client animation time. Lower values will cause it to take longer to catch up with the mob, this is a cool effect for conveying speed
 /proc/animate_movement(var/atom/movable/mover, var/atom/target, var/speed, var/client_lag = 1.0)
-	var/vector2/target_pixel_loc = target.get_global_pixel_loc() + new /vector2(mover.default_pixel_x, mover.default_pixel_y)
+	var/vector2/target_pixel_loc = target.get_global_pixel_loc() + get_new_vector(mover.default_pixel_x, mover.default_pixel_y)
 	var/vector2/pixel_delta = mover.get_global_pixel_loc() - target_pixel_loc //This is an inverse delta that gives the offset FROM target TO mover
-	var/vector2/cached_pixels = new /vector2(mover.default_pixel_x, mover.default_pixel_y)
+	var/vector2/cached_pixels = get_new_vector(mover.default_pixel_x, mover.default_pixel_y)
 	var/pixel_distance = pixel_delta.Magnitude()
 	var/pixels_per_decisecond = (world.icon_size * speed) * 0.1
 
@@ -176,7 +176,7 @@
 	if (C)
 		L = mover
 		L.lock_view = TRUE
-		cached_client_pixels = new /vector2(C.pixel_x, C.pixel_y)
+		cached_client_pixels = get_new_vector(C.pixel_x, C.pixel_y)
 
 
 	//Okay, lets set ourselves there

--- a/code/_helpers/pixels.dm
+++ b/code/_helpers/pixels.dm
@@ -6,7 +6,7 @@
 		given by the "params" argument of the mouse events.
 	*/
 	var global/regex/ScreenLocRegex = regex("(\\d+):(\\d+),(\\d+):(\\d+)")
-	var/vector2/position = new /vector2(0,0)
+	var/vector2/position = get_new_vector(0,0)
 	if(ScreenLocRegex.Find(screen_loc))
 		var list/data = ScreenLocRegex.group
 		//position.x = text2num(data[2]) + (text2num(data[1])) * world.icon_size
@@ -21,7 +21,7 @@
 /proc/get_global_pixel_click_location(var/params, var/client/client)
 
 	if (!client)
-		return new /vector2(0,0)
+		return get_new_vector(0,0)
 
 	var/vector2/world_loc
 
@@ -52,7 +52,7 @@
 
 
 /atom/proc/get_global_pixel_loc()
-	return new /vector2(((x-1)*world.icon_size) + pixel_x + 16, ((y-1)*world.icon_size) + pixel_y + 16)
+	return get_new_vector(((x-1)*world.icon_size) + pixel_x + 16, ((y-1)*world.icon_size) + pixel_y + 16)
 
 /atom/proc/get_global_pixel_offset(var/atom/from)
 	var/vector2/ourloc = get_global_pixel_loc()
@@ -68,7 +68,7 @@
 //Given a set of global pixel coords as input, this moves the atom and sets its pixel offsets so that it sits exactly on the specified point
 /atom/movable/proc/set_global_pixel_loc(var/vector2/coords)
 
-	var/vector2/tilecoords = new /vector2(round(coords.x / world.icon_size)+1, round(coords.y / world.icon_size)+1)
+	var/vector2/tilecoords = get_new_vector(round(coords.x / world.icon_size)+1, round(coords.y / world.icon_size)+1)
 	forceMove(locate(tilecoords.x, tilecoords.y, z))
 	pixel_x = (coords.x % world.icon_size)-16
 	pixel_y = (coords.y % world.icon_size)-16
@@ -101,7 +101,7 @@
 //This does not account for the object's existing pixel offsets, roll them into the input first if you wish
 /atom/proc/get_turf_at_pixel_offset(var/vector2/newpix)
 	//First lets just get the global pixel position of where this atom+newpix is
-	var/vector2/new_global_pixel_loc = new /vector2(((x-1)*world.icon_size) + newpix.x + 16, ((y-1)*world.icon_size) + newpix.y + 16)
+	var/vector2/new_global_pixel_loc = get_new_vector(((x-1)*world.icon_size) + newpix.x + 16, ((y-1)*world.icon_size) + newpix.y + 16)
 
 	return get_turf_at_pixel_coords(new_global_pixel_loc, z)
 
@@ -109,7 +109,7 @@
 
 //Global version of the above, requires a zlevel to check on
 /proc/get_turf_at_pixel_coords(var/vector2/coords, var/zlevel)
-	coords = new /vector2(round(coords.x / world.icon_size)+1, round(coords.y / world.icon_size)+1)
+	coords = get_new_vector(round(coords.x / world.icon_size)+1, round(coords.y / world.icon_size)+1)
 	return locate(coords.x, coords.y, zlevel)
 
 /proc/get_turf_at_mouse(var/clickparams, var/client/C)
@@ -142,7 +142,7 @@
 
 //This proc gets the client's total pixel offset from its eyeobject
 /client/proc/get_pixel_offset()
-	var/vector2/offset = new /vector2(0,0)
+	var/vector2/offset = get_new_vector(0,0)
 	if (ismob(eye))
 		var/mob/M = eye
 		offset = (Vector2.FromDir(M.dir))*M.view_offset
@@ -156,8 +156,8 @@
 //Figures out the offsets of the bottomleft and topright corners of the game window
 /client/proc/get_pixel_bounds()
 	var/radius = view*world.icon_size
-	var/vector2/bottomleft = new /vector2(-radius, -radius)
-	var/vector2/topright = new /vector2(radius, radius)
+	var/vector2/bottomleft = get_new_vector(-radius, -radius)
+	var/vector2/topright = get_new_vector(radius, radius)
 	var/vector2/offset = get_pixel_offset()
 	bottomleft += offset
 	topright += offset
@@ -226,7 +226,7 @@
 /atom/movable/proc/pixel_move(var/vector2/position_delta, var/time_delta)
 
 	//Now before we do animating, lets check if this movement is going to put us into a different tile
-	var/vector2/newpix = new /vector2((pixel_x + position_delta.x), (pixel_y + position_delta.y))
+	var/vector2/newpix = get_new_vector((pixel_x + position_delta.x), (pixel_y + position_delta.y))
 	var/blocked = FALSE
 	.=TRUE
 	if (is_outside_cell(newpix))

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -222,3 +222,13 @@
 else\
 {\
 BITSET(mobref.hud_updateflag, hudtype)}
+
+
+#define VECTOR_POOL_MAX	1000
+#define VECTOR_POOL_FULL	200
+#define VECTOR_POOL_MIN	25
+
+#define release_vector(A)	if (GLOB.vector_pool.len < VECTOR_POOL_MAX){A.x = 0;\
+A.y = 0;\
+GLOB.vector_pool += A;}\
+A = null;

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -227,11 +227,13 @@ BITSET(mobref.hud_updateflag, hudtype)}
 #define VECTOR_POOL_MAX	10000
 #define VECTOR_POOL_FULL	2000
 
-#define release_vector(A)	if (GLOB.vector_pool.len < VECTOR_POOL_MAX){A.x = 0;\
-A.y = 0;\
+#define release_vector(A)	if (length(GLOB.vector_pool) < VECTOR_POOL_MAX){\
 GLOB.vector_pool += A;}\
 A = null;
 
 
 #define release_vector_list(A)	for (var/vector2/v in A) {release_vector(v)}\
+A = null;
+
+#define release_vector_assoc_list(A)	for (var/b in A) {release_vector(A[b])}\
 A = null;

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -224,11 +224,14 @@ else\
 BITSET(mobref.hud_updateflag, hudtype)}
 
 
-#define VECTOR_POOL_MAX	1000
-#define VECTOR_POOL_FULL	200
-#define VECTOR_POOL_MIN	25
+#define VECTOR_POOL_MAX	10000
+#define VECTOR_POOL_FULL	2000
 
 #define release_vector(A)	if (GLOB.vector_pool.len < VECTOR_POOL_MAX){A.x = 0;\
 A.y = 0;\
 GLOB.vector_pool += A;}\
+A = null;
+
+
+#define release_vector_list(A)	for (var/vector2/v in A) {release_vector(v)}\
 A = null;

--- a/code/_onclick/click_handlers/placement.dm
+++ b/code/_onclick/click_handlers/placement.dm
@@ -32,6 +32,10 @@ GLOBAL_LIST_EMPTY(placement_previews)
 	.=..()
 
 
+/datum/click_handler/placement/Destroy()
+	release_vector(pixel_offset)
+	.=..()
+
 //Starting and finishing
 //---------------------------------------
 /datum/click_handler/placement/proc/start_placement()

--- a/code/_onclick/click_handlers/placement.dm
+++ b/code/_onclick/click_handlers/placement.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_EMPTY(placement_previews)
 	var/result_path		//The atom we'll spawn when placement is successful
 	var/snap_to_grid	//If true, the preview will snap to the centre of whatever tile the user hovers over
 	var/stopped = FALSE	//Used to prevent running stop code twice
-	var/vector2/pixel_offset = new /vector2(0,0)	//Is our preview image offset from the mouse cursor?
+	var/vector2/pixel_offset	//Is our preview image offset from the mouse cursor?
 	var/turf/last_location
 	var/rotate_angle = 90
 	flags = CLICK_HANDLER_REMOVE_ON_MOB_LOGOUT
@@ -28,6 +28,7 @@ GLOBAL_LIST_EMPTY(placement_previews)
 /datum/click_handler/placement/New(var/mob/user, var/datum/callback/C)
 	if (C)
 		call_on_place = C
+	pixel_offset = get_new_vector(0,0)
 	.=..()
 
 
@@ -154,7 +155,8 @@ GLOBAL_LIST_EMPTY(placement_previews)
 		preview = new /atom/movable()
 		var/atom/A = new path()
 		if (!snap_to_grid)
-			pixel_offset = new /vector2/(-WORLD_ICON_SIZE/2, -WORLD_ICON_SIZE/2) //Offset should be at least -16,-16 to center the icon.
+			pixel_offset.x = -WORLD_ICON_SIZE/2
+			pixel_offset.y = -WORLD_ICON_SIZE/2 //Offset should be at least -16,-16 to center the icon.
 		pixel_offset.x += A.pixel_x
 		pixel_offset.y += A.pixel_y
 		preview.appearance = A.appearance

--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -54,7 +54,7 @@
 		//Buffer is added to our own position, because we're position+buffer away from the lower sides
 		//Buffer is added TWICE to the world maxx/y values, because the percentage is measured as a whole along that line
 		//Because of the buffer, neither of the values will ever be 0 or 1
-		var/vector2/locpercent = new /vector2(
+		var/vector2/locpercent = get_new_vector(
 		(skybox.buffer_tiles + T.x) / (world.maxx + skybox.buffer_tiles*2),
 		(skybox.buffer_tiles + T.y) / (world.maxy + skybox.buffer_tiles*2)
 		)

--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -64,7 +64,7 @@
 		locpercent.x -= 1
 		locpercent.y -= 1
 		skybox.screen_loc = "CENTER:[round(skybox.base_offset + (skybox.slide_range * locpercent.x))],CENTER:[round(skybox.base_offset + (skybox.slide_range* locpercent.y))]"
-
+		release_vector(locpercent)
 
 /mob/Login()
 	..()

--- a/code/_onclick/hud/tracker.dm
+++ b/code/_onclick/hud/tracker.dm
@@ -105,6 +105,7 @@
 		//Its offscreen
 		hide()
 		release_vector(delta)
+		release_vector_assoc_list(bound_offsets)
 		return
 
 
@@ -114,14 +115,16 @@
 		//Its offscreen
 		hide()
 		release_vector(delta)
+		release_vector_assoc_list(bound_offsets)
 		return
 
 
 	//If we get here, the target is on our screen!
 	//Lets place it
-	delta += bound_offsets["OFFSET"]
+	delta.SelfAdd(bound_offsets["OFFSET"])
 	delta.x += C.view + 1
 	delta.y += C.view + 1
 	screen_loc = "[encode_screen_X(delta.x, origin)],[encode_screen_Y(delta.y,origin)]"
 	release_vector(delta)
+	release_vector_assoc_list(bound_offsets)
 	//AAaaand done

--- a/code/_onclick/hud/tracker.dm
+++ b/code/_onclick/hud/tracker.dm
@@ -97,7 +97,7 @@
 
 	//Lets get how far the screen extends around the origin
 	var/list/bound_offsets = C.get_tile_bounds(FALSE) //Cut off partial tiles or they might stretch the screen
-	var/vector2/delta = new /vector2(track_target.x - origin.x, track_target.y - origin.y)	//Lets get the position delta from origin to target
+	var/vector2/delta = get_new_vector(track_target.x - origin.x, track_target.y - origin.y)	//Lets get the position delta from origin to target
 	//Now check whether or not that would put it onscreen
 	//Bottomleft first
 	var/vector2/BL = bound_offsets["BL"]

--- a/code/_onclick/hud/tracker.dm
+++ b/code/_onclick/hud/tracker.dm
@@ -104,6 +104,7 @@
 	if (delta.x < BL.x || delta.y < BL.y)
 		//Its offscreen
 		hide()
+		release_vector(delta)
 		return
 
 
@@ -112,6 +113,7 @@
 	if (delta.x > TR.x || delta.y > TR.y)
 		//Its offscreen
 		hide()
+		release_vector(delta)
 		return
 
 
@@ -121,4 +123,5 @@
 	delta.x += C.view + 1
 	delta.y += C.view + 1
 	screen_loc = "[encode_screen_X(delta.x, origin)],[encode_screen_Y(delta.y,origin)]"
+	release_vector(delta)
 	//AAaaand done

--- a/code/datums/extensions/movement/conditional_move.dm
+++ b/code/datums/extensions/movement/conditional_move.dm
@@ -76,7 +76,7 @@
 
 
 /datum/extension/conditionalmove/pixel_align/conditional_move(var/atom/movable/am, var/atom/old_loc, var/atom/new_loc)
-	var/vector2/target_pixels = new /vector2(L.default_pixel_x, L.default_pixel_y)
+	var/vector2/target_pixels = get_new_vector(L.default_pixel_x, L.default_pixel_y)
 
 	//If we are at the target pixel coords, we are done
 	if (L.pixel_x == target_pixels.x && L.pixel_y == target_pixels.y)
@@ -84,6 +84,9 @@
 		return
 
 	//Alright, lets move towards them
-	var/vector2/delta = new /vector2(target_pixels.x - L.pixel_x, target_pixels.y - L.pixel_y)
+	var/vector2/delta = get_new_vector(target_pixels.x - L.pixel_x, target_pixels.y - L.pixel_y)
 	delta = delta.ClampMag(0, pixels_per_step)
 	animate(L, pixel_x = L.pixel_x + delta.x, pixel_y = L.pixel_y + delta.y, time = animate_time)
+
+	release_vector(delta)
+	release_vector(target_pixels)

--- a/code/datums/extensions/movement/conditional_move.dm
+++ b/code/datums/extensions/movement/conditional_move.dm
@@ -85,7 +85,7 @@
 
 	//Alright, lets move towards them
 	var/vector2/delta = get_new_vector(target_pixels.x - L.pixel_x, target_pixels.y - L.pixel_y)
-	delta = delta.ClampMag(0, pixels_per_step)
+	delta.SelfClampMag(0, pixels_per_step)
 	animate(L, pixel_x = L.pixel_x + delta.x, pixel_y = L.pixel_y + delta.y, time = animate_time)
 
 	release_vector(delta)

--- a/code/datums/extensions/wallmount.dm
+++ b/code/datums/extensions/wallmount.dm
@@ -95,7 +95,7 @@
 	.=..()
 	mountee = holder
 	mountpoint = target
-	offset = new /vector2(mountee.x - mountpoint.x,mountee.y - mountpoint.y)
+	offset = get_new_vector(mountee.x - mountpoint.x,mountee.y - mountpoint.y)
 	if (istype(target, /atom/movable))
 		GLOB.moved_event.register(mountpoint, src, /datum/extension/mount/proc/on_mountpoint_move)
 	GLOB.destroyed_event.register(mountpoint, src, /datum/extension/mount/proc/on_dismount)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -216,7 +216,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_analyse_health_panel,
 	/client/proc/visualpower,
 	/client/proc/visualpower_remove,
-	/client/proc/gc_stress
+	/client/proc/debug_vectorpool
 	)
 
 var/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/clothing/spacesuits/rig/modules/ds13/kinesis/fx.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ds13/kinesis/fx.dm
@@ -11,3 +11,7 @@
 
 /obj/effect/projectile/sustained/lightning/can_telegrip()
 	return FALSE
+
+/obj/effect/projectile/sustained/lightning/Destroy()
+	release_vector(offset)
+	.=..()

--- a/code/modules/clothing/spacesuits/rig/modules/ds13/kinesis/kinesis.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ds13/kinesis/kinesis.dm
@@ -297,7 +297,7 @@
 
 /obj/item/rig_module/kinesis/proc/grip(var/atom/movable/AM)
 
-	velocity = new /vector2(0,0)
+	velocity = get_new_vector(0,0)
 
 	subject = AM
 	subject.telegripped(src)	//Tell the object it was picked up
@@ -673,7 +673,7 @@
 
 //This proc actually adjusts the subject's position, based on the calculated velocity
 /obj/item/rig_module/kinesis/proc/move_subject(var/time_delta)
-	var/vector2/position_delta = new /vector2(velocity)	//Copy the velocity first, we don't want to modify it here
+	var/vector2/position_delta = get_new_vector(velocity)	//Copy the velocity first, we don't want to modify it here
 
 	//Velocity is in metres, we work in pixels, so lets convert it
 	position_delta *= WORLD_ICON_SIZE

--- a/code/modules/mob/living/abilities/brute_curl.dm
+++ b/code/modules/mob/living/abilities/brute_curl.dm
@@ -66,7 +66,7 @@
 	user.play_species_audio(user, SOUND_PAIN, 60, 1)
 
 	//Lets cache some data too
-	cached_pixels = new /vector2(user.pixel_x, user.pixel_y)
+	cached_pixels = get_new_vector(user.pixel_x, user.pixel_y)
 	cached_transform = user.transform
 	cached_view_range = user.view_range
 	cached_view_offset = user.view_offset
@@ -126,6 +126,8 @@
 	spawn(animtime)
 		user.stunned = 0 //The user is now no longer stunned
 		status = FORCE_COOLDOWN
+
+	release_vector(cached_pixels)
 
 
 

--- a/code/modules/mob/living/abilities/charge.dm
+++ b/code/modules/mob/living/abilities/charge.dm
@@ -169,7 +169,7 @@
 	else
 		//Note: This may fail near the map edge, if it overshoots world bounds. Tricky to fix, probably won't be a problem
 		var/vector2/delta = new(target.x - user.x, target.y - user.y)
-		delta = delta.ToMagnitude(max_range()+1)
+		delta.SelfToMagnitude(max_range()+1)
 		var/turf/target_turf = locate(user.x + delta.x, user.y + delta.y, user.z)
 		if (target_turf)
 			move_target = target_turf

--- a/code/modules/mob/living/abilities/leaper_tailstrike.dm
+++ b/code/modules/mob/living/abilities/leaper_tailstrike.dm
@@ -64,7 +64,7 @@
 		L.Stun(stuntime, TRUE) //Passing true here bypasses species resistance
 
 	//Here we start the windup.
-	cached_pixels = new /vector2(user.pixel_x, user.pixel_y)
+	cached_pixels = get_new_vector(user.pixel_x, user.pixel_y)
 	cached_transform = user.transform
 
 
@@ -111,7 +111,8 @@
 	//Start a timer to do the finishing hit
 	tailstrike_timer = addtimer(CALLBACK(src, .proc/finish), windup_time, TIMER_STOPPABLE)
 
-
+	release_vector(cached_pixels)
+	release_vector(pixel_offset)
 
 
 /datum/extension/tailstrike/proc/finish()

--- a/code/modules/mob/living/abilities/lunge.dm
+++ b/code/modules/mob/living/abilities/lunge.dm
@@ -16,10 +16,10 @@
 	var/mob/living/M = user
 	M.face_atom(get_turf(_target))
 	var/vector2/pixel_offset = Vector2.DirectionBetween(user, _target) * -24
-	cached_pixels = new /vector2(user.pixel_x, user.pixel_y)
+	cached_pixels = get_new_vector(user.pixel_x, user.pixel_y)
 	animate(user, pixel_x = user.pixel_x + pixel_offset.x, pixel_y = user.pixel_y + pixel_offset.y, time = delay, easing = BACK_EASING)
 
-
+	release_vector(cached_pixels)
 
 /datum/extension/charge/lunge/start()
 	animate(user, pixel_y = cached_pixels.y, pixel_x = cached_pixels.x, time = 0.5 SECONDS, easing = BACK_EASING)

--- a/code/modules/mob/living/abilities/particles/particle.dm
+++ b/code/modules/mob/living/abilities/particles/particle.dm
@@ -34,6 +34,7 @@
 	src.direction = direction
 	if (direction)
 		transform = direction.Rotation()
+		release_vector(direction)
 
 	if (color)
 		src.color = color
@@ -68,3 +69,8 @@
 	time = lifespan,
 	flags = ANIMATION_LINEAR_TRANSFORM)
 
+
+/obj/effect/particle/Destroy()
+	release_vector(destination_pixels)
+	release_vector(origin_pixels)
+	.=..()

--- a/code/modules/mob/living/abilities/particles/system.dm
+++ b/code/modules/mob/living/abilities/particles/system.dm
@@ -58,7 +58,7 @@
 	//Lets calculate a random angle for this particle
 	var/particle_angle = rand_between(0, angle) - angle*0.5	//We subtract half the angle to centre it
 	var/particle_direction = direction.Turn(particle_angle)
-	var/vector2/offset = new /vector2(rand_between(-randpixel, randpixel), rand_between(-randpixel, randpixel))
+	var/vector2/offset = get_new_vector(rand_between(-randpixel, randpixel), rand_between(-randpixel, randpixel))
 	var/obj/effect/particle/S = new particle_type(loc, particle_direction, particle_lifetime, particle_travel_distance, offset, particle_color)
 
 	return S

--- a/code/modules/mob/living/abilities/slam.dm
+++ b/code/modules/mob/living/abilities/slam.dm
@@ -57,7 +57,7 @@
 		L.Stun(stuntime, TRUE) //Passing true here bypasses species resistance
 
 	//Here we start the windup.
-	cached_pixels = new /vector2(user.pixel_x, user.pixel_y)
+	cached_pixels = get_new_vector(user.pixel_x, user.pixel_y)
 
 
 

--- a/code/modules/mob/living/abilities/wallrun.dm
+++ b/code/modules/mob/living/abilities/wallrun.dm
@@ -526,7 +526,7 @@
 		var/vector2/current_wall_normal = get_new_vector(mover.x - mountpoint.x, mover.y - mountpoint.y)
 
 		//Lets get the direction of the target now
-		var/vector2/desired_dir = Vector2.FromDir(new_dir)
+		var/vector2/desired_dir = Vector2.FromDir(new_dir)	//This is working with a preexisting global, should NOT be released
 
 		//Alright next up, we get the angle between these two
 		var/desired_angle = desired_dir.AngleFrom(current_wall_normal)
@@ -537,7 +537,6 @@
 		var/actual_dir = turn(SOUTH, desired_angle)
 		A.dir = actual_dir
 		release_vector(current_wall_normal)
-		release_vector(desired_dir)
 	visual_dir = new_dir
 
 

--- a/code/modules/mob/living/abilities/wallrun.dm
+++ b/code/modules/mob/living/abilities/wallrun.dm
@@ -146,7 +146,9 @@
 //This cannot fail, make sure safety checks are done already
 /datum/extension/wallrun/proc/mount_to_atom(var/atom/target)
 	mountpoint = target
-	offset = new /vector2(A.x - target.x, A.y - target.y)
+	if (offset)
+		release_vector(offset)
+	offset = get_new_vector(A.x - target.x, A.y - target.y)
 
 	if (istype(mountpoint, /atom/movable))
 		GLOB.moved_event.register(mountpoint, src, /datum/extension/wallrun/proc/on_mountpoint_move)
@@ -172,8 +174,7 @@
 	A.default_rotation = mount_angle
 
 
-	var/vector2/newpix = centre_offset	//The centre offset is used flatly without rotation
-	newpix += base_offset.Turn(mount_angle)	//The base offset is used with rotation
+	var/vector2/newpix = (centre_offset + base_offset.Turn(mount_angle))	//The base offset is used with rotation
 
 	A.default_pixel_x = newpix.x
 	A.default_pixel_y = newpix.y
@@ -184,7 +185,7 @@
 	animate(A, transform = A.get_default_transform(), alpha = A.default_alpha, pixel_x = A.default_pixel_x, pixel_y = A.default_pixel_y, time = mount_time, easing = BACK_EASING)
 
 
-
+	release_vector(newpix)
 
 
 
@@ -276,7 +277,7 @@
 
 
 /datum/extension/wallrun/proc/cache_data()
-	cached_pixels = new /vector2(A.default_pixel_x, A.default_pixel_y)
+	cached_pixels = get_new_vector(A.default_pixel_x, A.default_pixel_y)
 	default_rotation = A.default_rotation
 	cached_alpha = A.default_alpha
 	cached_passflags = A.pass_flags
@@ -292,13 +293,14 @@
 
 		//We cut the size in half and then subtract 16,16, which is the centre of a normal 32x32 tile.
 		size *= 0.5
-		size -= new /vector2(WORLD_ICON_SIZE * 0.5, WORLD_ICON_SIZE * 0.5)
+		size -= get_new_vector(WORLD_ICON_SIZE * 0.5, WORLD_ICON_SIZE * 0.5)
 		centre_offset = size*-1
 
 		//Base offset is simple. Its just the inverted Y offset and no X
 		base_offset = size
 		base_offset.x = 0
 		base_offset.y += pixel_offset_magnitude //We can add in the pixel offset here for efficiency too
+		release_vector(size)
 
 /datum/extension/wallrun/proc/unmount_animation()
 	//Visuals
@@ -521,7 +523,7 @@
 /datum/extension/wallrun/proc/dir_set(var/atom/mover, var/old_dir, var/new_dir)
 	if (mountpoint)
 		//We get the normal direction of the wall
-		var/vector2/current_wall_normal = new /vector2(mover.x - mountpoint.x, mover.y - mountpoint.y)
+		var/vector2/current_wall_normal = get_new_vector(mover.x - mountpoint.x, mover.y - mountpoint.y)
 
 		//Lets get the direction of the target now
 		var/vector2/desired_dir = Vector2.FromDir(new_dir)
@@ -534,6 +536,8 @@
 
 		var/actual_dir = turn(SOUTH, desired_angle)
 		A.dir = actual_dir
+		release_vector(current_wall_normal)
+		release_vector(desired_dir)
 	visual_dir = new_dir
 
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -309,7 +309,7 @@
 //Altitude is how high the plane is off the ground
 //Height is how tall the plane is
 /mob/living/carbon/human/proc/get_limbs_at_height(var/altitude, var/height = 0.01)
-	var/vector2/ourheight = new /vector2(altitude, altitude+height)
+	var/vector2/ourheight = get_new_vector(altitude, altitude+height)
 
 	var/list/limbs = list()
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -207,7 +207,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	//Do a chargeup animation. Pulls back and then launches forwards
 	//The time is equal to the windup time of the attack, plus 0.5 seconds to prevent a brief stop and ensure launching is a fluid motion
 	var/vector2/pixel_offset = Vector2.DirectionBetween(src, A) * -16
-	var/vector2/cached_pixels = new /vector2(src.pixel_x, src.pixel_y)
+	var/vector2/cached_pixels = get_new_vector(src.pixel_x, src.pixel_y)
 	animate(src, pixel_x = src.pixel_x + pixel_offset.x, pixel_y = src.pixel_y + pixel_offset.y, time = 1.5 SECONDS, easing = BACK_EASING, flags = ANIMATION_PARALLEL)
 	animate(pixel_x = cached_pixels.x, pixel_y = cached_pixels.y, time = 0.3 SECONDS)
 
@@ -232,7 +232,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 
 	//Do a chargeup animation
 	var/vector2/pixel_offset = Vector2.DirectionBetween(src, A) * -16
-	var/vector2/cached_pixels = new /vector2(src.pixel_x, src.pixel_y)
+	var/vector2/cached_pixels = get_new_vector(src.pixel_x, src.pixel_y)
 	animate(src, pixel_x = src.pixel_x + pixel_offset.x, pixel_y = src.pixel_y + pixel_offset.y, time = 0.7 SECONDS, easing = BACK_EASING, flags = ANIMATION_PARALLEL)
 	animate(pixel_x = cached_pixels.x, pixel_y = cached_pixels.y, time = 0.3 SECONDS)
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
@@ -310,7 +310,7 @@ The Lurker can only fire spines while its shell is open"
 	var/windup_anim_time = windup_time - fire_time
 
 	//Here we start the windup.
-	cached_pixels = new /vector2(user.pixel_x, user.pixel_y)
+	cached_pixels = get_new_vector(user.pixel_x, user.pixel_y)
 
 	x_direction = 0
 	//If the target is offset on our X axis, we'll have an extra factor on the animation
@@ -331,7 +331,7 @@ The Lurker can only fire spines while its shell is open"
 	animate(user, transform=turn(matrix(), user.default_rotation +(30*x_direction)), pixel_y = cached_pixels.y-6, pixel_x = cached_pixels.x + 22*x_direction, time = fire_time, easing = BACK_EASING, flags = ANIMATION_PARALLEL)
 	animate(transform=turn(matrix(), user.default_rotation), pixel_y = cached_pixels.y, pixel_x = cached_pixels.x, time = 5)	//Afterwards, reset to normal position
 	sleep(fire_time)
-
+	release_vector(cached_pixels)
 
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -28,8 +28,8 @@
 
 	//Slashers hold their arms up in an overhead pose, so they override height too
 	override_limb_types = list(
-	BP_L_ARM =  list("path" = /obj/item/organ/external/arm/blade, "height" = (new /vector2(1.6,2))),
-	BP_R_ARM =  list("path" = /obj/item/organ/external/arm/blade/right, "height" = (new /vector2(1.6,2)))
+	BP_L_ARM =  list("path" = /obj/item/organ/external/arm/blade, "height" = new /vector2(1.6,2)),
+	BP_R_ARM =  list("path" = /obj/item/organ/external/arm/blade/right, "height" = new /vector2(1.6,2))
 	)
 
 	hud_type = /datum/hud_data/necromorph/slasher

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -162,12 +162,14 @@ All of these properties combined make Step Strike tricky and disorienting to use
 			if (get_dist(src, A) <= 2)
 				return	//Can't do this if we're too close
 
-			var/vector2/delta = new /vector2(A.x - x, A.y - y)
+			var/vector2/delta = get_new_vector(A.x - x, A.y - y)
 			delta = delta.ToMagnitude(3)
 			var/turf/blink_target = locate(x+delta.x, y+delta.y, z)
 			if (blink_target)
 				var/datum/extension/twitch/T = get_extension(src, /datum/extension/twitch)
 				T.move_to(blink_target, speed = 12)
+
+			release_vector(delta)
 
 
 

--- a/code/modules/necromorph/corruption/cyst.dm
+++ b/code/modules/necromorph/corruption/cyst.dm
@@ -127,6 +127,8 @@
 		else
 			target_atom = infront //fallback incase of failure
 
+		release_vector(delta)
+
 	QDEL_NULL(payload)	//Delete the payload, so we don't fire again
 
 	//Fire the bomb!
@@ -235,7 +237,7 @@
 	if (mount_target)
 		pixel_offset = last_location.get_offset_to(mount_target, CYST_ATTACH_OFFSET)
 	else
-		pixel_offset = new /vector2(0,0)
+		pixel_offset = get_new_vector(0,0)
 
 
 /*
@@ -299,4 +301,4 @@
 	if (mount_target)
 		pixel_offset = last_location.get_offset_to(mount_target, CYST_ATTACH_OFFSET)
 	else
-		pixel_offset = new /vector2(0,0)
+		pixel_offset = get_new_vector(0,0)

--- a/code/modules/necromorph/corruption_source.dm
+++ b/code/modules/necromorph/corruption_source.dm
@@ -149,7 +149,6 @@
 //-------------------------
 //Called when we're first created, this examines all the existing nearby corruption vines.
 /datum/extension/corruption_source/proc/evaluate_existing()
-	var/list/sources_to_update = list()
 
 	for (var/obj/effect/vine/corruption/C as anything in get_reachable())
 		//We'll take control of any that lack a source regardless of anything else

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -151,6 +151,8 @@
 
 	if(autopsy_data)    autopsy_data.Cut()
 
+	release_vector(limb_height)
+
 	return ..()
 
 /obj/item/organ/external/set_dna(var/datum/dna/new_dna)

--- a/code/modules/projectiles/effects.dm
+++ b/code/modules/projectiles/effects.dm
@@ -214,8 +214,8 @@
 	icon_state = "gravity_tether"
 
 	//Start and endpoints are in world pixel coordinates
-	var/vector2/start
-	var/vector2/end
+	var/vector2/start = new /vector2(0,0)
+	var/vector2/end = new /vector2(0,0)
 	var/vector2/offset = new /vector2(0,0)
 	animate_movement = 0
 	lifespan = 0
@@ -223,12 +223,11 @@
 
 //Takes start and endpoint as vector2s of global pixel coords
 /obj/effect/projectile/sustained/proc/set_ends(var/vector2/_start = null, var/vector2/_end = null)
-	if (_start != start)
-		start = _start// + offset
+	start.x = _start.x
+	start.y = _start.y
 
-	if (_end != end)
-		end = _end// + offset
-
+	end.x = _end.x// + offset
+	end.y = _end.y
 
 
 	var/matrix/M = matrix()
@@ -252,9 +251,12 @@
 	set_global_pixel_loc(start + (delta*0.5) + offset)
 
 /obj/effect/projectile/sustained/Destroy()
-	release_vector(start)
-	release_vector(end)
-	release_vector(offset)
+	if (start)
+		release_vector(start)
+	if (end)
+		release_vector(end)
+	if (offset)
+		release_vector(offset)
 	.=..()
 
 

--- a/code/modules/projectiles/effects.dm
+++ b/code/modules/projectiles/effects.dm
@@ -252,6 +252,9 @@
 	set_global_pixel_loc(start + (delta*0.5) + offset)
 
 /obj/effect/projectile/sustained/Destroy()
+	release_vector(start)
+	release_vector(end)
+	release_vector(offset)
 	.=..()
 
 

--- a/code/modules/projectiles/guns/special/ripper/pixelmarkers.dm
+++ b/code/modules/projectiles/guns/special/ripper/pixelmarkers.dm
@@ -17,7 +17,7 @@
 
 //Sets the pixelmarker to be on the target pixel exactly
 /obj/effect/pixelmarker/set_global_pixel_loc(var/vector2/coords)
-	..(coords + new /vector2(16, 16))
+	..(coords + get_new_vector(16, 16))
 
 
 

--- a/code/modules/projectiles/guns/special/ripper/ripper.dm
+++ b/code/modules/projectiles/guns/special/ripper/ripper.dm
@@ -70,7 +70,7 @@
 		var/vector2/userdiff = last_clickpoint - user_loc
 		//If its farther than the max distance from the user
 		if (userdiff.Magnitude() > max_range)
-			userdiff = userdiff.ToMagnitude(max_range)//We rescale the magnitude of the diff
+			userdiff.SelfToMagnitude(max_range)//We rescale the magnitude of the diff
 			last_clickpoint = user_loc + userdiff //And change clickpoint to the rescaled
 
 		tether.set_ends(user_loc, last_clickpoint) //The tether points to the cursor, the blade catches up with it

--- a/code/modules/projectiles/guns/special/ripper/sawblade.dm
+++ b/code/modules/projectiles/guns/special/ripper/sawblade.dm
@@ -262,7 +262,7 @@
 
 
 	//Now before we do animating, lets check if this movement is going to put us into a different tile
-	var/vector2/newpix = new /vector2((pixel_x + diff.x), (pixel_y + diff.y))
+	var/vector2/newpix = get_new_vector((pixel_x + diff.x), (pixel_y + diff.y))
 	if (is_outside_cell(newpix))
 		//Yes it will, lets find that tile
 		var/turf/newtile = get_turf_at_pixel_offset(newpix)
@@ -298,6 +298,8 @@
 				set_global_pixel_loc(get_global_pixel_loc()) //This will move us into the tile while maintaining our global pixel coords
 
 	animate(src, pixel_x = newpix.x, pixel_y = newpix.y)
+	release_vector(newpix)
+	release_vector(diff)
 
 
 /obj/item/projectile/sawblade/proc/damage_turf()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -289,17 +289,17 @@
 	if (!direction)
 		return
 
-	base_dir = Vector2.FromDir(direction)
+	base_dir = Vector2.NewFromDir(direction)
 	base_dir = base_dir.Turn(rand_between(-angle, angle))
 
-	base_dir = base_dir.ToMagnitude(15) //Should be a long enough distance to get the angle right
+	base_dir.SelfToMagnitude(15) //Should be a long enough distance to get the angle right
 
 	//Before we redirect, move us into the bounceoff turf
 	last_loc = loc
 	loc = bounce_turf
 
 	redirect(bounceoff.x + base_dir.x, bounceoff.y + base_dir.y, bounce_turf)
-
+	release_vector(base_dir)
 
 #define CHECK_RESULT	if (last_result) { result = last_result; last_result = null}
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -102,6 +102,10 @@
 	alpha = 0
 	.=..()
 
+/obj/item/projectile/Destroy()
+	release_vector(pixel_click)
+	.=..()
+
 /obj/item/projectile/Initialize()
 	damtype = damage_type //TODO unify these vars properly
 	if(!hitscan)
@@ -113,7 +117,7 @@
 	. = ..()
 
 /obj/item/projectile/proc/set_pixel_offset()
-	var/vector2/newpixels = new /vector2(0,0)
+	var/vector2/newpixels = get_new_vector(0,0)
 	//Future todo: Get toplevel atom of firer
 	if (firer && isturf(firer.loc))
 		newpixels.x = firer.pixel_x
@@ -125,6 +129,7 @@
 
 	pixel_x = newpixels.x
 	pixel_y = newpixels.y
+	release_vector(newpixels)
 
 //Called when this projectile is to be deleted during normal gameplay, ie when it hits stuff
 /obj/item/projectile/proc/expire()

--- a/lib/vector2/CommonVectors.dm
+++ b/lib/vector2/CommonVectors.dm
@@ -34,13 +34,13 @@ Vector2
 	proc
 		//Gets a directional vector between two atoms
 		DirectionBetween(var/atom/A, var/atom/B)
-			var/vector2/delta = new /vector2(B.x - A.x, B.y - A.y)
+			var/vector2/delta = get_new_vector(B.x - A.x, B.y - A.y)
 			delta = delta.ToMagnitude(1)
 			return delta
 
 	proc
 		VecDirectionBetween(var/vector2/A, var/vector2/B)
-			var/vector2/delta = new /vector2(B.x - A.x, B.y - A.y)
+			var/vector2/delta = get_new_vector(B.x - A.x, B.y - A.y)
 			delta = delta.ToMagnitude(1)
 			return delta
 
@@ -49,11 +49,11 @@ Vector2
 		DirMagBetween(var/atom/A, var/atom/B)
 			if (get_turf(A) == get_turf(B))
 				return list("direction" = Vector2.Zero, "magnitude" = 0)
-			var/vector2/delta = new /vector2(B.x - A.x, B.y - A.y)
+			var/vector2/delta = get_new_vector(B.x - A.x, B.y - A.y)
 			return list("direction" = delta.ToMagnitude(1), "magnitude" = delta.Magnitude())
 	proc
 		MagnitudeBetween(var/atom/A, var/atom/B, var/magnitude)
-			var/vector2/delta = new /vector2(B.x - A.x, B.y - A.y)
+			var/vector2/delta = get_new_vector(B.x - A.x, B.y - A.y)
 			delta = delta.ToMagnitude(magnitude)
 			return delta
 
@@ -64,7 +64,7 @@ Vector2
 
 	proc
 		RandomDirection()
-			var/vector2/delta = new /vector2(rand(), rand())
+			var/vector2/delta = get_new_vector(rand(), rand())
 			return delta.ToMagnitude(1)
 
 	proc

--- a/lib/vector2/CommonVectors.dm
+++ b/lib/vector2/CommonVectors.dm
@@ -51,26 +51,28 @@ Vector2
 		//Gets a directional vector between two atoms
 		DirectionBetween(var/atom/A, var/atom/B)
 			var/vector2/delta = get_new_vector(B.x - A.x, B.y - A.y)
-			delta = delta.ToMagnitude(1)
+			delta.SelfToMagnitude(1)
 			return delta
 
 	proc
 		VecDirectionBetween(var/vector2/A, var/vector2/B)
 			var/vector2/delta = get_new_vector(B.x - A.x, B.y - A.y)
-			delta = delta.ToMagnitude(1)
+			delta.SelfToMagnitude(1)
 			return delta
 
 	proc
 		//Returns a directional vector and a magnitude between
 		DirMagBetween(var/atom/A, var/atom/B)
 			if (get_turf(A) == get_turf(B))
-				return list("direction" = Vector2.Zero, "magnitude" = 0)
+				return list("direction" = get_new_vector(0, 0), "magnitude" = 0)
 			var/vector2/delta = get_new_vector(B.x - A.x, B.y - A.y)
-			return list("direction" = delta.ToMagnitude(1), "magnitude" = delta.Magnitude())
+			var/list/returnlist = list("direction" = delta.ToMagnitude(1), "magnitude" = delta.Magnitude())
+			release_vector(delta)
+			return returnlist
 	proc
 		MagnitudeBetween(var/atom/A, var/atom/B, var/magnitude)
 			var/vector2/delta = get_new_vector(B.x - A.x, B.y - A.y)
-			delta = delta.ToMagnitude(magnitude)
+			delta.SelfToMagnitude(magnitude)
 			return delta
 
 	proc
@@ -81,7 +83,7 @@ Vector2
 	proc
 		RandomDirection()
 			var/vector2/delta = get_new_vector(rand(), rand())
-			return delta.ToMagnitude(1)
+			return delta.SelfToMagnitude(1)
 
 	proc
 		VectorAverage(var/vector2/A)

--- a/lib/vector2/CommonVectors.dm
+++ b/lib/vector2/CommonVectors.dm
@@ -31,6 +31,22 @@ Vector2
 				if(SOUTHWEST) return Southwest
 				else CRASH("Invalid direction.")
 
+
+	//Like from dir, but creates a new one which is safe to edit
+	proc
+		NewFromDir(dir)
+			var/vector2/v
+			switch(dir)
+				if(NORTH) v = North
+				if(SOUTH) v = South
+				if(EAST) v = East
+				if(WEST) v = West
+				if(NORTHEAST) v = Northeast
+				if(SOUTHEAST) v = Southeast
+				if(NORTHWEST) v = Northwest
+				if(SOUTHWEST) v = Southwest
+			return get_new_vector(v.x, v.y)
+
 	proc
 		//Gets a directional vector between two atoms
 		DirectionBetween(var/atom/A, var/atom/B)

--- a/lib/vector2/Vector2.dm
+++ b/lib/vector2/Vector2.dm
@@ -128,7 +128,7 @@ vector2
 			if (NonZero())
 				return ToMagnitude(1)
 			else
-				return new /vector2(0,0)
+				return get_new_vector(0,0)
 
 		/* Convert the vector to text with a specified number of significant figures.
 		*/
@@ -188,14 +188,14 @@ vector2
 			if (NonZero() && onto && onto.NonZero())
 				var/vector2/result = (onto*(src.Dot(onto) / onto.Dot(onto)))
 				return result
-			return new /vector2(0,0)
+			return get_new_vector(0,0)
 
 
 		SafeRejection(var/vector2/onto)
 			if (NonZero() && onto && onto.NonZero())
 				var/vector2/result = src - Projection(onto)
 				return result
-			return new /vector2(0,0)
+			return get_new_vector(0,0)
 
 		/* Get the matrix that rotates from_vector to point in this direction.
 			Also accepts a dir.

--- a/lib/vector2/Vector2.dm
+++ b/lib/vector2/Vector2.dm
@@ -154,14 +154,15 @@ vector2
 		RotationFrom(vector2/from_vector = Vector2.North)
 			var vector2/to_vector = Normalized()
 
-			if(isnum(from_vector)) from_vector = Vector2.FromDir(from_vector)
+			if(isnum(from_vector)) from_vector = Vector2.NewFromDir(from_vector)
 
 			if(istype(from_vector, /vector2))
-				from_vector = from_vector.Normalized()
+				from_vector.SelfNormalize()
 				var
 					cos_angle = to_vector.Dot(from_vector)
 					sin_angle = to_vector.Cross(from_vector)
-				return matrix(cos_angle, sin_angle, 0, -sin_angle, cos_angle, 0)
+				.= matrix(cos_angle, sin_angle, 0, -sin_angle, cos_angle, 0)
+				release_vector(to_vector)
 
 			else CRASH("Invalid 'from' vector.")
 
@@ -206,7 +207,7 @@ vector2
 			if(isnum(from_vector)) from_vector = Vector2.FromDir(from_vector)
 
 			var/angle = (Atan2(to_vector.y, to_vector.x) - Atan2(from_vector.y, from_vector.x))
-
+			release_vector(to_vector)
 			if (shorten)
 				angle = shortest_angle(angle)
 
@@ -214,6 +215,7 @@ vector2
 
 		/* Get a vector with the same magnitude rotated by a clockwise angle in degrees.
 		*/
+		//Future TODO: Make and implement a self version of this
 		Turn(angle) return src * matrix().Turn(angle)
 
 		FloorVec()

--- a/lib/vector2/Vector2.dm
+++ b/lib/vector2/Vector2.dm
@@ -36,27 +36,27 @@ vector2
 
 		/* Vector addition.
 		*/
-		operator+(vector2/v) return v ? new/vector2(x + v.x, y + v.y) : src
+		operator+(vector2/v) return v ? get_new_vector(x + v.x, y + v.y) : src
 
 		/* Vector subtraction and negation.
 		*/
-		operator-(vector2/v) return v ? new/vector2(x - v.x, y - v.y) : new/vector2(-x, -y)
+		operator-(vector2/v) return v ? get_new_vector(x - v.x, y - v.y) : get_new_vector(-x, -y)
 
 		/* Vector scaling.
 		*/
 		operator*(s)
 			// Scalar
-			if(isnum(s)) return new/vector2(x * s, y * s)
+			if(isnum(s)) return get_new_vector(x * s, y * s)
 
 			// Transform
 			else if(istype(s, /matrix))
 				var matrix/m = s
-				return new/vector2(x * m.a + y * m.b + m.c, x * m.d + y * m.e + m.f)
+				return get_new_vector(x * m.a + y * m.b + m.c, x * m.d + y * m.e + m.f)
 
 			// Component-wise
 			else if(istype(s, /vector2))
 				var vector2/v = s
-				return new/vector2(x * v.x, y * v.y)
+				return get_new_vector(x * v.x, y * v.y)
 
 			else CRASH("Invalid args.")
 
@@ -64,7 +64,7 @@ vector2
 		*/
 		operator/(d)
 			// Scalar
-			if(isnum(d)) return new/vector2(x / d, y / d)
+			if(isnum(d)) return get_new_vector(x / d, y / d)
 
 			// Inverse transform
 			else if(istype(d, /matrix)) return src * ~d
@@ -72,7 +72,7 @@ vector2
 			// Component-wise
 			else if(istype(d, /vector2))
 				var vector2/v = d
-				return new/vector2(x / v.x, y / v.y)
+				return get_new_vector(x / v.x, y / v.y)
 
 			else CRASH("Invalid args.")
 
@@ -257,6 +257,11 @@ vector2
 		SelfCeiling()
 			x = Ceiling(x)
 			y = Ceiling(y)
+
+
+		/* Get a vector in the same direction but with magnitude 1.
+		*/
+		SelfNormalize() SelfToMagnitude(1)
 
 		SelfToMagnitude(var/m)
 			m /= Magnitude()

--- a/lib/vector2/vectorpool.dm
+++ b/lib/vector2/vectorpool.dm
@@ -25,9 +25,9 @@ GLOBAL_VAR_INIT(vector_pool_filling, FALSE)
 	GLOB.vector_pool_filling = FALSE
 
 /proc/get_new_vector(var/new_x, var/new_y)
-
-	var/vector2/newvec = pop(GLOB.vector_pool)
-	if (newvec)
+	if (length(GLOB.vector_pool))
+		var/vector2/newvec
+		macropop(GLOB.vector_pool, newvec)
 		newvec.x = new_x
 		newvec.y = new_y
 		return newvec
@@ -43,3 +43,10 @@ GLOBAL_VAR_INIT(vector_pool_filling, FALSE)
 
 
 //Releasing vectors is handled via a define in _macros.dm
+
+
+
+/client/proc/debug_vectorpool()
+	set category = "Debug"
+	set name = "Vector Pool Debug"
+	to_chat(src, "Vecpool: [length(GLOB.vector_pool)]")

--- a/lib/vector2/vectorpool.dm
+++ b/lib/vector2/vectorpool.dm
@@ -8,6 +8,9 @@
 GLOBAL_LIST_EMPTY(vector_pool)
 GLOBAL_VAR_INIT(vector_pool_filling, FALSE)
 
+//GLOBAL_VAR_INIT(vectors_created, 0)
+//GLOBAL_VAR_INIT(vectors_recycled, 0)
+
 //Fills the pool with fresh vectors for later use. Sleeps while doing so to reduce lag.
 //This can take as long as it needs to, and other procs may extend the time by taking from the pool while it fills
 //If the pool runs empty during the process then vectors will be created on demand
@@ -35,7 +38,7 @@ GLOBAL_VAR_INIT(vector_pool_filling, FALSE)
 	else
 		//If we failed to get one from the list, make a new one for almost-immediate return
 		.=new /vector2(new_x,new_y)
-
+		//GLOB.vectors_created++
 		//And start the pool filling if needed
 		if (!GLOB.vector_pool_filling)
 			spawn()
@@ -50,3 +53,5 @@ GLOBAL_VAR_INIT(vector_pool_filling, FALSE)
 	set category = "Debug"
 	set name = "Vector Pool Debug"
 	to_chat(src, "Vecpool: [length(GLOB.vector_pool)]")
+	//to_chat(src, "Created: [GLOB.vectors_created]")
+	//to_chat(src, "Recycled: [GLOB.vectors_recycled]")

--- a/lib/vector2/vectorpool.dm
+++ b/lib/vector2/vectorpool.dm
@@ -1,0 +1,45 @@
+/*
+	Vector pooling solution
+	Keeps vectors in a global list and recycles them
+
+	Creates new ones when needed
+*/
+
+GLOBAL_LIST_EMPTY(vector_pool)
+GLOBAL_VAR_INIT(vector_pool_filling, FALSE)
+
+//Fills the pool with fresh vectors for later use. Sleeps while doing so to reduce lag.
+//This can take as long as it needs to, and other procs may extend the time by taking from the pool while it fills
+//If the pool runs empty during the process then vectors will be created on demand
+/proc/fill_vector_pool()
+	set waitfor = FALSE
+
+	if (GLOB.vector_pool_filling)
+		return
+
+	GLOB.vector_pool_filling = TRUE
+	while (length(GLOB.vector_pool) < VECTOR_POOL_FULL)
+		sleep()
+		GLOB.vector_pool += new /vector2(0,0)
+
+	GLOB.vector_pool_filling = FALSE
+
+/proc/get_new_vector(var/new_x, var/new_y)
+
+	var/vector2/newvec = pop(GLOB.vector_pool)
+	if (newvec)
+		newvec.x = new_x
+		newvec.y = new_y
+		return newvec
+
+	else
+		//If we failed to get one from the list, make a new one for almost-immediate return
+		.=new /vector2(new_x,new_y)
+
+		//And start the pool filling if needed
+		if (!GLOB.vector_pool_filling)
+			spawn()
+				fill_vector_pool()
+
+
+//Releasing vectors is handled via a define in _macros.dm


### PR DESCRIPTION
Don't merge this yet!

This PR is a huge overhauling of vector code, based on a design principle. Unnecessarily creating things is bad.

The primary goal, which it 99% succeeds at, is preventing vectors from constantly being created at runtime, by instead creating a few initially, and recycling those few endlessly. When they are no longer needed, they are put back in the list instead of deleted. The list typically contains 2000-10000 vectors, which sounds like a lot, but isn't for their massive use.

Thanks to roundstart slow processing, over 600,000 vectors would normally be created while starting the game, this is now done entirely by recycling that initial set. This has not been stress tested in a major environment, so i can't say for sure what the effects will be. But I expect that this will provide significant performance improvements in the following areas:

Roundstart Processing
Projectile Handling
Wallclimbing
Kinesis
Throwing objects
Explosions

It remains to be seen whether this is the magic bullet to solve all our problems.
But it will probably help