### PR TITLE
Necromorph and Corruption Buffs

### DIFF
--- a/code/__defines/skills_stats.dm
+++ b/code/__defines/skills_stats.dm
@@ -30,3 +30,4 @@
 //Value modifiers for extensions
 #define STATMOD_MOVESPEED_ADDITIVE	"additive movespeed modifiers"
 #define STATMOD_MOVESPEED_MULTIPLICATIVE	"multiplicative movespeed modifiers"
+#define STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE	"multiplicative recieved damage modifiers"

--- a/code/datums/extensions/extension_statmod.dm
+++ b/code/datums/extensions/extension_statmod.dm
@@ -72,3 +72,28 @@
 	for (var/datum/extension/E as anything in LAZYACCESS(statmods, STATMOD_MOVESPEED_MULTIPLICATIVE))
 		move_speed_factor *= E.movespeed_mod()
 
+
+
+/*
+	Incoming Damage
+*/
+/datum/extension/proc/register_incoming_damage_mod()
+	register_statmod(STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE)
+	holder.update_incoming_damage_factor()
+
+/datum/extension/proc/unregister_incoming_damage_mod()
+	unregister_statmod(STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE)
+	holder.update_incoming_damage_factor()
+
+/datum/extension/proc/incoming_damage_mod()
+	return 1
+
+//Additive modifiers first, then multiplicative
+/datum/proc/update_incoming_damage_factor()
+
+/mob/living/update_incoming_damage_factor()
+	incoming_damage_mult = 1
+
+	//We multiply by the result of each multiplicative modifier
+	for (var/datum/extension/E as anything in LAZYACCESS(statmods, STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE))
+		incoming_damage_mult *= E.incoming_damage_mod()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -14,6 +14,10 @@
 		..(damage, damagetype, def_zone, blocked)
 		return 1
 
+	//If the damage is one of the above types, it will be multiplied in the parent proc.
+	//If not, we multiply it here
+	damage *= incoming_damage_mult
+
 	handle_suit_punctures(damagetype, damage, def_zone)
 
 	if(blocked >= 100)	return 0

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -11,12 +11,12 @@
 	mob_type = /mob/living/carbon/human/necromorph/slasher
 	blurb = "The frontline soldier of the necromorph horde. Slow when not charging, but its blade arms make for powerful melee attacks"
 	unarmed_types = list(/datum/unarmed_attack/blades, /datum/unarmed_attack/bite/weak) //Bite attack is a backup if blades are severed
-	total_health = 75
+	total_health = 80
 	biomass = 50
 	mass = 70
 	virus_immune = 1
 
-	biomass_reclamation_time	=	8 MINUTES
+	biomass_reclamation_time	=	7 MINUTES
 
 	icon_template = 'icons/mob/necromorph/slasher/fleshy.dmi'
 	damage_mask = 'icons/mob/necromorph/slasher/damage_mask.dmi'
@@ -112,7 +112,7 @@
 	marker_spawnable = TRUE 	//Enable this once we have sprites for it
 	mob_type = /mob/living/carbon/human/necromorph/slasher_enhanced
 	unarmed_types = list(/datum/unarmed_attack/blades/strong, /datum/unarmed_attack/bite/strong)
-	total_health = 187.5
+	total_health = 200
 	slowdown = 2.8
 	biomass = 125
 	view_range = 8
@@ -125,7 +125,7 @@
 	icon_lying = "_lying"
 	//lying_rotation = 90
 
-	biomass_reclamation_time	=	12 MINUTES
+	biomass_reclamation_time	=	11 MINUTES
 
 	limb_health_factor = 1.75
 
@@ -192,6 +192,7 @@
 	damage = 16
 	delay = 13
 	airlock_force_power = 2
+	armor_penetration = 5
 
 #define SLASHER_CHARGE_DESC	"<h2>Charge:</h2><br>\
 <h3>Hotkey: Ctrl+Alt+Click </h3><br>\
@@ -228,7 +229,7 @@ Dodge is a skill that requires careful timing, but if used correctly, it can all
 	damage = 24
 	delay = 11
 	airlock_force_power = 3
-
+	armor_penetration = 10
 
 /*
 	Abilities

--- a/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
@@ -70,6 +70,7 @@
 	damage = 12
 	delay = 16
 	airlock_force_power = 1.5
+	armor_penetration = 5
 
 #define SPITTER_PASSIVE	"<h2>PASSIVE: No Friendly Fire:</h2><br>\
 All projectiles fired by this necromorph will harmlessly pass over other necromorphs, and will only hit enemies."

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -10,6 +10,10 @@
 */
 /mob/living/proc/apply_damage(var/damage = 0,var/damagetype = BRUTE, var/def_zone = null, var/blocked = 0, var/damage_flags = 0, var/used_weapon = null)
 	if(!damage || (blocked >= 100))	return 0
+
+	//Multiply the incoming damage
+	damage *= incoming_damage_mult
+
 	switch(damagetype)
 		if(BRUTE)
 			adjustBruteLoss(damage * blocked_mult(blocked))	//This calls organ damage procs which call updatehealth

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -58,3 +58,4 @@
 
 
 	var/attack_speed_factor	=	1	//Multiplier on attackspeed. Used as a divisor on unarmed attack delays, and certain ability cooldowns
