### PR TITLE
Total Biomass Purchasing

### DIFF
--- a/code/__defines/qdel.dm
+++ b/code/__defines/qdel.dm
@@ -26,6 +26,9 @@
 
 #define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) } ; x = null }
 
+#define QDEL_LIST(x) if(x) { for(var/y in x) { qdel(y) } ; x = list() }
+#define QDEL_ASSOC_LIST(x) if(x) { for(var/y in x) { if(x[y]){qdel(x[y])} } ; x = list() }
+
 #define QDEL_NULL(x) if(x) { qdel(x) ; x = null }
 
 #define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE)

--- a/code/controllers/subsystems/necromorph.dm
+++ b/code/controllers/subsystems/necromorph.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(necromorph)
 	var/list/major_vessels = list()	//Necromorphs that need a player to control them. they are inert husks without one.
 	var/list/minor_vessels	=	list()	//Necromorphs that have AI and don't need a player, but can be possessed anyway if someone wants to do manual control
 	var/list/shards = list()	//Marker shards in the world
+	var/list/spawned_necromorph_types = list() //Assoc list of typepath = quantity, tracks the number of necromorphs ever spawned this round
 
 	//Signal Lists
 	var/list/signals	=	list()	//List of all signal players
@@ -24,6 +25,7 @@ SUBSYSTEM_DEF(necromorph)
 	var/list/sightings = list()
 
 	//Misc
+	var/list/massive_necroatoms = list()	//A list of all necromorphs which are worth biomass
 
 	//Tiny bit of a hack. This shared global variable is used to cycle through the shards list.
 	//Under the mostly likely assumption that two people generally won't be jumping to shards at the same time
@@ -109,7 +111,26 @@ SUBSYSTEM_DEF(necromorph)
 
 
 
+/proc/add_massive_atom(var/atom/A)
+	if ((A in SSnecromorph.massive_necroatoms))
+		return
 
+	SSnecromorph.massive_necroatoms += A
+	var/obj/machinery/marker/M = get_marker()
+	if (M)
+		M.invested_biomass = NONSENSICAL_VALUE
+		M.unavailable_biomass = NONSENSICAL_VALUE
+
+
+/proc/remove_massive_atom(var/atom/A)
+	if (!(A in SSnecromorph.massive_necroatoms))
+		return
+
+	SSnecromorph.massive_necroatoms -= A
+	var/obj/machinery/marker/M = get_marker()
+	if (M)
+		M.invested_biomass = NONSENSICAL_VALUE
+		M.unavailable_biomass = NONSENSICAL_VALUE
 
 
 //Possible future todo: Allow this to take some kind of faction id in order to allow a necros vs necros gamemode

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -58,6 +58,7 @@
 /mob/living/carbon/human/Destroy()
 	GLOB.human_mob_list -= src
 	worn_underwear = null
+	remove_massive_atom(src)	//Remove necromorphs from the massive atoms list
 	for(var/organ in organs)
 		qdel(organ)
 	return ..()

--- a/code/modules/mob/living/carbon/human/species/necromorph/lesser.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/lesser.dm
@@ -22,6 +22,7 @@
 	max_gas = null
 	harm_intent_damage = 5
 	mass = 1
+	biomass = 0
 	density = FALSE
 	var/lifespan = 10 MINUTES	//Minor necromorphs don't last forever, their health gradually ticks down
 	stompable = TRUE
@@ -38,6 +39,9 @@
 
 /mob/living/simple_animal/necromorph/Initialize()
 	.=..()
+	SSnecromorph.minor_vessels |= src
+	if (get_biomass())
+		add_massive_atom(src)
 	if (lifespan)
 		var/time_per_tick = lifespan / max_health
 		addtimer(CALLBACK(src, /mob/living/simple_animal/necromorph/proc/decay), time_per_tick)
@@ -70,7 +74,8 @@
 /mob/living/simple_animal/necromorph/death()
 	if (LAZYLEN(pain_sounds))
 		playsound(src, pick(pain_sounds), VOLUME_LOUD, TRUE)
-
+	SSnecromorph.minor_vessels -= src
+	remove_massive_atom(src)
 	.=..()
 
 //Attack sounds when hitting
@@ -83,7 +88,10 @@
 
 
 
-
+/mob/living/simple_animal/necromorph/Destroy()
+	SSnecromorph.minor_vessels -= src
+	remove_massive_atom(src)
+	.=..()
 
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph.dm
@@ -14,11 +14,14 @@
 	var/marker_spawnable = TRUE	//Set this to true to allow the marker to spawn this type of necro. Be sure to unset it on the enhanced version unless desired
 	var/preference_settable = TRUE
 	biomass = 80	//This var is defined for all species
+	var/use_total_biomass = FALSE
 	var/biomass_reclamation	=	1	//The marker recovers cost*reclamation
 	var/biomass_reclamation_time	=	8 MINUTES	//How long does it take for all of the reclaimed biomass to return to the marker? This is a pseudo respawn timer
 	var/spawn_method = SPAWN_POINT	//What method of spawning from marker should be used? At a point or manual placement? check _defines/necromorph.dm
 	var/major_vessel = TRUE	//If true, we can fill this mob from the necroqueue
 	var/spawner_spawnable = FALSE	//If true, a nest can be upgraded to autospawn this unit
