### PR TITLE
A fix for emotes seen by ghosts

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -152,16 +152,14 @@
 	if(M.get_preference_value(/datum/client_preference/ghost_sight) == GLOB.PREF_ALL_EMOTES && !(src in view(M)))
 		remote = "\[R\]"
 
-	var/speaker_name = name
+	var/speaker_name = ""
 
-	if(speaker_name != real_name && real_name)
-		speaker_name = "[real_name]/([speaker_name])"
-
-	speaker_name = speaker_name
+	if(name != real_name)
+		speaker_name = "<span class='warning'>([real_name])</span> "
 
 	var/track = "([ghost_follow_link(src, M)])"
 
-	message = track + remote + " " + speaker_name + ": " + message
+	message = track + remote + " " + speaker_name  + message
 	return message
 
 /mob/proc/ghost_skip_message(var/mob/observer/ghost/M)

--- a/html/changelogs/terror4000rus-emotes.yml
+++ b/html/changelogs/terror4000rus-emotes.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Terror4000rus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed ghost's prefix about the characters real name. So, no more things like '(F)Cody Green/(Unknown(as Cody Green): Cody Green screams!' The prefix will appear only if the character's visual name is 'Unknown' or 'Unknown (as not-real-name)'."


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19491666/95026279-744fc280-06ba-11eb-8068-4a44d61b5b17.png)
No more  things like
![image](https://cdn.discordapp.com/attachments/683216679299186745/757419586361491477/unknown.png)
or
![image](https://user-images.githubusercontent.com/19491666/95026327-d3153c00-06ba-11eb-8571-ac36f1b67d9c.png)
