### PR TITLE
Projectile Balance Tweaks

### DIFF
--- a/code/modules/necromorph/corruption/cyst.dm
+++ b/code/modules/necromorph/corruption/cyst.dm
@@ -6,7 +6,7 @@
 
 #define CYST_ATTACH_OFFSET	8	//How many pixels the cyst offsets towards a wall or object its attached
 #define CYST_IMPACT_DAMAGE	10
-#define CYST_BLAST_POWER	40
+#define CYST_BLAST_POWER	35
 
 /obj/structure/corruption_node/cyst
 	name = "cyst"
@@ -171,7 +171,7 @@
 	damage = CYST_IMPACT_DAMAGE	//The direct on-hit damage is minor, most of the effect is in a resulting explosion
 	var/exploded = FALSE
 	check_armour = "bomb"
-	step_delay = 2.5
+	step_delay = 3
 	muzzle_type = /obj/effect/projectile/bio/muzzle
 	grippable = TRUE
 

--- a/code/modules/projectiles/guns/ds13/line_cutter.dm
+++ b/code/modules/projectiles/guns/ds13/line_cutter.dm
@@ -85,13 +85,13 @@
 --------------------------*/
 /obj/item/projectile/wave/linecutter
 	damage = 34
-	accuracy = 150
+	accuracy = 130
 	penetrating = TRUE
 	edge = TRUE
 	icon = 'icons/obj/weapons/ds13_projectiles_large.dmi'
 	icon_state = "linecutter_48"
 	step_delay = 2
-	kill_count = 10	//Short ranged
+	kill_count = 9	//Short ranged
 	height = 0.1	//10cm thick wave
 
 	var/dig_power = 1800

--- a/code/modules/projectiles/guns/ds13/pulse_rifle.dm
+++ b/code/modules/projectiles/guns/ds13/pulse_rifle.dm
@@ -20,6 +20,7 @@ The Pulse Rifle is the standard-issue service rifle of the Earth Defense Force a
 	mag_insert_sound = 'sound/weapons/guns/interaction/pulse_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/pulse_magout.ogg'
 	one_hand_penalty = 6	//Don't try to fire this with one hand
+	accuracy = 5	//Slight accuracy increase
 
 	aiming_modes = list(/datum/extension/aim_mode/rifle)
 

--- a/code/modules/projectiles/guns/ds13/rivet_gun.dm
+++ b/code/modules/projectiles/guns/ds13/rivet_gun.dm
@@ -141,7 +141,7 @@
 	Projectile
 */
 /obj/item/projectile/bullet/rivet
-	damage = 5	//Weaker than a pulse rifle shot, and lacks full auto
+	damage = 7	//Weaker than a pulse rifle shot, and lacks full auto
 	expiry_method = EXPIRY_FADEOUT
 	muzzle_type = /obj/effect/projectile/pulse/muzzle/light
 	//fire_sound='sound/weapons/guns/fire/divet_fire.ogg'
@@ -245,7 +245,7 @@
 	Fragmentation
 */
 /obj/item/projectile/bullet/pellet/fragment/rivet
-	damage = 1.2
+	damage = 1.8
 	range_step = 3 //controls damage falloff with distance. projectiles lose a "pellet" each time they travel this distance. Can be a non-integer.
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone

--- a/html/changelogs/gunbalance.yml
+++ b/html/changelogs/gunbalance.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako  
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Slightly buffed accuracy of pulse rifle"
+  - tweak: "Significantly buffed damage of rivet gun"
+  - tweak: "Reduced damage and projectile speed of cysts."
+  - tweak: "Slightly Reduced accuracy and range of line cutter."


### PR DESCRIPTION
changes: 
  - tweak: "Slightly buffed accuracy of pulse rifle"
  - tweak: "Significantly buffed damage of rivet gun"
  - tweak: "Reduced damage and projectile speed of cysts."
  - tweak: "Slightly Reduced accuracy and range of line cutter."