### PR TITLE
Evac fixes

### DIFF
--- a/code/controllers/evacuation/evacuation_lifepods.dm
+++ b/code/controllers/evacuation/evacuation_lifepods.dm
@@ -21,8 +21,8 @@
 		return list()
 	if (is_idle())
 		return list(evacuation_options[EVAC_OPT_ABANDON_SHIP])
-	if (is_evacuating())
-		return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
+//	if (is_evacuating())	//disabled until proper cancel evac is coded
+//		return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
 
 #undef EVAC_OPT_ABANDON_SHIP
 #undef EVAC_OPT_CANCEL_ABANDON_SHIP

--- a/code/controllers/evacuation/evacuation_lifepods.dm
+++ b/code/controllers/evacuation/evacuation_lifepods.dm
@@ -23,6 +23,7 @@
 		return list(evacuation_options[EVAC_OPT_ABANDON_SHIP])
 //	if (is_evacuating())	//disabled until proper cancel evac is coded
 //		return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
+	return list()
 
 #undef EVAC_OPT_ABANDON_SHIP
 #undef EVAC_OPT_CANCEL_ABANDON_SHIP

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -62,9 +62,9 @@
 		return list()
 	if (is_idle())
 		return list(evacuation_options[EVAC_OPT_ABANDON_SHIP])
-	if (is_evacuating())
-		if (emergency_evacuation)
-			return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
+	//if (is_evacuating())
+		//if (emergency_evacuation)	//disabled until proper cancel evac is coded
+		//	return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
 
 /datum/evacuation_option/abandon_ship
 	option_text = "Abandon spacecraft"

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -65,6 +65,7 @@
 	//if (is_evacuating())
 		//if (emergency_evacuation)	//disabled until proper cancel evac is coded
 		//	return list(evacuation_options[EVAC_OPT_CANCEL_ABANDON_SHIP])
+	return list()
 
 /datum/evacuation_option/abandon_ship
 	option_text = "Abandon spacecraft"

--- a/code/controllers/evacuation/evacuation_shuttle.dm
+++ b/code/controllers/evacuation/evacuation_shuttle.dm
@@ -111,8 +111,8 @@
 		return list()
 	if (is_idle())
 		return list(evacuation_options[EVAC_OPT_CALL_SHUTTLE])
-	else
-		return list(evacuation_options[EVAC_OPT_RECALL_SHUTTLE])
+	//else	//disabled until proper cancel evac is coded
+		//return list(evacuation_options[EVAC_OPT_RECALL_SHUTTLE])
 
 /datum/evacuation_option/call_shuttle
 	option_text = "Call emergency shuttle"

--- a/code/controllers/evacuation/evacuation_shuttle.dm
+++ b/code/controllers/evacuation/evacuation_shuttle.dm
@@ -113,6 +113,7 @@
 		return list(evacuation_options[EVAC_OPT_CALL_SHUTTLE])
 	//else	//disabled until proper cancel evac is coded
 		//return list(evacuation_options[EVAC_OPT_RECALL_SHUTTLE])
+	return list()
 
 /datum/evacuation_option/call_shuttle
 	option_text = "Call emergency shuttle"

--- a/code/game/gamemodes/marker/evac_points.dm
+++ b/code/game/gamemodes/marker/evac_points.dm
@@ -8,6 +8,13 @@
 	var/last_pointgain_quantity = 0
 	var/pointgain_timer
 
+	//used to determine approximate time till evac
+	var/minutes_per_point = 0
+
+	//admin warnings to show approaching evac time
+	var/show_admin_warning_10 = TRUE
+	var/show_admin_warning_5 = TRUE
+
 /datum/game_mode/marker/proc/charge_evac_points()
 	deltimer(pointgain_timer) //Recursive function that will slowly tick down the clock until the valour comes to rescue the ishimura's crew.
 
@@ -32,12 +39,37 @@
 		evac_points = evac_threshold
 		//No addtimer call here, so we'll stop gaining points now
 	else
+		check_admin_warnings()
 		pointgain_timer = addtimer(CALLBACK(src, .proc/charge_evac_points), 1 MINUTE, TIMER_STOPPABLE) //Shuttle was unable to be called. Try again recursively.
 	return FALSE
 
+//proc that handles messages to admins regarding close evac time
+/datum/game_mode/marker/proc/check_admin_warnings()
+	var/time_till_evac = (evac_threshold - evac_points) * minutes_per_point MINUTES	//for Nanako, this formula here needs checking
+	if(time_till_evac <= 10 MINUTES)
+		if(show_admin_warning_10)
+			show_admin_warning_10 = FALSE
+			message_admins("Approximate time until evacuation is unlocked is less than 10 minutes.")
+		else
+			if(time_till_evac <= 5 MINUTES && show_admin_warning_5)
+				show_admin_warning_5 = FALSE
+				message_admins("Approximate time until evacuation is unlocked is less than 5 minutes.")
 
