### PR TITLE
Acid Fixes

### DIFF
--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -2,6 +2,7 @@
 #define RAND_F(LOW, HIGH) (rand()*(HIGH-LOW) + LOW)
 #define ceil(x) (-round(-(x)))
 #define CEILING(x, y) ( -round(-(x) / (y)) * (y) )
+#define NEAR_INFINITY	9999999999	//Just a really big number
 
 // min is inclusive, max is exclusive
 /proc/Wrap(val, min, max)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -909,21 +909,22 @@ THIS SCOPE CODE IS DEPRECATED, USE AIM MODES INSTEAD.
 		return FALSE
 	health -= amount
 
-	if (health <= 0)
-		health = 0
-		return zero_health(amount, damtype, user, used_weapon, bypass_resist)//Some zero health overrides do things with a return value
-	else
-		update_icon()
-		return TRUE
+	updatehealth()
 
+
+//Sets an object's health to a percenrage of its max health. Calls all the usual updating functions
+/obj/item/proc/set_healthpercent(var/percentage)
+	health = max_health * percentage
+	updatehealth()
 
 
 /obj/item/proc/updatehealth()
 	if (health <= 0)
 		health = 0
-		return zero_health()
-
-
+		return zero_health()//Some zero health overrides do things with a return value
+	else
+		update_icon()
+		return TRUE
 
 //Called when health drops to zero. Parameters are the params of the final hit that broke us, if this was called from take_damage
 /obj/item/proc/zero_health(var/amount, var/damtype = BRUTE, var/user, var/used_weapon, var/bypass_resist)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -22,6 +22,8 @@
 
 	var/list/files = list(  )
 
+	unacidable = TRUE	//These melt too easily
+
 /obj/item/weapon/card/data
 	name = "data disk"
 	desc = "A disk of data."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -18,6 +18,9 @@
 	var/permeability_threshold = 0.8	//As long as health is above this proportion of max health, reagent permeability is unaffected. Below that value it increases rapidly
 	var/coverage = null	//Calculate this at runtime
 
+	//If not null, this piece of clothing belongs to a rig frame
+	var/obj/item/weapon/rig/rig
+
 
 // Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/clothing/proc/update_clothing_icon()

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -17,6 +17,7 @@
 		)
 	species_restricted = null
 
+
 /obj/item/clothing/gloves/rig
 	name = "gauntlets"
 	item_flags = ITEM_FLAG_THICKMATERIAL
@@ -150,3 +151,42 @@
 	cold_protection =    HANDS
 	species_restricted = null
 	gender = PLURAL
+
+
+
+
+
+//When rig pieces take damage, they send that damage to their frame instead
+//The frame will spread the damage evenly over the pieces
+/obj/item/clothing/take_damage(var/amount, var/damtype = BRUTE, var/user, var/used_weapon, var/bypass_resist = FALSE)
+	if (!rig)
+		.=..()
+		return
+
+	return rig.take_damage(amount, damtype, user, used_weapon, bypass_resist)
+
+//Things which are part of a rig don't get deleted when broken
+/obj/item/clothing/zero_health()
+	if (rig)
+		return
+
+	.=..()
+
+/obj/item/weapon/rig/updatehealth()
+	.=..()
+	if (health > 0)
+		var/healthpercent = health / max_health
+
+		for (var/obj/item/clothing/C as anything in get_pieces())
+			C.set_healthpercent(healthpercent)
+
+
+//RIGs don't get deleted when broken, but they go into a malfunctioning state forever
+/obj/item/weapon/rig/zero_health()
+	malfunctioning = NEAR_INFINITY
+	malfunction_delay = NEAR_INFINITY
+
+/obj/item/weapon/rig/repair(var/repair_power, var/datum/repair_source, var/mob/user)
+	.=..()
+	malfunctioning = 0
+	malfunction_delay = 0

--- a/code/modules/clothing/spacesuits/rig/suits/civilian.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/civilian.dm
@@ -6,6 +6,8 @@
 	offline_slowdown = 1
 	online_slowdown = 0
 
+	max_health = 1500
+
 	chest_type = null
 	helm_type =  null
 	boot_type =  null

--- a/code/modules/clothing/spacesuits/rig/suits/hacker.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/hacker.dm
@@ -14,6 +14,8 @@
 	glove_type = /obj/item/clothing/gloves/lightrig/hacker
 	boot_type = /obj/item/clothing/shoes/lightrig/hacker
 
