### PR TITLE
Deceptive Voice

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2182,6 +2182,7 @@
 #include "code\modules\mob\observer\freelook\marker\signal.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\_defines.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\assault_wave.dm"
+#include "code\modules\mob\observer\freelook\marker\signal_abilities\audio.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\blood_writing.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\blowout.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\breach.dm"

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/audio.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/audio.dm
@@ -1,0 +1,46 @@
+/datum/signal_ability/audio
+	name = "False Sound"
+	id = "sound_premarker"
+	desc = "Plays a fake sound of a chosen type, from a necromorph species of your choice. This spell becomes a lot cheaper once the marker is active"
+	target_string = "any turf to play the sound from"
+	energy_cost = 150
+	cooldown = 3 MINUTES
+	require_corruption = FALSE
+	require_necrovision = TRUE
+	target_types = list(/turf)
+
+	targeting_method	=	TARGET_CLICK
+
+	var/datum/species/selected_species
+	var/selected_soundtype
+	marker_active_required = -1
+
+/datum/signal_ability/audio/marker
+	name = "Deceptive Sound"
+	id = "sound_postmarker"
+	desc = "Plays a fake sound of a chosen type, from a necromorph species of your choice."
+
+	energy_cost = 50
+	cooldown = 10 SECONDS
+	marker_active_required = TRUE
+
+
+/datum/signal_ability/audio/pre_cast(var/mob/user)
+	var/choice1 = input(user,"Select which necromorph type to impersonate. Try to pick something plausible for the current round time.","Species Selection") as null|anything in GLOB.all_necromorph_species
+	if (!choice1)
+		return FALSE
+
+	var/choice2 = input(user,"Which kind of sound would you like to play?","Sound Selection") as null|anything in list(SOUND_ATTACK, SOUND_DEATH, SOUND_PAIN, SOUND_SHOUT, SOUND_SHOUT_LONG, SOUND_SPEECH)
+	if (!choice2)
+		return FALSE
+
+	selected_species = GLOB.all_necromorph_species[choice1]
+	selected_soundtype = choice2
+	return TRUE
+
+/datum/signal_ability/audio/on_cast(var/mob/user, var/atom/target, var/list/data)
+	var/volume = VOLUME_MID
+	if (selected_soundtype == SOUND_SHOUT || selected_soundtype == SOUND_SHOUT_LONG || selected_soundtype == SOUND_DEATH)
+		volume = VOLUME_LOUD
+	selected_species.play_species_audio(target, selected_soundtype, volume, 1, 2)
+

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/signal_ability.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/signal_ability.dm
@@ -59,6 +59,7 @@
 
 	//If true, this spell can only be cast after the marker has activated
 	//If false, it can be cast anytime from roundstart
+	//If -1, it can only be cast BEFORE marker activation
 	var/marker_active_required = FALSE
 
 
@@ -118,6 +119,9 @@
 		to_chat(user, SPAN_WARNING(check))
 		return
 
+	if (!pre_cast(user))
+		return
+
 	user.RemoveClickHandlersByType(/datum/click_handler/placement/ability)	//Remove any old placement handlers first, a mob should never have more than one of these
 	user.RemoveClickHandlersByType(/datum/click_handler/target)	//Remove targeting handlers too
 
@@ -137,7 +141,8 @@
 			to_chat(user, SPAN_NOTICE("Now Casting [name]!"))
 			select_target(user, user)
 
-
+/datum/signal_ability/proc/pre_cast(var/mob/user)
+	return TRUE
 
 //Path to the end of the cast
 /datum/signal_ability/proc/finish_casting(var/mob/user, var/atom/target,  var/list/data)
@@ -344,7 +349,11 @@
 	if (marker_active_required)
 		var/obj/machinery/marker/M = get_marker()
 		if (M && !M.active)
-			return FALSE
+			if (marker_active_required == TRUE)
+				return FALSE
+		else if (M && M.active)
+			if (marker_active_required == -1)
+				return FALSE
 
 	return TRUE
 

--- a/html/changelogs/falsevoice.yml
+++ b/html/changelogs/falsevoice.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added an audible new Signal Ability!"

--- a/nano/templates/signal_abilities.tmpl
+++ b/nano/templates/signal_abilities.tmpl
@@ -30,7 +30,7 @@ h3 {
 		</td>
 	</tr>	
 	<tr style="height: 80vh;">
-		<td style="width: 25%; vertical-align: top; text-align: center;">
+		<td style="width: 35%; vertical-align: top; text-align: center;">
 			<div style="height:100%;  height: 440px; overflow-y: auto;">
 			<h2>Abilities</h2>
 			<hr>
@@ -43,7 +43,7 @@ h3 {
 			
 			</div>
 		</td>
-		<td style="width: 75%; vertical-align: top;">
+		<td style="width: 65%; vertical-align: top;">
 			{{if data.current}}
 				<h1>{{:data.current.name}}</h1>
 				<div style="line-height: 120%; font-size: 11px;">{{:data.current.desc}}</div>


### PR DESCRIPTION
Adds a new signal ability allowing signals to fake the vocal sounds of necromorphs at a location of their choice. Useful to terrify or lure crewmembers

There are two versions, one for pre-marker activation, and one for after. The latter has a much lower cost and cooldown