### PR TITLE
Another one fix for ghost tracking message

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -154,8 +154,9 @@
 
 	var/speaker_name = ""
 
-	if(name != real_name)
-		speaker_name = "<span class='warning'>([real_name])</span> "
+	if(real_name)
+		if(name != real_name && name != "Unknown (as [real_name])")
+			speaker_name = "<span class='warning'>([real_name])</span> "
 
 	var/track = "([ghost_follow_link(src, M)])"
 


### PR DESCRIPTION
At last launch, I noticed there still were some issues with prefix, like lack of `real_name' for animals (devider parts, hello) and prefix before characters with covered face, but with proper ID.
<details>

![image](https://user-images.githubusercontent.com/19491666/95865775-3b39e100-0d91-11eb-8543-fa354f0922f4.png)

</details>
So, it should be fixed now.