### PR TITLE
pda, detonator, config fixes

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/engineering.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/engineering.dm
@@ -2,7 +2,7 @@
 	name = "engineering rig"
 	desc = "A lightweight and flexible armoured rig suit, designed for mining and shipboard engineering."
 	icon_state = "ds_engineering_rig"
-	armor = list(melee = 45, bullet = 60, laser = 60, energy = 25, bomb = 60, bio = 100, rad = 60)
+	armor = list(melee = 45, bullet = 60, laser = 60, energy = 25, bomb = 60, bio = 100, rad = 95)
 	offline_slowdown = 4
 	online_slowdown = 2
 	acid_resistance = 1.75	//Contains a fair bit of plastic

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -20,7 +20,7 @@
 	hard_drive.store_file(new /datum/computer_file/program/records())
 	if(prob(50)) //harmless tax software
 		hard_drive.store_file(new /datum/computer_file/program/uplink())
-	set_autorun("emailc")
+	//set_autorun("emailc")
 
 /obj/item/modular_computer/pda/medical/install_default_hardware()
 	..()

--- a/code/modules/projectiles/guns/ds13/detonator.dm
+++ b/code/modules/projectiles/guns/ds13/detonator.dm
@@ -315,7 +315,7 @@
 
 
 /decl/hierarchy/supply_pack/mining/detonator
-	name = "Mining Tool - C99 Supercollider Contact Beam"
+	name = "Mining Tool - Detonator Mine Launcher"
 	contains = list(/obj/item/ammo_casing/tripmine = 6,
 	/obj/item/weapon/gun/projectile/detonator = 1)
 	cost = 80

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -200,16 +200,16 @@ GUEST_BAN
 # FORUMURL http://example.com
 
 ## Wiki address
-# WIKIURL http://example.com
+WIKIURL https://ds-ss13.com/index.php/ 
 
 ## GitHub address
-# GITHUBURL https://github.com/example-user/example-repository
+GITHUBURL https://github.com/DS-13-Dev-Team/DS13
 
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 # BANAPPEALS http://example.com
 
 ## Discord URL - Used for the "Join the Discord" verb in OOC.
-# DISCORD_URL https://discord.gg/example
+DISCORD_URL https://discord.gg/WH2fT2Y
 
 ## In-game features
 ## spawns a spellbook which gives object-type spells instead of verb-type spells for the wizard

--- a/html/changelogs/pdatextdiscord.yml
+++ b/html/changelogs/pdatextdiscord.yml
@@ -36,4 +36,5 @@ changes:
   - bugfix: "Fixed an error message about solnet when spawning as an observer or editing your character."
   - tweak: "The discord button in the UI is now normally colored."
   - rscdel: "Removed the Lore button from the topright. It contained bay specific stuff which isn't relevant for us."
-  - bugfix: "Fixed detonator crate being wrongly named in cargo interface.""S
+  - bugfix: "Fixed detonator crate being wrongly named in cargo interface."
+  - tweak: "Majorly increased radiation resistance on the engineering rig.  Dedicated radsuits are still slightly better though."

--- a/html/changelogs/pdatextdiscord.yml
+++ b/html/changelogs/pdatextdiscord.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed an error message about solnet when spawning as an observer or editing your character."
+  - tweak: "The discord button in the UI is now normally colored."
+  - rscdel: "Removed the Lore button from the topright. It contained bay specific stuff which isn't relevant for us."
+  - bugfix: "Fixed detonator crate being wrongly named in cargo interface.""S

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1098,18 +1098,22 @@ window "mainwindow"
 		size = 640x440
 		anchor1 = none
 		anchor2 = none
+		background-color = none
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-maximized = true
 		icon = 'icons\\ss13_64.png'
 		macro = "macro"
 		menu = "menu"
+		outer-size = 1616x916
+		inner-size = 1600x857
 	elem "asset_cache_browser"
 		type = BROWSER
 		pos = 424,208
 		size = 1x1
 		anchor1 = none
 		anchor2 = none
