### PR TITLE
Nest verb fix

### DIFF
--- a/code/modules/necromorph/corruption/nest.dm
+++ b/code/modules/necromorph/corruption/nest.dm
@@ -73,6 +73,7 @@
 /obj/structure/corruption_node/nest/verb/upgrade_spawner(var/mob/user)
 	set name = "Upgrade Spawner"
 	set desc = "Allows turning a nest into a spawner"
+	set category = null
 	set src in view()
 	if (!istype(user))
 		user = usr

--- a/html/changelogs/nest-verb-fix.yml
+++ b/html/changelogs/nest-verb-fix.yml
@@ -1,0 +1,6 @@
+author: Jeser
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed necromorph nest's Upgrade Spawner verb appearing in verb tabs and lagging players in view. Verb is still accessible via right clicking nest."


### PR DESCRIPTION
bugfix: "Fixed necromorph nest's Upgrade Spawner verb appearing in verb tabs and lagging players in view. Verb is still accessible via right clicking nest."