### PR TITLE
Sheet and Storage Fixes

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -30,11 +30,18 @@
 		src.amount = amount
 
 /obj/item/stack/Destroy()
+
+	//When deleting inside stacks, remove us from them
+	if (istype(loc, /obj/item/weapon/storage) && !QDELETED(loc))
+		var/obj/item/weapon/storage/S = loc
+		S.remove_from_storage(src, get_turf(src))
+
 	if(uses_charge)
 		return 1
 	if (src && usr && usr.machine == src)
 		usr << browse(null, "window=stack")
-	return ..()
+	.= ..()
+
 
 /obj/item/stack/examine(mob/user)
 	if(..(user, 1))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -195,7 +195,7 @@
 			for(var/mob/M in viewers(usr, null))
 				if (M == usr)
 					to_chat(usr, "<span class='notice'>You put \the [W] into [src].</span>")
-				else if (M in range(1, src)) //If someone is standing close enough, they can tell what it is... TODO replace with distance check
+				else if (get_dist(M, src) <= 2) //If someone is standing close enough, they can tell what it is... TODO replace with distance check
 					M.show_message("<span class='notice'>\The [usr] puts [W] into [src].</span>")
 				else if (W && W.w_class >= ITEM_SIZE_NORMAL) //Otherwise they can only see large or normal items from a distance...
 					M.show_message("<span class='notice'>\The [usr] puts [W] into [src].</span>")
@@ -227,7 +227,7 @@
 	new_location = new_location || get_turf(src)
 
 	if(storage_ui)
-		storage_ui.on_pre_remove(usr, W)
+		storage_ui.on_pre_remove(W)
 
 	if(ismob(loc))
 		W.dropped(usr)

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -76,18 +76,17 @@
 	if(user.s_active)
 		user.s_active.show_to(user)
 
-/datum/storage_ui/default/on_pre_remove(var/mob/user, var/obj/item/W)
-	for(var/mob/M in range(1, storage.loc))
-		if (M.s_active == storage)
-			if (M.client)
-				M.client.screen -= W
+/datum/storage_ui/default/on_pre_remove(var/obj/item/W)
+	for(var/mob/M in is_seeing)
+		if (M.client)
+			M.client.screen -= W
 
 /datum/storage_ui/default/on_post_remove(var/mob/user)
 	if(user.s_active)
 		user.s_active.show_to(user)
 
 /datum/storage_ui/default/on_hand_attack(var/mob/user)
-	for(var/mob/M in range(1))
+	for(var/mob/M in is_seeing)
 		if (M.s_active == storage)
 			storage.close(M)
 
@@ -149,6 +148,8 @@
 		else
 			is_seeing -= M
 	return cansee
+
+
 
 //This proc draws out the inventory and places the items on it. tx and ty are the upper left tile and mx, my are the bottm right.
 //The numbers are calculated from the bottom-left The bottom-left slot being 1,1.

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -2,8 +2,8 @@
 /obj/item/stack/material
 	force = 5.0
 	throwforce = 5
-	w_class = ITEM_SIZE_LARGE
-	
+	w_class = ITEM_SIZE_NORMAL
+
 	throw_range = 3
 	max_amount = 60
 	center_of_mass = null

--- a/html/changelogs/sheetstack.yml
+++ b/html/changelogs/sheetstack.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed sheets in storages getting stuck on screen when merging"
+  - tweak: "Material stacks can now fit inside ordinary storage compartments."


### PR DESCRIPTION
changes: 
  - bugfix: "Fixed sheets in storages getting stuck on screen when merging"
  - tweak: "Material stacks can now fit inside ordinary storage compartments."

Also unlisted, optimises storages a little bit on insert/removal