### PR TITLE
Rebranding NTNet to SolNet

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -64,7 +64,7 @@ obj/item/weapon/circuitboard/rdserver
 							/obj/item/weapon/stock_parts/console_screen = 1)
 
 /obj/item/weapon/circuitboard/ntnet_relay
-	name = "Circuit board (NTNet Quantum Relay)"
+	name = "Circuit board (SolNet Quantum Relay)"
 	build_path = /obj/machinery/ntnet_relay
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 4)

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -39,7 +39,7 @@ var/global/datum/ntnet/ntnet_global = new()
 	build_news_list()
 	build_emails_list()
 	build_reports_list()
-	add_log("NTNet logging system activated.")
+	add_log("SolNet logging system activated.")
 
 /datum/ntnet/proc/add_log_with_ids_check(var/log_string, var/obj/item/weapon/computer_hardware/network_card/source = null)
 	if(intrusion_detection_enabled)

--- a/code/modules/modular_computers/NTNet/NTNet_relay.dm
+++ b/code/modules/modular_computers/NTNet/NTNet_relay.dm
@@ -1,6 +1,6 @@
 // Relays don't handle any actual communication. Global NTNet datum does that, relays only tell the datum if it should or shouldn't work.
 /obj/machinery/ntnet_relay
-	name = "NTNet Quantum Relay"
+	name = "SolNet Quantum Relay"
 	desc = "A very complex router and transmitter capable of connecting electronic devices together. Looks fragile."
 	use_power = 2
 	active_power_usage = 20000 //20kW, apropriate for machine that keeps massive cross-Zlevel wireless network operational.
