### PR TITLE
Exploder and rivetgun tweaks

### DIFF
--- a/code/modules/mob/living/abilities/shoot.dm
+++ b/code/modules/mob/living/abilities/shoot.dm
@@ -107,6 +107,8 @@
 	if (isliving(user))
 		L = user
 		target_zone = L.zone_sel.selecting
+	else
+		target_zone = ran_zone()
 
 	//First of all, if nomove is set, lets paralyse the user
 	if (nomove && L)

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
@@ -205,8 +205,12 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 
 	//A normal explosion
 	spawn()
-		//-1 devastation range because hull breaches are not cool
-		explosion(T, -1, 3, 5, 6)
+		//Max power 2 because hull breaches are not cool
+		T.explosion(5,2)
+
+	spawn()
+		//An immediate second, smaller explosion to deal more damage
+		T.explosion(4,3)
 
 	//Make sure the pustule is deleted if these explosions don't destroy it
 	spawn()

--- a/code/modules/projectiles/guns/ds13/rivet_gun.dm
+++ b/code/modules/projectiles/guns/ds13/rivet_gun.dm
@@ -54,7 +54,6 @@
 //Adds a rivet to our internal tracking list so we can detonate it later
 /obj/item/weapon/gun/projectile/rivet/proc/register_rivet(var/obj/item/embedded_rivet/ER)
 	//If we have too many, delete them
-
 	if (rivets.len >= max_rivets)
 
 		var/obj/item/embedded_rivet/redundant = rivets[1]
@@ -217,8 +216,8 @@
 	plane = ABOVE_OBJ_PLANE
 	layer = 0
 
-/obj/item/embedded_rivet/New(var/atom/loc, var/obj/item/projectile/bullet/rivet/rivet)
-	if (istype(rivet.	, /obj/item/weapon/gun/projectile/rivet))
+/obj/item/embedded_rivet/New(var/atom/location, var/obj/item/projectile/bullet/rivet/rivet)
+	if (istype(rivet.launcher, /obj/item/weapon/gun/projectile/rivet))
 		rivetgun = rivet.launcher
 		rivetgun.register_rivet(src)
 	QDEL_IN(src, lifetime)
@@ -228,7 +227,7 @@
 /obj/item/embedded_rivet/proc/detonate()
 	if (!QDELETED(src) && !detonated)
 		detonated = TRUE
-		fragmentate(T=get_turf(src), fragment_number = 15, spreading_range = 3, fragtypes=list(/obj/item/projectile/bullet/pellet/fragment/rivet))
+		fragmentate(T=get_turf(src), fragment_number = 17, spreading_range = 3, fragtypes=list(/obj/item/projectile/bullet/pellet/fragment/rivet))
 		qdel(src)
 
 /obj/item/embedded_rivet/Destroy()
@@ -243,7 +242,7 @@
 	Fragmentation
 */
 /obj/item/projectile/bullet/pellet/fragment/rivet
-	damage = 1.8
+	damage = 2.2
 	range_step = 3 //controls damage falloff with distance. projectiles lose a "pellet" each time they travel this distance. Can be a non-integer.
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -232,7 +232,10 @@
 		return 0
 
 	original = target
-	def_zone = target_zone
+	if (target_zone)
+		def_zone = target_zone
+	else
+		def_zone = ran_zone()
 
 	addtimer(CALLBACK(src, .proc/finalize_launch, curloc, targloc, x_offset, y_offset, angle_offset),0)
 	return 0

--- a/html/changelogs/exploder.yml
+++ b/html/changelogs/exploder.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Exploder is back and explodier than ever!"
+  - tweak: "Object-based shooting abilities now hit a random part of the target instead of always the chest. This currently affects detonator, harvester, and cyst"
+  - bugfix: "Fixed the rivet gun's fragmentate mode not working."
+  - tweak: "Buffed the rivet fragments' damage, from 1.8 to 2.2

--- a/html/changelogs/exploder.yml
+++ b/html/changelogs/exploder.yml
@@ -36,4 +36,4 @@ changes:
   - bugfix: "Exploder is back and explodier than ever!"
   - tweak: "Object-based shooting abilities now hit a random part of the target instead of always the chest. This currently affects detonator, harvester, and cyst"
   - bugfix: "Fixed the rivet gun's fragmentate mode not working."
-  - tweak: "Buffed the rivet fragments' damage, from 1.8 to 2.2
+  - tweak: "Buffed the rivet fragments' damage, from 1.8 to 2.2"


### PR DESCRIPTION
changes: 
  - bugfix: "Exploder is back and explodier than ever!"
  - tweak: "Object-based shooting abilities now hit a random part of the target instead of always the chest. This currently affects detonator, harvester, and cyst"
  - bugfix: "Fixed the rivet gun's fragmentate mode not working."
  - tweak: "Buffed the rivet fragments' damage, from 1.8 to 2.2