+	var/incoming_damage_mult = 1	//Multiplier on all damage recieved, regardless of source

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/wall.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/wall.dm
@@ -9,7 +9,7 @@
 /datum/signal_ability/placement/corruption/wall/visible
 	name = "Frantic Growth"
 	id = "wall2"
-	energy_cost = 125
+	energy_cost = 100
 	LOS_block = FALSE
 	placement_atom = /obj/structure/corruption_node/wall/visible
 
@@ -32,7 +32,7 @@
 	default_scale = 1
 	pixel_y = 6
 
-	max_health = 60
+	max_health = 65
 	resistance = 6
 	can_block_movement = TRUE
 

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -332,7 +332,7 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 //-------------------
 //Any mob that walks over a corrupted tile recieves this effect. It does varying things
 	//On most mobs, it applies a slow to movespeed
-	//On necromorphs, it applies a passive healing instead
+	//On necromorphs, it applies a speedboost, passive healing and defense buff instead
 
 /datum/extension/corruption_effect
 	name = "Corruption Effect"
@@ -340,11 +340,12 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	flags = EXTENSION_FLAG_IMMEDIATE
 
 	//Effects on necromorphs
-	var/healing_per_tick = 1.2
-	var/speedup = 1.2
+	var/healing_per_tick = 1.2	//Passive Healing
+	var/speedup = 1.25	//Bonus movespeed
+	var/incoming_damage_mod = 0.85	//Incoming damage reduction
 
 	//Effects on non necros
-	var/slowdown = 0.65	//Multiply speed by this
+	var/slowdown = 0.60	//Movespeed Penalty
 
 	var/speed_factor = 0
 
@@ -358,12 +359,14 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	if (L.is_necromorph())
 		necro = TRUE
 		speed_factor = speedup //Necros are sped up
+		register_incoming_damage_mod()
 		to_chat(L, SPAN_DANGER("The corruption beneath speeds your passage and mends your vessel."))
 	else
 		to_chat(L, SPAN_DANGER("This growth underfoot is sticky and slows you down."))
 		speed_factor = slowdown	//humans are slowed down
 
 	register_movemod(STATMOD_MOVESPEED_MULTIPLICATIVE)
+
 
 	START_PROCESSING(SSprocessing, src)
 
@@ -382,8 +385,14 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 
 /datum/extension/corruption_effect/Destroy()
 	unregister_movemod(STATMOD_MOVESPEED_MULTIPLICATIVE)
-
+	var/mob/living/L = holder
+	if (L.is_necromorph())
+		unregister_incoming_damage_mod()
 	.=..()
 
 /datum/extension/corruption_effect/movespeed_mod()
 	return speed_factor
+
+
+/datum/extension/corruption_effect/incoming_damage_mod()
+	return incoming_damage_mod

--- a/code/modules/necromorph/corruption/harvester.dm
+++ b/code/modules/necromorph/corruption/harvester.dm
@@ -48,6 +48,7 @@
 
 	//Harvester dies fast without corruption support
 	degen = 5
+	regen = 0.75
 
 	//The harvester needs to exist for this long before it fully deploys
 	var/deployment_time = 1 MINUTE

--- a/html/changelogs/slasherbuff.yml
+++ b/html/changelogs/slasherbuff.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Necromorphs now recieve a 15% reduction to all incoming damage, while standing on corruption. Should help against spawncamping crew assaults."
+  - tweak: "Increased the strength of movespeed effects from walking on corruption. Necromorph movespeed bonus from 20 to 25%, human speed penalty from 35 to 40%"
+  - tweak: "Bladed necromorph basic attacks (Slasher, spitter, twitcher, enhanced slasher) now have minor armor penetration, making them better against crew in tough suits."
+  - tweak: "Slasher max health slightly increased, from 75 to 80. Enhanced slasher adjusted proportionately"
+  - tweak: "Slasher biomass reclamation time reduced, from 8 minutes to 7, enhanced from 12 to 11"
+  - tweak: "Reduced harvester health regen, from 1 to 0.75, should make it easier to kill with sustained assault."


### PR DESCRIPTION
Humans have been getting a fair bit stronger recently, with several waves of new content in rigs, guns and tools. Necros were feeling a bit weak and getting spawncamped a lot. This PR should partially offset that.

Main new feature here is a damage reduction mechanic, currently implemented for corruption. Necromoprhs get a bit of protection while standing on it 

Aside from that, a small package of incremental tweaks to balance the scales in subtle ways. 

The harvester is getting a little nerf though, it was designed to be strong, but people are having more trouble fighting it than originally anticipated, its health regen has been reduced a bit to compensate

changes: 
  - rscadd: "Necromorphs now recieve a 15% reduction to all incoming damage, while standing on corruption. Should help against spawncamping crew assaults."
  - tweak: "Increased the strength of movespeed effects from walking on corruption. Necromorph movespeed bonus from 20 to 25%, human speed penalty from 35 to 40%"
  - tweak: "Bladed necromorph basic attacks (Slasher, spitter, twitcher, enhanced slasher) now have minor armor penetration, making them better against crew in tough suits."
  - tweak: "Slasher max health slightly increased, from 75 to 80. Enhanced slasher adjusted proportionately"
  - tweak: "Slasher biomass reclamation time reduced, from 8 minutes to 7, enhanced from 12 to 11"
  - tweak: "Reduced harvester health regen, from 1 to 0.75, should make it easier to kill with sustained assault."