### PR TITLE
LimbPrintRemoval

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1430,20 +1430,6 @@ CIRCUITS BELOW
 	build_path = /obj/item/weapon/circuitboard/crew
 	sort_string = "FAGAI"
 
-/datum/design/circuit/bioprinter
-	name = "bioprinter"
-	id = "bioprinter"
-	req_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
-	build_path = /obj/item/weapon/circuitboard/bioprinter
-	sort_string = "FAGAK"
-
-/datum/design/circuit/roboprinter
-	name = "prosthetic organ fabricator"
-	id = "roboprinter"
-	req_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 3)
-	build_path = /obj/item/weapon/circuitboard/roboprinter
-	sort_string = "FAGAM"
-
 /datum/design/circuit/rdconsole
 	name = "R&D control console"
 	id = "rdconsole"

--- a/html/changelogs/Snypehunter007-PR-840.yml
+++ b/html/changelogs/Snypehunter007-PR-840.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Snypehunter007
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removed the ability for Roboprinter and Bioprinter circuits to be researched, essentially removing the two from the game."


### PR DESCRIPTION
Removes roboprinter and bioprinter circuits from the research designs list + changelog.

Fixes #805 