+	var/necroshop_item_type = /datum/necroshop_item //Give this a subtype if you want to have special behaviour for when this necromorph is spawned from the necroshop
+	var/global_limit = 0	//0 = no limit
 
 	strength    = STR_MEDIUM
 	show_ssd = "dead" //If its not moving, it looks like a corpse
@@ -210,6 +213,8 @@
 			var/obj/item/organ/external/E	= H.organs_by_name[organ_tag]
 			initial_health_values[organ_tag] = E.max_damage
 
+	if (biomass)
+		add_massive_atom(H)
 
 
 //Necromorphs die when they've taken enough total damage to all their limbs.
@@ -228,6 +233,7 @@
 		return
 	if (H.biomass)
 		SSnecromorph.marker.add_biomass_source(H, H.biomass*biomass_reclamation, biomass_reclamation_time, /datum/biomass_source/reclaim)
+		remove_massive_atom(H)
 	GLOB.necrovision.remove_source(H)
 
 //How much damage has this necromorph taken?

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -8,7 +8,9 @@
 	total_health = INFINITY	//This number doesn't matter, it won't ever be used
 	can_obliterate = FALSE
 	healing_factor = 4	//Lots of constant healing
-	biomass	=	1600	//Endgame, real expensive
+	biomass	=	3000	//Endgame, real expensive
+	use_total_biomass = TRUE
+	global_limit = 1
 	mass = 130
 	limb_health_factor = 1	//Not as fragile as a slasher
 	virus_immune = 1

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -8,7 +8,7 @@
 	total_health = INFINITY	//This number doesn't matter, it won't ever be used
 	can_obliterate = FALSE
 	healing_factor = 4	//Lots of constant healing
-	biomass	=	3000	//Endgame, real expensive
+	biomass	=	4500	//Endgame, real expensive
 	use_total_biomass = TRUE
 	global_limit = 1
 	mass = 130

--- a/code/modules/necromorph/corruption_nodes.dm
+++ b/code/modules/necromorph/corruption_nodes.dm
@@ -35,6 +35,8 @@
 	if (!isturf(loc))
 		dummy = TRUE
 
+	if (!dummy && SSnecromorph.marker && biomass_reclamation && biomass)
+		add_massive_atom(src)
 
 	update_icon()
 	if (!dummy)
@@ -49,7 +51,7 @@
 /obj/structure/corruption_node/Destroy()
 	if (!dummy && SSnecromorph.marker && biomass_reclamation)
 		SSnecromorph.marker.add_biomass_source(src, biomass*biomass_reclamation, reclamation_time, /datum/biomass_source/reclaim)
-
+		remove_massive_atom(src)
 	.=..()
 
 

--- a/html/changelogs/ubermorph_total.yml
+++ b/html/changelogs/ubermorph_total.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Tier IV Necromorphs are now spawned with total biomass instead of spending your storage. Total biomass includes the mass currently invested in necromorphs and corruption nodes, so there is no requirement to save up a lump sum."

--- a/nano/templates/necroshop.tmpl
+++ b/nano/templates/necroshop.tmpl
@@ -43,13 +43,20 @@ h3 {
 		<td style="width: 75%; vertical-align: top;">
 			{{if data.current}}
 				<h1>{{:data.current.name}}</h1>
+				{{if data.current.reqtotal}}
+					<hr>
+					<span class="notice" style="padding: 4px">Total Biomass: {{:data.total}}/{{:data.current.price}}    </br>
+					Total Biomass includes biomass currently invested in necromorphs and corruption nodes, whether they are alive, or dead and being reclaimed </br>
+					This can be spawned for free when you accumulate enough total mass.</span>
+					<hr>
+				{{/if}}
 				<div style="line-height: 120%; font-size: 11px;">{{:data.current.desc}}</div>
 			{{else}}
 				<h2>Nothing Selected</h2>
 			{{/if}}
 		</td>
 		<td style="width: 25%; vertical-align: top; text-align: center;">
-			<div style="height:100%;  height: 550px; overflow-y: auto;">
+			<div style="height:100%;  overflow-y: auto;">
 			<h2>Necromorphs</h2>
 			<hr>
 			{{for data.necromorphs}}


### PR DESCRIPTION
T4 necromorphs are intended to bring the round to an end, they are a necromorph victory condition.
The current system of requiring a large quantity of biomass to be saved up, has not worked well though Ubermorph is almost never seen aside from adminspawning.

This PR remedies that by moving T4 necros to a new system, Total Biomass. This counts:
-Biomass currently available in the marker
-Biomass that was spent on necromorphs or corruption nodes which are still alive
-Biomass spent on the above which is currently being reclaimed

In short, it counts all the sources that the marker "owns", and which can't be denied to it. 

Unabsorbed human corpses do not count, they still need to be eaten first

changes: 
  - tweak: "Tier IV Necromorphs are now spawned with total biomass instead of spending your storage. Total biomass includes the mass currently invested in necromorphs and corruption nodes, so there is no requirement to save up a lump sum."

Closes #882