+	max_health = 1500
+
 	initial_modules = list(
 		/obj/item/rig_module/healthbar,
 		/obj/item/rig_module/storage/light,

--- a/code/modules/clothing/spacesuits/rig/suits/vintage.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vintage.dm
@@ -6,6 +6,8 @@
 	offline_slowdown = 5
 	online_slowdown = 3.5
 
+	max_health = 4000
+
 	chest_type = /obj/item/clothing/suit/space/rig/vintage
 	helm_type =  /obj/item/clothing/head/helmet/space/rig/vintage
 	boot_type =  /obj/item/clothing/shoes/magboots/rig/vintage

--- a/code/modules/mob/living/abilities/particles/particle.dm
+++ b/code/modules/mob/living/abilities/particles/particle.dm
@@ -8,7 +8,7 @@
 	density = FALSE
 	dir = NORTH
 
-	var/vector2/destination_pixels
+	var/vector2/pixel_delta
 	var/vector2/origin_pixels
 
 	var/scale_x_start = 	1
@@ -35,7 +35,7 @@
 	src.direction = direction
 	if (direction)
 		transform = direction.Rotation()
-		release_vector(direction)
+
 
 	if (color)
 		src.color = color
@@ -49,8 +49,8 @@
 
 	//Lets calculate the destination pixel_loc
 	origin_pixels = get_global_pixel_loc()
-	destination_pixels = origin_pixels + (direction * (range * WORLD_ICON_SIZE))
-
+	pixel_delta = (direction * (range * WORLD_ICON_SIZE))
+	release_vector(direction)
 
 	//And the transform we'll eventually transition to
 	target_transform = matrix(transform)
@@ -59,7 +59,6 @@
 
 /obj/effect/particle/Initialize()
 	.=..()
-	var/vector2/pixel_delta = destination_pixels - origin_pixels
 
 	//Lets start the animation!
 	animate(src,
@@ -72,6 +71,6 @@
 
 
 /obj/effect/particle/Destroy()
-	release_vector(destination_pixels)
 	release_vector(origin_pixels)
+	release_vector(pixel_delta)
 	.=..()

--- a/code/modules/mob/living/abilities/particles/system.dm
+++ b/code/modules/mob/living/abilities/particles/system.dm
@@ -51,7 +51,12 @@
 	addtimer(CALLBACK(src, /obj/effect/particle_system/proc/tick), tick_delay)
 
 /obj/effect/particle_system/proc/set_direction(var/vector2/new_direction)
-	direction = new_direction
+	if (!direction)
+		direction = new_direction.Copy()
+	else
+		direction.x = new_direction.x
+		direction.y = new_direction.y
+
 
 /obj/effect/particle_system/proc/spawn_particle()
 

--- a/code/modules/mob/living/abilities/spray.dm
+++ b/code/modules/mob/living/abilities/spray.dm
@@ -14,6 +14,7 @@ w//DO NOT INCLUDE THIS FILE
 	var/status
 	var/mob/living/user
 	var/vector2/target
+	var/atom/target_atom
 	var/angle
 	var/length
 	var/chemical
@@ -82,14 +83,36 @@ Vars/
 
 /datum/extension/spray/proc/set_target_loc(var/vector2/newloc, var/target_object)
 	target = newloc
-	if (isliving(user) && target_object)
-		user.face_atom(target_object)
+	if (target_object)
+		target_atom = target_object
+		if (isliving(user))
+			user.face_atom(target_object)
+	else if (source)
+		target_atom = get_turf_at_pixel_coords(target, source.z)
 	recalculate_cone()
 
+/datum/extension/spray/proc/get_direction()
+	//As long as we're not on the same turf, we can do this easily
+	var/vector2/ourloc = source.get_global_pixel_loc()
+	if (!(ourloc ~= target))
+
+		.=Vector2.VecDirectionBetween(ourloc, target)
+		release_vector(ourloc)
+		return
+
+	else
+		//User and target are on same turf? Lets try basing it on direction
+		var/spraydir = SOUTH
+		if (source)
+			spraydir = source.dir
+		release_vector(ourloc)
+		return Vector2.NewFromDir(spraydir)
 
 /datum/extension/spray/proc/recalculate_cone()
 	affected_turfs = list()
-	direction = Vector2.VecDirectionBetween(source.get_global_pixel_loc(), target)
+	if (direction)
+		release_vector(direction)
+	direction = get_direction()
 	affected_turfs = get_view_cone(source, direction, length, angle)
 	affected_turfs -= get_turf(source)
 	if (fx)

--- a/code/modules/reagents/Chemistry-Reagents/acid.dm
+++ b/code/modules/reagents/Chemistry-Reagents/acid.dm
@@ -147,7 +147,7 @@
 		take_damage((acid.power*volume)/acid_resistance, BURN)
 
 		//If taking damage caused it to be deleted, then we'll do the melting effect
-		if (health <= 0 || QDELETED(src))
+		if ((health <= 0 || QDELETED(src)) && !acid_melted)
 			melt = TRUE
 
 		if (melt)

--- a/html/changelogs/acid.yml
+++ b/html/changelogs/acid.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Acid now deals damage to RIG suits, and will eventually melt through and damage the wearer. The suit or frame will never be completely destroyed."
+  - bugfix: "Puker vomit no longer goes through windows."

--- a/lib/vector2/Vector2.dm
+++ b/lib/vector2/Vector2.dm
@@ -160,7 +160,10 @@ vector2
 		RotationFrom(vector2/from_vector = Vector2.North)
 			var vector2/to_vector = Normalized()
 
-			if(isnum(from_vector)) from_vector = Vector2.NewFromDir(from_vector)
+			var/from_created = FALSE
+			if(isnum(from_vector))
+				from_vector = Vector2.NewFromDir(from_vector)
+				from_created = TRUE
 
 			if(istype(from_vector, /vector2))
 				from_vector.SelfNormalize()
@@ -170,7 +173,11 @@ vector2
 				.= matrix(cos_angle, sin_angle, 0, -sin_angle, cos_angle, 0)
 				release_vector(to_vector)
 
-			else CRASH("Invalid 'from' vector.")
+			else
+				CRASH("Invalid 'from' vector.")
+
+			if (from_created)
+				release_vector(from_vector)
 
 
 


### PR DESCRIPTION
Closes #798
Closes #796
Closes #795
Closes #725

changes: 
  - rscadd: "Acid now deals damage to RIG suits, and will eventually melt through and damage the wearer. The suit or frame will never be completely destroyed."
  - bugfix: "Puker vomit no longer goes through windows."