### PR TITLE
Divider Speech

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1972,7 +1972,7 @@
 #include "code\modules\mob\living\carbon\human\species\necromorph\lesser.dm"
 #include "code\modules\mob\living\carbon\human\species\necromorph\lurker.dm"
 #include "code\modules\mob\living\carbon\human\species\necromorph\mob.dm"
-#include "code\modules\mob\living\carbon\human\species\necromorph\necromorph.dm"
+#include "code\modules\mob\living\carbon\human\species\necromorph\necromorph_species.dm"
 #include "code\modules\mob\living\carbon\human\species\necromorph\puker.dm"
 #include "code\modules\mob\living\carbon\human\species\necromorph\slasher.dm"
 #include "code\modules\mob\living\carbon\human\species\necromorph\spitter.dm"

--- a/code/__defines/languages.dm
+++ b/code/__defines/languages.dm
@@ -2,6 +2,8 @@
 #define LANGUAGE_GALCOM "English, Galactic Common"
 #define LANGUAGE_GUTTER "Gutter"
 #define LANGUAGE_SIGN "Sign Language"
+#define LANGUAGE_NECROCHAT "Signal Hivemind"
+
 // Language flags.
 #define WHITELISTED  1   // Language is available if the speaker is whitelisted.
 #define RESTRICTED   2   // Language can only be acquired by spawning or an admin.

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -155,7 +155,6 @@ var/global/list/string_slot_flags = list(
 	var/rkey = 0
 	paths = typesof(/datum/species)
 	for(var/T in paths)
-
 		rkey++
 
 		var/datum/species/S = T

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -856,10 +856,12 @@ proc/dd_sortedTextList(list/incoming)
 /proc/dump_list(var/list/L, var/depth = 0)
 	var/output = ""
 	var/depthstring = ""
+
 	for (var/i in 0 to depth)
 		depthstring = "[depthstring]-"
 
 	for (var/element in L)
+		var/typestring = "(?)"
 		if (islist(element))
 			output += "[dump_list(element, depth+1)]"
 		else if (L[element])
@@ -869,10 +871,16 @@ proc/dd_sortedTextList(list/incoming)
 				output += linestring
 				output += "[dump_list(L[element], depth+1)]"
 			else
-				linestring += "[L[element]]\n"
+				var/datum/thing = L[element]
+				if (istype(thing))
+					typestring = "([thing.type])"
+				linestring += "[L[element]][typestring]\n"
 				output += linestring
 		else
-			output += "[depthstring][element]\n"
+			var/datum/thing = element
+			if (istype(thing))
+				typestring = "([thing.type])"
+			output += "[depthstring][element][typestring]\n"
 
 	return output
 

--- a/code/datums/communication/necrochat.dm
+++ b/code/datums/communication/necrochat.dm
@@ -73,13 +73,14 @@
 	sanitize_and_communicate(/decl/communication_channel/necrochat, client, message)
 
 
-
+/*
 /mob/living/carbon/human/necromorph/say(var/message)
 	sanitize_and_communicate(/decl/communication_channel/necrochat, client, message)
 
 	if(prob(species.speech_chance) && check_audio_cooldown(SOUND_SPEECH))
 		set_audio_cooldown(SOUND_SPEECH, 5 SECONDS)
 		play_species_audio(src, SOUND_SPEECH, VOLUME_LOW, TRUE)
+*/
 
 /mob/living/simple_animal/necromorph/say(var/message)
 	sanitize_and_communicate(/decl/communication_channel/necrochat, client, message)
@@ -87,6 +88,40 @@
 	if(LAZYLEN(attack_sounds) && check_audio_cooldown(SOUND_SPEECH))
 		set_audio_cooldown(SOUND_SPEECH, 5 SECONDS)
 		playsound(src, pick(attack_sounds), VOLUME_MID, TRUE)
+
+
+
+/*
+	Necromorph language interface
+*/
+/datum/language/necromorph
+	name = LANGUAGE_NECROCHAT
+	desc = "A psychic hivemind between marker signals and their necromorph vessels"
+	speech_verb = "groans"
+	ask_verb = "wails"
+	exclaim_verb = "screams"
+	colour = "soghun"
+	key = "q"
+	flags = RESTRICTED | HIVEMIND
+	syllables = list("hs","zt","kr","st","sh")
+	shorthand = "RT"
+
+/datum/language/necromorph/broadcast(var/mob/living/speaker,var/message,var/speaker_mask)
+
+	/*
+	*/
+	sanitize_and_communicate(/decl/communication_channel/necrochat, speaker.client, message)
+
+	var/datum/species/S = speaker.get_mental_species_datum()
+	if(prob(S.speech_chance) && speaker.check_audio_cooldown(SOUND_SPEECH))
+		speaker.set_audio_cooldown(SOUND_SPEECH, 5 SECONDS)
+		S.play_species_audio(speaker, SOUND_SPEECH, VOLUME_LOW, TRUE)
+
+	//log_say("[key_name(speaker)] : ([name]) [message]")
+
+
+
+
 
 //Global Necromorph Procs
 //-------------------------

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -148,6 +148,14 @@
 	languages.Add(new_language)
 	return 1
 
+/mob/living/add_language(rem_language)
+	.=..()
+	if (.)
+		var/datum/language/L = all_languages[rem_language]
+		if (!default_language)
+			default_language = L
+
+
 /mob/proc/remove_language(var/rem_language)
 	var/datum/language/L = all_languages[rem_language]
 	. = (L in languages)
@@ -158,6 +166,12 @@
 	if(default_language == L)
 		default_language = null
 	return ..()
+
+/mob/proc/remove_all_languages()
+	world << "Remove all languages"
+	for (var/datum/language/L in languages)
+		world << "Removing [L]"
+		remove_language(L.name)
 
 // Can we speak this language, as opposed to just understanding it?
 /mob/proc/can_speak(datum/language/speaking)

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -168,9 +168,7 @@
 	return ..()
 
 /mob/proc/remove_all_languages()
-	world << "Remove all languages"
 	for (var/datum/language/L in languages)
-		world << "Removing [L]"
 		remove_language(L.name)
 
 // Can we speak this language, as opposed to just understanding it?

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -457,15 +457,6 @@
 	dna.check_integrity(src)
 	return
 
-/mob/living/carbon/human/get_species()
-	if(!species)
-		set_species()
-	return species.name
-
-/mob/living/carbon/human/get_species_datum()
-	if(!species)
-		set_species()
-	return species
 
 /mob/living/carbon/human/proc/play_xylophone()
 	if(!src.xylophone)

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/head.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/head.dm
@@ -69,6 +69,13 @@
 
 
 
+
+
+
+
+/*
+	Core Takeover Code
+*/
 /mob/living/simple_animal/necromorph/divider_component/head/proc/takeover(var/mob/living/carbon/human/H)
 	//Safety checks done, we are past the point of no return
 
@@ -110,6 +117,10 @@
 	mind.transfer_to(H)
 	H.verbs +=/mob/living/carbon/human/proc/abandon_vessel
 
+	//Fix up comms
+	H.remove_all_languages()
+	H.add_language(LANGUAGE_NECROCHAT)
+
 	//Apply debuffs
 	set_extension(H, /datum/extension/divider_puppet)
 	set_extension(H, /datum/extension/used_vessel)
@@ -119,6 +130,15 @@
 
 	//Delete this mob
 	qdel(src)
+
+
+
+
+
+
+
+
+
 
 
 /*

--- a/code/modules/mob/living/carbon/human/species/necromorph/mob.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/mob.dm
@@ -103,10 +103,8 @@
 
 //We'll check the species on the brain first, before the rest of the body
 /mob/living/carbon/human/is_necromorph()
-	var/obj/item/organ/internal/brain/B = internal_organs_by_name[BP_BRAIN]
-	if (B && B.species)
-		return B.species.is_necromorph()
-	return species.is_necromorph()
+	var/datum/species/S = get_mental_species_datum()
+	return S.is_necromorph()
 
 
 /datum/species/necromorph/is_necromorph()

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
@@ -118,7 +118,7 @@
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_POISON  | SPECIES_FLAG_NO_BLOCK      // Various specific features.
 	appearance_flags = 0      // Appearance/display related features.
 	spawn_flags = SPECIES_IS_RESTRICTED | SPECIES_NO_FBP_CONSTRUCTION | SPECIES_NO_FBP_CHARGEN           // Flags that specify who can spawn as this specie
-
+	language = LANGUAGE_NECROCHAT
 
 	//Audio
 	step_volume = 60 //Necromorphs can't wear shoes, so their base footstep volumes are louder

--- a/code/modules/mob/living/carbon/human/species/species_getters.dm
+++ b/code/modules/mob/living/carbon/human/species/species_getters.dm
@@ -96,3 +96,46 @@
 
 /datum/species/proc/get_husk_icon(var/mob/living/carbon/human/H)
 	return husk_icon
+
+
+/mob/proc/get_species()
+	return ""
+
+/mob/proc/get_species_datum()
+	return null
+
+
+/mob/living/carbon/human/get_species()
+	if(!species)
+		set_species()
+	return species.name
+
+/mob/living/carbon/human/get_species_datum()
+	if(!species)
+		set_species()
+	return species
+
+
+//returns the species of this mob's brain
+//In 99.999% of cases this is the same as the body. but in the case of a divider puppet it can be different
+/mob/proc/get_mental_species()
+	return get_species()
+
+/mob/living/carbon/human/get_mental_species()
+	var/obj/item/organ/internal/brain/B = internal_organs_by_name[BP_BRAIN]
+	if (B && B.species)
+		return B.species.name
+	return get_species()
+
+
+/mob/proc/get_mental_species_datum()
+	return get_species_datum()
+
+
+/mob/living/carbon/human/get_mental_species_datum()
+	var/obj/item/organ/internal/brain/B = internal_organs_by_name[BP_BRAIN]
+
+	if (B && B.species)
+		return B.species
+
+	.=..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -851,11 +851,7 @@
 	resting = max(resting + amount,0)
 	return
 
-/mob/proc/get_species()
-	return ""
 
-/mob/proc/get_species_datum()
-	return null
 
 /mob/proc/get_visible_implants(var/class = 0)
 	var/list/visible_implants = list()

--- a/html/changelogs/dividervoice.yml
+++ b/html/changelogs/dividervoice.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Divider puppets can no longer speak common, but will speak on the necrochat instead. Their body will make telltale wailing sounds when they do, so keeping quiet is key to going unnoticed."


### PR DESCRIPTION
changes: 
  - tweak: "Divider puppets can no longer speak common, but will speak on the necrochat instead. Their body will make telltale wailing sounds when they do, so keeping quiet is key to going unnoticed."