+		background-color = none
 		is-visible = false
 		saved-params = ""
 	elem "hotkey_toggle"
@@ -1118,6 +1122,7 @@ window "mainwindow"
 		size = 80x20
 		anchor1 = 100,100
 		anchor2 = none
+		background-color = none
 		saved-params = ""
 		text = "Hotkey Toggle"
 		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
@@ -1128,6 +1133,7 @@ window "mainwindow"
 		size = 634x416
 		anchor1 = 0,0
 		anchor2 = 100,100
+		background-color = none
 		saved-params = "splitter"
 		right = "rpane"
 		is-vert = true
@@ -1147,6 +1153,7 @@ window "mainwindow"
 		size = 40x20
 		anchor1 = 100,100
 		anchor2 = none
+		background-color = none
 		saved-params = "is-checked"
 		text = "Chat"
 		command = ".winset \"saybutton.is-checked=true?input.command=\"!say \\\"\" macrobutton.is-checked=false:input.command=\""
@@ -1159,6 +1166,7 @@ window "mapwindow"
 		size = 640x480
 		anchor1 = none
 		anchor2 = none
+		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		titlebar = false
 		statusbar = false
@@ -1166,6 +1174,7 @@ window "mapwindow"
 		can-minimize = false
 		can-resize = false
 		is-pane = true
+		outer-size = 654x494
 	elem "map"
 		type = MAP
 		pos = 0,0
@@ -1186,6 +1195,7 @@ window "outputwindow"
 		size = 640x480
 		anchor1 = none
 		anchor2 = none
+		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		titlebar = false
 		statusbar = false
@@ -1193,6 +1203,7 @@ window "outputwindow"
 		can-minimize = false
 		can-resize = false
 		is-pane = true
+		outer-size = 654x494
 	elem "output"
 		type = OUTPUT
 		pos = 0,0
@@ -1208,14 +1219,15 @@ window "rpane"
 	elem "rpane"
 		type = MAIN
 		pos = 281,0
-		size = 640x480
+		size = 672x577
 		anchor1 = none
 		anchor2 = none
 		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
 		is-pane = true
-		outer-size = 656x538
-		inner-size = 640x499
+		outer-size = 672x577
+		inner-size = 656x538
 	elem "rpanewindow"
 		type = CHILD
 		pos = 0,0
@@ -1247,17 +1259,6 @@ window "rpane"
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "Changelog"
-		group = "rpanemode"
-	elem "Lore"
-		type = BUTTON
-		pos = 413,0
-		size = 67x16
-		anchor1 = none
-		anchor2 = none
-		background-color = none
-		saved-params = "is-checked"
-		text = "Lore"
-		command = "Lore"
 		group = "rpanemode"
 	elem "forumb"
 		type = BUTTON
@@ -1297,14 +1298,12 @@ window "rpane"
 		button-type = pushbox
 	elem "discordb"
 		type = BUTTON
-		pos = 484,0
+		pos = 412,0
 		size = 60x16
 		anchor1 = none
 		anchor2 = none
 		font-size = 1
-		font-style = "bold underline"
-		text-color = #ffffff
-		background-color = #663300
+		background-color = none
 		saved-params = "is-checked"
 		text = "Discord"
 		command = "discord"


### PR DESCRIPTION
changes: 
  - bugfix: "Fixed an error message about solnet when spawning as an observer or editing your character."
  - tweak: "The discord button in the UI is now normally colored."
  - rscdel: "Removed the Lore button from the topright. It contained bay specific stuff which isn't relevant for us."
  - bugfix: "Fixed detonator crate being wrongly named in cargo interface."
  - tweak: "Majorly increased radiation resistance on the engineering rig.  Dedicated radsuits are still slightly better though."

Notes: First one is done by disabling email program autorun. this may improve observation times

Also unlisted change: The example config now contains default urls for wiki, discord and github, just to make those buttons functional.