+/datum/game_mode/marker/proc/get_time_until_evac()
+	var/time_till_evac = (evac_threshold - evac_points) * minutes_per_point	//for Nanako, this formula here needs checking
+	return time_till_evac
+
+//proc used to adjust evac threshold points (e.g. admin verb adjustment).
+/datum/game_mode/marker/proc/adjust_evac_threshold(var/extra_time)
+	if(extra_time > 0)
+		show_admin_warning_10 = TRUE
+		show_admin_warning_5 = TRUE
+	evac_threshold += round(extra_time / minutes_per_point)
 
 /datum/evacuation_predicate/travel_points/New()
+	var/datum/game_mode/marker/GM = ticker.mode
+	if(GM)
+		GM.minutes_per_point = GM.minimum_evac_time / initial(GM.evac_threshold)
 	return
 
 /datum/evacuation_predicate/travel_points/Destroy()
@@ -57,7 +89,7 @@
 
 	if (user && GM && GM.last_pointgain_quantity)
 
-		var/time_remaining = ((GM.evac_threshold - GM.evac_points) / GM.last_pointgain_quantity) MINUTES
+		var/time_remaining = ((GM.evac_threshold - GM.evac_points) / GM.last_pointgain_quantity) MINUTES	//for Nanako, this formula here needs checking
 		to_chat(user, SPAN_DANGER("There is no viable site within range for evacuation at the present time. ETA: [time2text(time_remaining, "mm:ss")]"))
 
 	return FALSE

--- a/code/game/gamemodes/marker/evac_points.dm
+++ b/code/game/gamemodes/marker/evac_points.dm
@@ -45,7 +45,7 @@
 
 //proc that handles messages to admins regarding close evac time
 /datum/game_mode/marker/proc/check_admin_warnings()
-	var/time_till_evac = (evac_threshold - evac_points) * minutes_per_point MINUTES	//for Nanako, this formula here needs checking
+	var/time_till_evac = get_time_until_evac()	//for Nanako, this formula here needs checking
 	if(time_till_evac <= 10 MINUTES)
 		if(show_admin_warning_10)
 			show_admin_warning_10 = FALSE
@@ -55,8 +55,9 @@
 				show_admin_warning_5 = FALSE
 				message_admins("Approximate time until evacuation is unlocked is less than 5 minutes.")
 
+//returns approximate time in minutes until evac at normal condititions based on current points and threshold will be unlocked
 /datum/game_mode/marker/proc/get_time_until_evac()
-	var/time_till_evac = (evac_threshold - evac_points) * minutes_per_point	//for Nanako, this formula here needs checking
+	var/time_till_evac = (evac_threshold - evac_points) * minutes_per_point MINUTES	//for Nanako, this formula here needs checking
 	return time_till_evac
 
 //proc used to adjust evac threshold points (e.g. admin verb adjustment).

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -51,6 +51,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/jumptoturf,			//allows us to jump to a specific turf,
 	/client/proc/admin_call_shuttle,	//allows us to call the emergency shuttle,
 //	/client/proc/admin_cancel_shuttle,	//allows us to cancel the emergency shuttle, sending it back to centcomm, -disabled since cancelling evac requires proper rework. Delay evac added instead
+	/client/proc/admin_delay_shuttle,	//allows us to delay until emergency shuttle can be called by normal means,
 	/client/proc/cmd_admin_direct_narrate,	//send text directly to a player with no padding. Useful for narratives and fluff-text,
 	/client/proc/cmd_admin_visible_narrate,
 	/client/proc/cmd_admin_audible_narrate,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -50,7 +50,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/jumptomob,				//allows us to jump to a specific mob,
 	/client/proc/jumptoturf,			//allows us to jump to a specific turf,
 	/client/proc/admin_call_shuttle,	//allows us to call the emergency shuttle,
-	/client/proc/admin_cancel_shuttle,	//allows us to cancel the emergency shuttle, sending it back to centcomm,
+//	/client/proc/admin_cancel_shuttle,	//allows us to cancel the emergency shuttle, sending it back to centcomm, -disabled since cancelling evac requires proper rework. Delay evac added instead
 	/client/proc/cmd_admin_direct_narrate,	//send text directly to a player with no padding. Useful for narratives and fluff-text,
 	/client/proc/cmd_admin_visible_narrate,
 	/client/proc/cmd_admin_audible_narrate,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -785,14 +785,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 	var/extra_time = input("Current approximate time until evacuation is [time2text(GM.get_time_until_evac() MINUTES, "hh:mm:ss")].\nEnter the amount of time in minutes you want to add/remove:", text("Adjusting evacuation time")) as num
-	message_admins(" extra_time = [extra_time], extra_time MINUTES = [extra_time MINUTES] [time2text(extra_time MINUTES, "mm:ss")].")
 	extra_time = extra_time
 	var/options = alert(src, "Do you want to INCREASE or DECREASE time until evacuation is available by [time2text(extra_time MINUTES, "mm:ss")] minutes? ", "Options", "Increase", "Decrease", "Cancel")
 	if(options == "Cancel")
 		return
 	else if(options == "Decrease")
 		extra_time *= -1