@@ -65,7 +65,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "ntnet_relay.tmpl", "NTNet Quantum Relay", 500, 300, state = state)
+		ui = new(user, src, ui_key, "ntnet_relay.tmpl", "SolNet Quantum Relay", 500, 300, state = state)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/code/modules/modular_computers/_description.dm
+++ b/code/modules/modular_computers/_description.dm
@@ -1,6 +1,7 @@
 /*
 Program-based computers, designed to replace computer3 project and eventually most consoles on station
 
+Renamed to SolNet in-game, players will see that rather than NTNet
 
 1. Basic information
 Program based computers will allow you to do multiple things from single computer. Each computer will have programs, with more being downloadable from NTNet (stationwide network with wireless coverage)

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -219,7 +219,7 @@
 		return
 
 	if(P.requires_ntnet && !get_ntnet_status(P.requires_ntnet_feature)) // The program requires NTNet connection, but we are not connected to NTNet.
-		to_chat(user, "<span class='danger'>\The [src]'s screen shows \"NETWORK ERROR - Unable to connect to NTNet. Please retry. If problem persists contact your system administrator.\" warning.</span>")
+		to_chat(user, "<span class='danger'>\The [src]'s screen shows \"NETWORK ERROR - Unable to connect to SolNet. Please retry. If problem persists contact your system administrator.\" warning.</span>")
 		return
 
 	if(active_program)

--- a/code/modules/modular_computers/file_system/program_events.dm
+++ b/code/modules/modular_computers/file_system/program_events.dm
@@ -15,5 +15,5 @@
 	if(background)
 		computer.visible_message("<span class='warning'>\The [computer]'s screen displays an error: \"Network connectivity lost - process [filename].[filetype] (PID [rand(100,999)]) terminated.\"</span>", range = 1)
 	else
-		computer.visible_message("<span class='warning'>\The [computer]'s screen briefly freezes and then shows: \"FATAL NETWORK ERROR - NTNet connection lost. Please try again later. If problem persists, please contact your system administrator.\"</span>", range = 1)
+		computer.visible_message("<span class='warning'>\The [computer]'s screen briefly freezes and then shows: \"FATAL NETWORK ERROR - SolNet connection lost. Please try again later. If problem persists, please contact your system administrator.\"</span>", range = 1)
 		computer.update_icon()

--- a/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
@@ -1,6 +1,6 @@
 /datum/computer_file/program/access_decrypter
 	filename = "nt_accrypt"
-	filedesc = "NTNet Access Decrypter"
+	filedesc = "SolNet Access Decrypter"
 	program_icon_state = "hostile"
 	program_key_state = "security_key"
 	program_menu_icon = "unlocked"
@@ -75,7 +75,7 @@
 		return 1
 
 /datum/nano_module/program/access_decrypter
-	name = "NTNet Access Decrypter"
+	name = "SolNet Access Decrypter"
 	var/list/restricted_access_codes = list() // access codes that are not hackable due to balance reasons
 
 /datum/nano_module/program/access_decrypter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -4,7 +4,7 @@
 	program_icon_state = "hostile"
 	program_key_state = "security_key"
 	program_menu_icon = "arrow-4-diag"
-	extended_desc = "This advanced script can perform denial of service attacks against NTNet quantum relays. The system administrator will probably notice this. Multiple devices can run this program together against same relay for increased effect"
+	extended_desc = "This advanced script can perform denial of service attacks against SolNet quantum relays. The system administrator will probably notice this. Multiple devices can run this program together against same relay for increased effect"
 	size = 20
 	requires_ntnet = 1
 	available_on_ntnet = 0

--- a/code/modules/modular_computers/file_system/programs/generic/news_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/news_browser.dm
@@ -1,6 +1,6 @@
 /datum/computer_file/program/newsbrowser
 	filename = "newsbrowser"
-	filedesc = "NTNet/ExoNet News Browser"
+	filedesc = "SolNet/ExoNet News Browser"
 	extended_desc = "This program may be used to view and download news articles from the network."
 	program_icon_state = "generic"
 	program_key_state = "generic_key"
@@ -87,7 +87,7 @@
 
 
 /datum/nano_module/program/computer_newsbrowser
-	name = "NTNet/ExoNet News Browser"
+	name = "SolNet/ExoNet News Browser"
 
 /datum/nano_module/program/computer_newsbrowser/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 
@@ -125,7 +125,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "news_browser.tmpl", "NTNet/ExoNet News Browser", 575, 750, state = state)
+		ui = new(user, src, ui_key, "news_browser.tmpl", "SolNet/ExoNet News Browser", 575, 750, state = state)
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
@@ -1,6 +1,6 @@
 /datum/computer_file/program/ntnetdownload
 	filename = "ntndownloader"
-	filedesc = "NTNet Software Download Tool"
+	filedesc = "SolNet Software Download Tool"
 	program_icon_state = "generic"
 	program_key_state = "generic_key"
 	program_menu_icon = "arrowthickstop-1-s"
@@ -42,7 +42,7 @@
 	ui_header = "downloader_running.gif"
 
 	if(PRG in ntnet_global.available_station_software)
-		generate_network_log("Began downloading file [PRG.filename].[PRG.filetype] from NTNet Software Repository.")
+		generate_network_log("Began downloading file [PRG.filename].[PRG.filetype] from SolNet Software Repository.")
 		hacked_download = 0
 	else if(PRG in ntnet_global.available_antag_software)
 		generate_network_log("Began downloading file **ENCRYPTED**.[PRG.filetype] from unspecified server.")
@@ -196,7 +196,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "ntnet_downloader.tmpl", "NTNet Download Program", 575, 700, state = state)
+		ui = new(user, src, ui_key, "ntnet_downloader.tmpl", "SolNet Download Program", 575, 700, state = state)
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -1,14 +1,14 @@
 /datum/computer_file/program/chatclient
 	filename = "ntnrc_client"
-	filedesc = "NTNet Relay Chat Client"
+	filedesc = "SolNet Relay Chat Client"
 	program_icon_state = "command"
 	program_key_state = "med_key"
 	program_menu_icon = "comment"
-	extended_desc = "This program allows communication over NTNRC network"
+	extended_desc = "This program allows communication over SolNRC network"
 	size = 8
 	requires_ntnet = 1
 	requires_ntnet_feature = NTNET_COMMUNICATION
-	network_destination = "NTNRC server"
+	network_destination = "NTNRC server" 
 	ui_header = "ntnrc_idle.gif"
 	available_on_ntnet = 1
 	nanomodule_path = /datum/nano_module/program/computer_chatclient/
@@ -87,7 +87,7 @@
 		var/mob/living/user = usr
 		if(can_run(usr, 1, access_bridge))
 			if(channel)
-				var/response = alert(user, "Really engage admin-mode? You will be disconnected from your current channel!", "NTNRC Admin mode", "Yes", "No")
+				var/response = alert(user, "Really engage admin-mode? You will be disconnected from your current channel!", "SolNRC Admin mode", "Yes", "No")
 				if(response == "Yes")
 					if(channel)
 						channel.remove_client(src)
@@ -116,7 +116,7 @@
 		var/datum/computer_file/data/logfile = new/datum/computer_file/data/logfile()
 		// Now we will generate HTML-compliant file that can actually be viewed/printed.
 		logfile.filename = logname
-		logfile.stored_data = "\[b\]Logfile dump from NTNRC channel [channel.title]\[/b\]\[BR\]"
+		logfile.stored_data = "\[b\]Logfile dump from SolNRC channel [channel.title]\[/b\]\[BR\]"
 		for(var/logstring in channel.messages)
 			logfile.stored_data += "[logstring]\[BR\]"
 		logfile.stored_data += "\[b\]Logfile dump completed.\[/b\]"
@@ -182,7 +182,7 @@
 	..(forced)
 
 /datum/nano_module/program/computer_chatclient
-	name = "NTNet Relay Chat Client"
+	name = "SolNet Relay Chat Client"
 
 /datum/nano_module/program/computer_chatclient/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 	if(!ntnet_global || !ntnet_global.chat_channels)
@@ -226,7 +226,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "ntnet_chat.tmpl", "NTNet Relay Chat Client", 575, 700, state = state)
+		ui = new(user, src, ui_key, "ntnet_chat.tmpl", "SolNet Relay Chat Client", 575, 700, state = state)
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/modular_computers/file_system/programs/generic/nttransfer.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/nttransfer.dm
@@ -2,7 +2,7 @@ var/global/nttransfer_uid = 0
 
 /datum/computer_file/program/nttransfer
 	filename = "nttransfer"
-	filedesc = "NTNet P2P Transfer Client"
+	filedesc = "SolNet P2P Transfer Client"
 	extended_desc = "This program allows for simple file transfer via direct peer to peer connection."
 	program_icon_state = "comm_logs"
 	program_key_state = "generic_key"
@@ -77,7 +77,7 @@ var/global/nttransfer_uid = 0
 
 
 /datum/nano_module/program/computer_nttransfer
-	name = "NTNet P2P Transfer Client"
+	name = "SolNet P2P Transfer Client"
 
 /datum/nano_module/program/computer_nttransfer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
 	if(!program)
@@ -126,7 +126,7 @@ var/global/nttransfer_uid = 0
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "ntnet_transfer.tmpl", "NTNet P2P Transfer Client", 575, 700, state = state)
+		ui = new(user, src, ui_key, "ntnet_transfer.tmpl", "SolNet P2P Transfer Client", 575, 700, state = state)
 		ui.auto_update_layout = 1
 		ui.set_initial_data(data)
 		ui.open()

--- a/code/modules/modular_computers/file_system/programs/research/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/research/ntmonitor.dm
@@ -1,6 +1,6 @@
 /datum/computer_file/program/ntnetmonitor
 	filename = "ntmonitor"
-	filedesc = "NTNet Diagnostics and Monitoring"
+	filedesc = "SolNet Diagnostics and Monitoring"
 	program_icon_state = "comm_monitor"
 	program_key_state = "generic_key"
 	program_menu_icon = "wrench"
@@ -12,7 +12,7 @@
 	nanomodule_path = /datum/nano_module/computer_ntnetmonitor/
 
 /datum/nano_module/computer_ntnetmonitor
-	name = "NTNet Diagnostics and Monitoring"
+	name = "SolNet Diagnostics and Monitoring"
 	available_to_ai = TRUE
 
 /datum/nano_module/computer_ntnetmonitor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = GLOB.default_state)
@@ -37,7 +37,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "ntnet_monitor.tmpl", "NTNet Diagnostics and Monitoring Tool", 575, 700, state = state)
+		ui = new(user, src, ui_key, "ntnet_monitor.tmpl", "SolNet Diagnostics and Monitoring Tool", 575, 700, state = state)
 		if(host.update_layout())
 			ui.auto_update_layout = 1
 		ui.set_initial_data(data)
@@ -68,7 +68,7 @@
 		// NTNet is enabled and user is about to shut it down. Let's ask them if they really want to do it, as wirelessly connected computers won't connect without NTNet being enabled (which may prevent people from turning it back on)
 		if(!user)
 			return 1
-		var/response = alert(user, "Really disable NTNet wireless? If your computer is connected wirelessly you won't be able to turn it back on! This will affect all connected wireless devices.", "NTNet shutdown", "Yes", "No")
+		var/response = alert(user, "Really disable SolNet wireless? If your computer is connected wirelessly you won't be able to turn it back on! This will affect all connected wireless devices.", "SolNet shutdown", "Yes", "No")
 		if(response == "Yes")
 			ntnet_global.setting_disabled = 1
 		return 1

--- a/code/modules/modular_computers/hardware/network_card.dm
+++ b/code/modules/modular_computers/hardware/network_card.dm
@@ -1,8 +1,8 @@
 var/global/ntnet_card_uid = 1
 
 /obj/item/weapon/computer_hardware/network_card/
-	name = "basic NTNet network card"
-	desc = "A basic network card for usage with standard NTNet frequencies."
+	name = "basic SolNet network card"
+	desc = "A basic network card for usage with standard SolNet frequencies."
 	power_usage = 50
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 1)
 	critical = 0
@@ -31,8 +31,8 @@ var/global/ntnet_card_uid = 1
 	ntnet_card_uid++
 
 /obj/item/weapon/computer_hardware/network_card/advanced
-	name = "advanced NTNet network card"
-	desc = "An advanced network card for usage with standard NTNet frequencies. It's transmitter is strong enough to connect even when far away."
+	name = "advanced SolNet network card"
+	desc = "An advanced network card for usage with standard SolNet frequencies. It's transmitter is strong enough to connect even when far away."
 	long_range = 1
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 2)
 	power_usage = 100 // Better range but higher power usage.
@@ -40,8 +40,8 @@ var/global/ntnet_card_uid = 1
 	hardware_size = 1
 
 /obj/item/weapon/computer_hardware/network_card/wired
-	name = "wired NTNet network card"
-	desc = "An advanced network card for usage with standard NTNet frequencies. This one also supports wired connection."
+	name = "wired SolNet network card"
+	desc = "An advanced network card for usage with standard SolNet frequencies. This one also supports wired connection."
 	ethernet = 1
 	origin_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 3)
 	power_usage = 100 // Better range but higher power usage.

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -2,7 +2,7 @@
 
 /obj/machinery/lapvend
 	name = "computer vendor"
-	desc = "A vending machine with a built-in microfabricator, capable of dispensing various NT-branded computers."
+	desc = "A vending machine with a built-in microfabricator, capable of dispensing various Zebra Industries computers."
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "robotics"
 	layer = BELOW_OBJ_LAYER

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1708,7 +1708,7 @@ CIRCUITS BELOW
 	sort_string = "VAAAB"
 
 /datum/design/circuit/ntnet_relay
-	name = "NTNet Quantum Relay"
+	name = "SolNet Quantum Relay"
 	id = "ntnet_relay"
 	req_tech = list(TECH_DATA = 4)
 	build_path = /obj/item/weapon/circuitboard/ntnet_relay

--- a/html/changelogs/aguyiguess-rebranding.yml
+++ b/html/changelogs/aguyiguess-rebranding.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.
+author: aguyiguess
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "NTNet has been rebranded to SolNet."

--- a/nano/templates/computer_fabricator.tmpl
+++ b/nano/templates/computer_fabricator.tmpl
@@ -57,7 +57,7 @@
 	<hr>
 	<b>Battery</b> allows your device to operate without external utility power source. Advanced batteries increase battery life.<br>
 	<b>Hard Drive</b> stores file on your device. Advanced drives can store more files, but use more power, shortening battery life.<br>
-	<b>Network Card</b> allows your device to wirelessly connect to the local NTNet network. Basic cards are limited to on-station use, while advanced cards can operate anywhere near the uplink, which includes the asteroid outposts. Advanced cards also tend to have better bandwidth.<br>
+	<b>Network Card</b> allows your device to wirelessly connect to the local SolNet network. Basic cards are limited to on-station use, while advanced cards can operate anywhere near the uplink, which includes the asteroid outposts. Advanced cards also tend to have better bandwidth.<br>
 	<b>Processor Unit</b> is critical for your device's functionality. It allows you to run programs from your hard drive. Advanced CPUs use more power, but allow you to run more programs on background at once.<br>
 	<b>Tesla Relay</b> is an advanced wireless power relay that allows your device to connect to nearby area power controller to provide alternative power source.<br>
 	<b>Nano Printer</b> is device that allows printing of various documents. This device was certified EcoFriendlyPlus and is capable of recycling existing paper for printing purposes.<br>

--- a/nano/templates/email_administration.tmpl
+++ b/nano/templates/email_administration.tmpl
@@ -79,7 +79,7 @@
 		<b>No messages found in selected account.</b>
 	{{/if}}	
 {{else}}
-	<h2>Welcome to NTNet Email Administration System</h2>
+	<h2>Welcome to SolNet Email Administration System</h2>
 	<i>SECURE SYSTEM - Have your identification ready</i><br><br>
 	{{:helper.link('Create New Account', null, {'newaccount' : 1})}}<br><br>
 	<b>Select account which you wish to administrate:</b>

--- a/nano/templates/email_client.tmpl
+++ b/nano/templates/email_client.tmpl
@@ -168,7 +168,7 @@
 		{{/if}}
 	{{/if}}
 {{else}}
-	<b>Welcome to NTNet Email System. Please log in.</b>
+	<b>Welcome to SolNet Email System. Please log in.</b>
 	<div class="item">
 		<div class="itemLabel">
 			Email address:

--- a/nano/templates/ntnet_monitor.tmpl
+++ b/nano/templates/ntnet_monitor.tmpl
@@ -1,7 +1,7 @@
 <h1>WIRELESS CONNECTIVITY</h1>
 	<div class="item">
 		<div class="itemLabelWide">
-                	Active NTNet Relays: 
+                	Active SolNet Relays: 
 		</div>
 		<div class="itemContentNarrow">
                 	<b>{{:data.ntnetrelays}}</b>


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
There are a LOT of NTNet files in game so I might've missed something, there was at least 75 files to go through.

NTNet is referred to as SolNet in-game now. Not any of the variables or procs. 

Additionally, in the laptop_vendor.dm file, I changed NT-branded to Zebra Industries. 