### PR TITLE
Wheelchair speed fix

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -9,7 +9,7 @@
 	var/mob/living/pulling = null
 	var/bloodiness
 
-	movement_handlers = list(/datum/movement_handler/delay = list(2), /datum/movement_handler/move_relay_self)
+	movement_handlers = list(/datum/movement_handler/delay = list(5), /datum/movement_handler/move_relay_self)
 
 /obj/structure/bed/chair/wheelchair/update_icon()
 	return

--- a/html/changelogs/terror4000rus-wchair.yml
+++ b/html/changelogs/terror4000rus-wchair.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Terror4000rus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed wheelchair speed abuse."


### PR DESCRIPTION
Right now you can use a wheelchair to speed up your character without any drawbacks from items or wounds.
I "fixed" it without new checks and other changes. I think it's better than see a fast train of crew with a man in wheelchair at it's head or even have a `nice time` to catch a man in it without admin's help.