### PR TITLE
Cyst and slam tweaks

### DIFF
--- a/code/game/gamemodes/marker/gamemodes.dm
+++ b/code/game/gamemodes/marker/gamemodes.dm
@@ -116,13 +116,9 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	set category = "Admin"
 	set desc = "Forces the marker to immediately activate"
 
-	if(check_rights(R_MOD))
-		var/confirm = alert(src, "You will be activating the marker. Are you super duper sure?", "Make us Whole?", "Send in the Necromorphs!", "On second thought, maybe not...")
-		if(confirm != "Send in the Necromorphs!")
-			return
-	else if(!check_rights(R_MOD))
+	var/confirm = alert(src, "You will be activating the marker. Are you super duper sure?", "Make us Whole?", "Send in the Necromorphs!", "On second thought, maybe not...")
+	if(confirm != "Send in the Necromorphs!")
 		return
-
 
 	var/datum/game_mode/marker/GM = ticker.mode
 	if (!istype(GM))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -131,16 +131,16 @@
 			for(var/atom/movable/AM in contents)
 				AM.ex_act(severity++, epicentre)
 
-			take_damage(rand(150,300), BRUTE, null, epicentre)
+			take_damage(rand(200,400), BRUTE, null, epicentre)
 		if(2.0)
 			if(prob(50))
 				for(var/atom/movable/AM in contents)
 					AM.ex_act(severity++, epicentre)
 
-			take_damage(rand(60,150), BRUTE, null, epicentre)
+			take_damage(rand(100,200), BRUTE, null, epicentre)
 
 		if(3.0)
-			take_damage(rand(25,60), BRUTE, null, epicentre)
+			take_damage(rand(25,100), BRUTE, null, epicentre)
 
 /obj/structure/bullet_act(var/obj/item/projectile/P)
 	take_damage(P.get_structure_damage(), user = P.firer, used_weapon = P)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -6,7 +6,7 @@
 	layer = BELOW_OBJ_LAYER
 	w_class = ITEM_SIZE_NO_CONTAINER
 	var/state = 0
-	health = 200
+	max_health = 80
 	var/cover = 50 //how much cover the girder provides against projectiles.
 	var/material/reinf_material
 	var/reinforcing = 0
@@ -18,7 +18,6 @@
 /obj/structure/girder/displaced
 	icon_state = "displaced"
 	anchored = 0
-	health = 50
 	cover = 25
 
 /obj/structure/girder/attack_generic(var/mob/user, var/damage, var/attack_message = "smashes apart", var/wallbreaker)
@@ -42,7 +41,7 @@
 /obj/structure/girder/proc/reset_girder()
 	anchored = 1
 	cover = initial(cover)
-	health = min(health,initial(health))
+	health = max_health
 	state = 0
 	icon_state = initial(icon_state)
 	reinforcing = 0
@@ -179,7 +178,7 @@
 
 /obj/structure/girder/proc/reinforce_girder()
 	cover = 75
-	health = 500
+	max_health = 120
 	state = 2
 	icon_state = "reinforced"
 	reinforcing = 0
@@ -188,34 +187,13 @@
 	new /obj/item/stack/material/steel(get_turf(src))
 	qdel(src)
 
-/obj/structure/girder/attack_hand(mob/user as mob)
-	if (HULK in user.mutations)
-		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
-		dismantle()
-		return
-	return ..()
 
 
-/obj/structure/girder/ex_act(severity)
-	switch(severity)
-		if(1.0)
-			qdel(src)
-			return
-		if(2.0)
-			if (prob(30))
-				dismantle()
-			return
-		if(3.0)
-			if (prob(5))
-				dismantle()
-			return
-		else
-	return
 
 /obj/structure/girder/cult
 	icon= 'icons/obj/cult.dmi'
 	icon_state= "cultgirder"
-	health = 250
+	max_health = 120
 	cover = 70
 
 /obj/structure/girder/cult/dismantle()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -212,7 +212,6 @@
 	ChangeTurf(floor_type)
 
 /turf/simulated/wall/ex_act(severity)