-		message_admins(" extra_time * -1 = [extra_time].")
 
 	GM.adjust_evac_threshold(extra_time)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -763,7 +763,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			return
 
 	var/choice = input("Is this an emergency evacuation or a crew transfer?") in list("Emergency", "Crew Transfer")
-	evacuation_controller.call_evacuation(usr, (choice == "Emergency"))
+	evacuation_controller.call_evacuation(usr, (choice == "Emergency"), TRUE)
 
 	feedback_add_details("admin_verb","CSHUT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_and_message_admins("admin-called an evacuation.")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -769,6 +769,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	log_and_message_admins("admin-called an evacuation.")
 	return
 
+/*
+disabled while adding delay_shuttle since evac cancelling needs a complete rework
 /client/proc/admin_cancel_shuttle()
 	set category = "Admin"
 	set name = "Cancel Evacuation"
@@ -786,7 +788,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	log_and_message_admins("admin-cancelled the evacuation.")
 
 	return
-
+*/
 /client/proc/admin_deny_shuttle()
 	set category = "Admin"
 	set name = "Toggle Deny Evac"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -769,6 +769,39 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	log_and_message_admins("admin-called an evacuation.")
 	return
 
+/client/proc/admin_delay_shuttle()
+	set category = "Admin"
+	set name = "Delay Evacuation"
+
+	if(!check_rights(R_ADMIN))	return
+
+	if(!ticker || !evacuation_controller)
+		to_chat(usr, "<span class='warning'>Ticker or evacuation controller are missing.</span>")
+		return
+
+	var/datum/game_mode/marker/GM = ticker.mode
+	if(!GM)
+		to_chat(usr, "<span class='warning'>Marker gamemode not found.</span>")
+		return
+
+	var/extra_time = input("Current approximate time until evacuation is [time2text(GM.get_time_until_evac() MINUTES, "hh:mm:ss")].\nEnter the amount of time in minutes you want to add/remove:", text("Adjusting evacuation time")) as num
+	message_admins(" extra_time = [extra_time], extra_time MINUTES = [extra_time MINUTES] [time2text(extra_time MINUTES, "mm:ss")].")
+	extra_time = extra_time
+	var/options = alert(src, "Do you want to INCREASE or DECREASE time until evacuation is available by [time2text(extra_time MINUTES, "mm:ss")] minutes? ", "Options", "Increase", "Decrease", "Cancel")
+	if(options == "Cancel")
+		return
+	else if(options == "Decrease")
+		extra_time *= -1
+		message_admins(" extra_time * -1 = [extra_time].")
+
+	GM.adjust_evac_threshold(extra_time)
+
+	feedback_add_details("admin_verb","DELAYSH")
+	if(options == "Increase")
+		log_and_message_admins("increased time until evacuation is available by [time2text(extra_time MINUTES, "mm:ss")].")
+	else
+		log_and_message_admins("decreased time until evacuation is available by [time2text(extra_time MINUTES * -1, "mm:ss")].")
+	return
 /*
 disabled while adding delay_shuttle since evac cancelling needs a complete rework
 /client/proc/admin_cancel_shuttle()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -784,7 +784,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		to_chat(usr, "<span class='warning'>Marker gamemode not found.</span>")
 		return
 
-	var/extra_time = input("Current approximate time until evacuation is [time2text(GM.get_time_until_evac() MINUTES, "hh:mm:ss")].\nEnter the amount of time in minutes you want to add/remove:", text("Adjusting evacuation time")) as num
+	var/extra_time = input("Current approximate time until evacuation is [time2text(GM.get_time_until_evac(), "hh:mm:ss")].\nEnter the amount of time in minutes you want to add/remove:", text("Adjusting evacuation time")) as num
 	extra_time = extra_time
 	var/options = alert(src, "Do you want to INCREASE or DECREASE time until evacuation is available by [time2text(extra_time MINUTES, "mm:ss")] minutes? ", "Options", "Increase", "Decrease", "Cancel")
 	if(options == "Cancel")

--- a/html/changelogs/evac-fixes.yml
+++ b/html/changelogs/evac-fixes.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Jeser
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed evacuation called by admins not being forced."
+  - rscdel: "Disabled evacuation cancelling code due to being outdated and not doing anything."
+  - rscadd: "Added admin verb Delay Evacuation that allows to increase or decrease time until evacuation is allowed."
+  - rscadd: "Added admin warnings that trigger at approximately 10 and 5 minutes until evacuation will be allowed normally."


### PR DESCRIPTION
  - bugfix: "Fixed evacuation called by admins not being forced." 
  - rscdel: "Disabled evacuation cancelling code due to being outdated and not doing anything." 
  - rscadd: "Added admin verb Delay Evacuation that allows to increase or decrease time until evacuation is allowed." 
  - rscadd: "Added admin warnings that trigger at approximately 10 and 5 minutes until evacuation will be allowed normally." 

Nanako needs to check and, most likely, fix evac points formulas, since they misbehave.