-	world << "Wall ex act [severity]"
 	switch(severity)
 		if(1.0)
 			take_damage(rand(500, 800))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -212,6 +212,7 @@
 	ChangeTurf(floor_type)
 
 /turf/simulated/wall/ex_act(severity)
+	world << "Wall ex act [severity]"
 	switch(severity)
 		if(1.0)
 			take_damage(rand(500, 800))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -214,7 +214,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_analyse_health_panel,
 	/client/proc/visualpower,
 	/client/proc/visualpower_remove,
-	/client/proc/debug_vectorpool
+	/client/proc/debug_vectorpool,
+	/client/proc/activate_marker
 	)
 
 var/list/admin_verbs_paranoid_debug = list(

--- a/code/modules/mob/living/abilities/leaper_tailstrike.dm
+++ b/code/modules/mob/living/abilities/leaper_tailstrike.dm
@@ -226,6 +226,10 @@
 		if(error_messages) to_chat(src, "Target is too close, step back to use your tail!")
 		return
 
+	//Can't destroy walls
+	if (isturf(target))
+		return FALSE
+
 	return TRUE
 
 /mob/living/can_tailstrike(var/atom/target, var/error_messages = TRUE)

--- a/code/modules/mob/living/abilities/slam.dm
+++ b/code/modules/mob/living/abilities/slam.dm
@@ -139,7 +139,6 @@
 			T.ex_act(4-effective_power, user)
 			if (!QDELETED(T) && T.density)
 				//If the turf is dense (walls, but not floors) then it gets hit a second time
-				world << "Hitting [T] twice"
 				T.ex_act(4-power, user)
 
 

--- a/code/modules/mob/living/abilities/slam.dm
+++ b/code/modules/mob/living/abilities/slam.dm
@@ -4,6 +4,7 @@
 
 	Any mobs in the affected area take heavy damage. This damage is multiplied if the victim is lying down, or otherwise incapacitated
 	Any standing mobs in the affected area which are smaller than the attacker, will be knocked down for a time
+	Any dense nonmob atoms in the affected area are hit twice
 */
 
 /*
@@ -123,11 +124,23 @@
 				shake_camera(L, 3, damage/10) //Shake camera of mobs too
 			else
 				//Atoms get ex_acted
-				if (power)A.ex_act(4-power, user)
+				var/effective_power = power
+				if (A.density)
+					effective_power++
+				if (effective_power)
+					A.ex_act(4-effective_power, user)
 
-		T.shake_animation(damage)	//Shake the turf itself
-		if (power)
-			T.ex_act(4-power, user)
+
+		var/effective_power = power
+		if (T.density)
+			effective_power++
+		if (effective_power)
+			T.shake_animation(damage)	//Shake the turf itself
+			T.ex_act(4-effective_power, user)
+			if (!QDELETED(T) && T.density)
+				//If the turf is dense (walls, but not floors) then it gets hit a second time
+				world << "Hitting [T] twice"
+				T.ex_act(4-power, user)
 
 
 	//Now we weaken these values for the next round
@@ -153,11 +166,18 @@
 				shake_camera(L, 3, damage/10) //Shake camera of mobs too
 			else
 				//Atoms get ex_acted
-				if (power)A.ex_act(4-power, user)
+				var/effective_power = power
+				if (A.density)
+					effective_power++
+				if (effective_power)
+					A.ex_act(4-effective_power, user)
 
-		T.shake_animation(damage)	//Shake the turf itself
-		if (power)
-			T.ex_act(4-power, user)
+		var/effective_power = power
+		if (T.density)
+			effective_power++
+		if (effective_power)
+			T.shake_animation(damage)	//Shake the turf itself
+			T.ex_act(4-effective_power, user)
 
 
 	//Wait a bit longer before we return to neutral

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -1,5 +1,5 @@
-#define BRUTE_BIOBOMB_IMPACT_DAMAGE	10
-#define BRUTE_BIOBOMB_BLAST_DAMAGE	25
+#define BRUTE_BIOBOMB_IMPACT_DAMAGE	12
+#define BRUTE_BIOBOMB_BLAST_DAMAGE	30
 
 /datum/species/necromorph/brute
 	name = SPECIES_NECROMORPH_BRUTE
@@ -364,7 +364,7 @@ Brute will be forced into a reflexive curl under certain circumstances, but it c
 	'sound/effects/creatures/necromorph/cyst/cyst_fire_4.ogg'))
 
 	face_atom(A)
-	.= shoot_ability(/datum/extension/shoot/brute_biobomb, A , /obj/item/projectile/bullet/biobomb/weak, accuracy = 50, dispersion = 0, num = 1, windup_time = 1.5 SECONDS, fire_sound = firesound, nomove = 2 SECOND, cooldown = 12 SECONDS)
+	.= shoot_ability(/datum/extension/shoot/brute_biobomb, A , /obj/item/projectile/bullet/biobomb/weak, accuracy = 50, dispersion = 0, num = 1, windup_time = 1.25 SECONDS, fire_sound = firesound, nomove = 2 SECOND, cooldown = 12 SECONDS)
 	if (.)
 		play_species_audio(src, SOUND_ATTACK, VOLUME_MID, 1, 3)
 
@@ -383,9 +383,9 @@ Brute will be forced into a reflexive curl under certain circumstances, but it c
 	sleep(windup_time)
 
 /datum/extension/shoot/brute_biobomb/fire_animation()
-	spawn(5)
+	spawn(4)
 		var/mob/living/L = user
-		animate(L, transform=L.get_default_transform(),pixel_x = L.default_pixel_x, time = 1 SECOND, flags = ANIMATION_PARALLEL)
+		animate(L, transform=L.get_default_transform(),pixel_x = L.default_pixel_x, time = 0.8 SECOND, flags = ANIMATION_PARALLEL)
 
 /obj/item/projectile/bullet/biobomb/weak
 	blast_power = BRUTE_BIOBOMB_BLAST_DAMAGE

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -17,7 +17,7 @@
 	blurb = "A long range ambusher, the leaper can leap on unsuspecting victims from afar, knock them down, and tear them apart with its bladed tail. Not good for prolonged combat though."
 	unarmed_types = list(/datum/unarmed_attack/claws) //Bite attack is a backup if blades are severed
 	total_health = 90
-	biomass = 80
+	biomass = 75
 
 	//Normal necromorph flags plus no slip
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_POISON  | SPECIES_FLAG_NO_BLOCK | SPECIES_FLAG_NO_SLIP
@@ -279,10 +279,12 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	if (!A)
 		A = get_step(src, dir)
 
-	//The sound has a randomised delay
-	spawn(rand_between(0, 2 SECONDS))
-		play_species_audio(src, SOUND_ATTACK, 30, 1)
-	return tailstrike_attack(A, _damage = 22.5, _windup_time = 0.75 SECONDS, _winddown_time = 1.2 SECONDS, _cooldown = 0.5)
+
+	.=tailstrike_attack(A, _damage = 22.5, _windup_time = 0.75 SECONDS, _winddown_time = 1.2 SECONDS, _cooldown = 0.5)
+	if (.)
+		//The sound has a randomised delay
+		spawn(rand_between(0, 2 SECONDS))
+			play_species_audio(src, SOUND_ATTACK, 30, 1)
 
 
 /mob/living/carbon/human/proc/tailstrike_leaper_enhanced(var/atom/A)

--- a/code/modules/mob/living/carbon/human/species/necromorph/mob.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/mob.dm
@@ -101,11 +101,16 @@
 	return FALSE
 
 
+//We'll check the species on the brain first, before the rest of the body
 /mob/living/carbon/human/is_necromorph()
-	if (istype(species, /datum/species/necromorph))
-		return TRUE
-	return FALSE
+	var/obj/item/organ/internal/brain/B = internal_organs_by_name[BP_BRAIN]
+	if (B && B.species)
+		return B.species.is_necromorph()
+	return species.is_necromorph()
 
+
+/datum/species/necromorph/is_necromorph()
+	return TRUE
 
 
 

--- a/code/modules/necromorph/corruption/cyst.dm
+++ b/code/modules/necromorph/corruption/cyst.dm
@@ -81,6 +81,21 @@
 	if (AM == src || AM == attached)	//Don't fire at ourselves or what we're stuck to
 		return
 
+	//Don't trigger on non physical objects
+	if (AM.atom_flags & ATOM_FLAG_INTANGIBLE)
+		return
+
+	//Don't get triggered by bullets
+	if (isprojectile(AM))
+		return
+
+	//If an organ was just cut off within the past couple seconds and is now flying through the air, don't shoot at it
+	//this was causing necromorphs to get shot whenever their limbs were cut
+	if (istype(AM, /obj/item/organ))
+		var/obj/item/organ/O = AM
+		if ((world.time - O.severed_time) < 2 SECONDS)
+			return
+
 	if (AM.is_necromorph())
 		return	//Necromorphs don't trigger firing
 
@@ -171,7 +186,7 @@
 	damage = CYST_IMPACT_DAMAGE	//The direct on-hit damage is minor, most of the effect is in a resulting explosion
 	var/exploded = FALSE
 	check_armour = "bomb"
-	step_delay = 3
+	step_delay = 3.2
 	muzzle_type = /obj/effect/projectile/bio/muzzle
 	grippable = TRUE
 	embed = FALSE

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -858,6 +858,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!(limb_flags & ORGAN_FLAG_CAN_AMPUTATE) || !owner)
 		return
 
+	severed_time = world.time
+
 	if(BP_IS_CRYSTAL(src) || (disintegrate == DROPLIMB_EDGE && species.limbs_are_nonsolid))
 		disintegrate = DROPLIMB_BLUNT //splut
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -51,6 +51,7 @@
 
 /obj/item/organ/internal/removed(var/mob/living/user, var/drop_organ=1, var/detach=1)
 	if(owner)
+		severed_time = world.time
 		owner.internal_organs_by_name[organ_tag] = null
 		owner.internal_organs_by_name -= organ_tag
 		owner.internal_organs_by_name -= null

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -27,6 +27,7 @@ var/list/organ_cache = list()
 	var/rejecting                     // Is this organ already being rejected?
 
 	var/death_time
+	var/severed_time = 0	//If this organ was cut off/out of a humanoid mob, when did that happen?
 
 	biomass = 0						//How much biomass this organ is worth to the marker.
 

--- a/html/changelogs/slamcyst.yml
+++ b/html/changelogs/slamcyst.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Brute's slam attack now deals much more damage to dense objects, especially walls."
+  - tweak: "Brute's biobomb attack is now a bit faster to fire and deals more damage."
+  - tweak: "Leaper's tailstrike can no longer hit walls"
+  - tweak: "Cysts will no longer fire at projectiles or freshly severed limbs"
+  - bugfix: "Divider puppet now properly counts as a necromorph, and won't be attacked by traps."
+  - bugfix: "Fixed some cases where girders were almost impossible to break"
+  

--- a/html/changelogs/slamcyst.yml
+++ b/html/changelogs/slamcyst.yml
@@ -36,6 +36,7 @@ changes:
   - tweak: "Brute's slam attack now deals much more damage to dense objects, especially walls."
   - tweak: "Brute's biobomb attack is now a bit faster to fire and deals more damage."
   - tweak: "Leaper's tailstrike can no longer hit walls"
+  - tweak: "Leaper's biomass cost reduced from 80 to 75"
   - tweak: "Cysts will no longer fire at projectiles or freshly severed limbs"
   - bugfix: "Divider puppet now properly counts as a necromorph, and won't be attacked by traps."
   - bugfix: "Fixed some cases where girders were almost impossible to break"


### PR DESCRIPTION
Closes #877 

changes: 
  - tweak: "Brute's slam attack now deals much more damage to dense objects, especially walls."
  - tweak: "Brute's biobomb attack is now a bit faster to fire and deals more damage."
  - tweak: "Leaper's tailstrike can no longer hit walls"
  - tweak: "Leaper's biomass cost reduced from 80 to 75"
  - tweak: "Cysts will no longer fire at projectiles or freshly severed limbs"
  - bugfix: "Divider puppet now properly counts as a necromorph, and won't be attacked by traps."
  - bugfix: "Fixed some cases where girders were almost impossible to break"