### PR TITLE
Necromorph Healing and Health Tweaks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2186,6 +2186,7 @@
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\blowout.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\breach.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\flicker.dm"
+#include "code\modules\mob\observer\freelook\marker\signal_abilities\heal.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\lockdown.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\placement_ability.dm"
 #include "code\modules\mob\observer\freelook\marker\signal_abilities\psi_energy.dm"

--- a/code/_onclick/hud/healthbar.dm
+++ b/code/_onclick/hud/healthbar.dm
@@ -79,6 +79,7 @@
 		delta_meter = new(src)
 		limit_meter = new(src)
 		textholder = new(src)
+		update(TRUE)
 
 
 /obj/screen/healthbar/proc/set_mob(var/mob/living/newmob)
@@ -167,7 +168,7 @@
 
 
 
-/obj/screen/healthbar/proc/update()
+/obj/screen/healthbar/proc/update(var/force_update = FALSE)
 	var/list/data = L.get_health_report()
 	var/max = data["max"]
 
@@ -185,7 +186,13 @@
 		health_changed = 1
 	if (new_health < current_health)
 		health_changed = -1
+
+
 	current_health = new_health
+
+	if (!health_changed && force_update)
+
+		health_changed = TRUE
 
 	if (textholder)
 		textholder.maptext = "[Ceiling(current_health)]/[total_health]"

--- a/code/modules/mob/living/abilities/regenerate.dm
+++ b/code/modules/mob/living/abilities/regenerate.dm
@@ -119,10 +119,11 @@
 
 		if (biomass_limb_cost)
 			var/biomass_delta = O.max_damage*biomass_limb_cost
-			to_chat(user, "Regenerating [O] at a cost of [biomass_delta] kg biomass")
+			if (biomass_delta)
+				to_chat(user, "Regenerating [O] at a cost of [biomass_delta] kg biomass")
 
 			if (M)
-				if (M.playermob)
+				if (M.playermob && biomass_delta)
 					to_chat(M.playermob, "Regenerating [O] at a cost of [biomass_delta] kg biomass")
 				M.pay_biomass("Limb Regrowth", biomass_delta, allow_negative = TRUE)
 				user.adjust_biomass(biomass_delta)
@@ -132,9 +133,13 @@
 		user.adjustLastingDamage(lasting_heal*-1)
 		if (biomass_lasting_damage_cost)
 			if (M)
-				var/biomass_delta = user.getLastingDamage()*biomass_lasting_damage_cost
-				if (M.playermob)
-					to_chat(M.playermob, "Regenerating [user.getLastingDamage()] lasting damage at a cost of [biomass_delta] kg biomass")
+				var/lasting = user.getLastingDamage()
+				var/biomass_delta = lasting*biomass_lasting_damage_cost
+				if (biomass_delta)
+					to_chat(user, "Regenerating [lasting] lasting damage at a cost of [biomass_delta] kg biomass")
+
+				if (M.playermob && biomass_delta)
+					to_chat(M.playermob, "Regenerating [lasting] lasting damage at a cost of [biomass_delta] kg biomass")
 
 				M.pay_biomass("Necrotic Reconstruction", biomass_delta, allow_negative = TRUE)
 				user.adjust_biomass(biomass_delta)

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
@@ -4,7 +4,7 @@
 	mob_type = /mob/living/carbon/human/necromorph/divider
 	blurb = "A bizarre walking horrorshow, slow but extremely durable. On death, it splits into five smaller creatures, in an attempt to find a new body to control. The divider is hard to kill, and has several abilities which excel at pinning down a lone target."
 	unarmed_types = list(/datum/unarmed_attack/claws/strong/divider)
-	total_health = 200
+	total_health = 210
 	biomass = 150
 	mass = 120
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -16,7 +16,7 @@
 	mob_type	=	/mob/living/carbon/human/necromorph/leaper
 	blurb = "A long range ambusher, the leaper can leap on unsuspecting victims from afar, knock them down, and tear them apart with its bladed tail. Not good for prolonged combat though."
 	unarmed_types = list(/datum/unarmed_attack/claws) //Bite attack is a backup if blades are severed
-	total_health = 90
+	total_health = 100
 	biomass = 75
 
 	//Normal necromorph flags plus no slip

--- a/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/lurker.dm
@@ -29,7 +29,7 @@
 	mob_type	=	/mob/living/carbon/human/necromorph/lurker
 	blurb = "Long range fire-support. The lurker is tough and hard to hit as long as its retractible armor is closed. When open it is slow and vulnerable, but fires sharp spines in waves of three."
 	unarmed_types = list(/datum/unarmed_attack/bite/lurker) //Bite attack is a backup if blades are severed
-	total_health = 60
+	total_health = 65
 	biomass = 55
 	health_doll_offset	= 50
 	torso_damage_mult = 0.75

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
@@ -22,7 +22,7 @@
 	var/spawner_spawnable = FALSE	//If true, a nest can be upgraded to autospawn this unit
 	var/necroshop_item_type = /datum/necroshop_item //Give this a subtype if you want to have special behaviour for when this necromorph is spawned from the necroshop
 	var/global_limit = 0	//0 = no limit
-	lasting_damage_factor = 0.10	//Necromorphs take lasting damage based on incoming hits
+	lasting_damage_factor = 0.15	//Necromorphs take lasting damage based on incoming hits
 
 	strength    = STR_MEDIUM
 	show_ssd = "dead" //If its not moving, it looks like a corpse

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
@@ -22,6 +22,7 @@
 	var/spawner_spawnable = FALSE	//If true, a nest can be upgraded to autospawn this unit
 	var/necroshop_item_type = /datum/necroshop_item //Give this a subtype if you want to have special behaviour for when this necromorph is spawned from the necroshop
 	var/global_limit = 0	//0 = no limit
+	lasting_damage_factor = 0.10	//Necromorphs take lasting damage based on incoming hits
 
 	strength    = STR_MEDIUM
 	show_ssd = "dead" //If its not moving, it looks like a corpse
@@ -266,8 +267,12 @@
 		//And now add to total
 		total += subtotal
 
+	var/lasting = H.getLastingDamage()
+	blocked += lasting
+	total += lasting
+
 	if (return_list)
-		return list("damage" = total, "blocked" = blocked+H.lasting_damage)
+		return list("damage" = total, "blocked" = blocked)
 
 	return total
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
@@ -217,7 +217,7 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 //Snapshot projectile. Lower damage, limited range
 /obj/item/projectile/bullet/acid/puker_snap
 	icon_state = "acid_small"
-	damage = 17.5
+	damage = 15
 	step_delay = 1.25
 	kill_count = PUKER_SNAPSHOT_RANGE
 	impact_type = /obj/effect/projectile/acid/impact/small
@@ -228,7 +228,7 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 	name = "acid blast"
 	icon_state = "acid_large"
 	step_delay = 1.75
-	damage = 35
+	damage = 30
 	grippable = TRUE
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -11,7 +11,7 @@
 	mob_type = /mob/living/carbon/human/necromorph/slasher
 	blurb = "The frontline soldier of the necromorph horde. Slow when not charging, but its blade arms make for powerful melee attacks"
 	unarmed_types = list(/datum/unarmed_attack/blades, /datum/unarmed_attack/bite/weak) //Bite attack is a backup if blades are severed
-	total_health = 80
+	total_health = 90
 	biomass = 50
 	mass = 70
 
@@ -112,7 +112,7 @@
 	marker_spawnable = TRUE 	//Enable this once we have sprites for it
 	mob_type = /mob/living/carbon/human/necromorph/slasher_enhanced
 	unarmed_types = list(/datum/unarmed_attack/blades/strong, /datum/unarmed_attack/bite/strong)
-	total_health = 200
+	total_health = 225
 	slowdown = 2.8
 	biomass = 125
 	view_range = 8

--- a/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
@@ -2,7 +2,7 @@
 /datum/species/necromorph/slasher/spitter
 	name = SPECIES_NECROMORPH_SPITTER
 	name_plural = "Spitters"
-	total_health = 55
+	total_health = 65
 	biomass = 55
 	mass = 45
 	view_range = 8

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -27,6 +27,7 @@
 	virus_immune = 1
 	biomass	=	120
 	lying_rotation = 90
+	total_health = 100
 
 	slowdown = 1.5
 	view_offset = 3 * WORLD_ICON_SIZE //Forward view offset allows longer-ranged charges

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -15,6 +15,7 @@
 	limb_health_factor = 1	//Not as fragile as a slasher
 	virus_immune = 1
 	reach = 2
+	lasting_damage_factor = 0 //It regenerates this stuff away
 
 
 	icon_template = 'icons/mob/necromorph/ubermorph.dmi'
@@ -176,7 +177,7 @@ Best used near the end, when all seems quiet, to help the necromorphs hunt down 
 	set category = "Abilities"
 	set desc = "Regrows a missing limb and restores some of your health."
 
-	.= regenerate_ability(_heal_amount = 40, _duration = 4 SECONDS, _max_limbs = 1, _cooldown = 0)
+	.= regenerate_ability(_heal_amount = 40, _duration = 4 SECONDS, _cooldown = 0)
 	if (.)
 		play_species_audio(src, SOUND_PAIN, VOLUME_HIGH, 1, 3)
 

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -201,7 +201,8 @@
 	var/mob/observer/eye/signal/master/S = new(M)
 
 	playermob = S
-	qdel(M)
+	if (!isliving(M))
+		qdel(M)
 	update_icon()
 	//GLOB.unitologists.add_antagonist(playermob.mind)
 	return S
@@ -221,6 +222,9 @@
 		QDEL_NULL(playermob)
 		update_icon()
 		return S
+	else
+		//Just vacate the player slot so someone else can join
+		player = null
 
 //This is defined at atom level to enable non-marker spawning systems in future
 /atom/proc/get_available_biomass()

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -243,8 +243,8 @@
 
 
 
-/obj/machinery/marker/proc/pay_biomass(var/purpose, var/amount)
-	if (biomass >= amount)
+/obj/machinery/marker/proc/pay_biomass(var/purpose, var/amount, var/allow_negative = FALSE)
+	if (allow_negative || biomass >= amount)
 		biomass -= amount
 		return TRUE
 	return FALSE

--- a/code/modules/mob/observer/freelook/marker/master.dm
+++ b/code/modules/mob/observer/freelook/marker/master.dm
@@ -43,6 +43,12 @@
 
 	SSnecromorph.marker.vacate_master_signal()
 
+	//Something must have gone wrong, we aren't deleted yet!
+	//Turn ourselves into a signal as a fallback
+	if (!QDELETED(src))
+		var/mob/observer/eye/signal/S = new(src)
+		qdel(src)
+
 /mob/observer/eye/signal/master/verb/shop_verb()
 	set name = "Spawning Menu"
 	set category = SPECIES_NECROMORPH

--- a/code/modules/mob/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal.dm
@@ -129,11 +129,13 @@
 
 //Evacuates a mob from their body but makes them a marker signal instead of a normal ghost
 /mob/proc/necro_ghost()
-	var/signaltype = /mob/observer/eye/signal
 	if (is_marker_master(src))	//If they are the marker's player, lets be sure to put them into the correct signal type
-		signaltype = /mob/observer/eye/signal/master
-
-	.=new signaltype(src)
+		var/obj/machinery/marker/marker = get_marker()
+		if (marker)
+			marker.become_master_signal(src)
+		return
+	else
+		.=new /mob/observer/eye/signal(src)
 
 	//If we're in some kind of observer body, delete it
 	if (!isliving(src))

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/heal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/heal.dm
@@ -1,0 +1,64 @@
+/datum/signal_ability/heal
+	name = "Reconstitute"
+	id = "reconstitute"
+	desc = "Regrows one severed limb on a target necromorph. <br>\
+	The target also recieves Lasting Damage proportional to the health of the limb, effectively reducing their maximum health."
+	target_string = "A necromorph with missing limbs (must be on corruption)"
+	energy_cost = 100
+	autotarget_range = 1
+	cooldown = 1 MINUTE
+
+	target_types = list(/mob/living/carbon/human)
+	allied_check = TRUE
+
+	targeting_method	=	TARGET_CLICK
+
+	require_corruption = TRUE
+	require_necrovision = TRUE
+
+	target_types = list(/mob/living/carbon/human)
+
+/datum/signal_ability/heal/on_cast(var/mob/user, var/mob/living/target, var/list/data)
+	var/mob/living/carbon/human/H = target
+	H.regenerate_ability(subtype = /datum/extension/regenerate/reconstitute, _duration = 4 SECONDS, _cooldown =0)
+
+
+/datum/extension/regenerate/reconstitute
+	limb_lasting_damage = 0.5
+	lasting_damage_heal = 0
+	heal_amount = 40
+	max_limbs = 1
+
+
+
+
+/datum/signal_ability/heal/marker
+	marker_only = TRUE
+
+	energy_cost = 1000
+	autotarget_range = 1
+	cooldown = 1 MINUTE
+
+
+	name = "Rebuild"
+	id = "rebuild"
+	desc = "Fully heals the target necromorph, restoring all limbs and healing all lasting damage.<br>\
+	 Costs biomass based on the limb health and lasting damage restored. <br>\
+	 The biomass spent in this way is invested into the necromorph, not destroyed, and thus will be gradually recovered after it dies"
+	target_string = "A damaged necromorph, must be on corruption"
+
+
+/datum/signal_ability/heal/marker/on_cast(var/mob/user, var/mob/living/target, var/list/data)
+	var/mob/living/carbon/human/H = target
+	H.regenerate_ability(subtype = /datum/extension/regenerate/rebuild, _duration = 8 SECONDS, _cooldown =0)
+
+
+
+/datum/extension/regenerate/rebuild
+	lasting_damage_heal = 200
+
+	biomass_limb_cost = 0.5	//When a limb is replaced, the marker transfers biomass to the mob, equal to the limb's health * this value
+	biomass_lasting_damage_cost = 0.5	//When lasting_damage is healed, the marker transfers biomass to the mob, equal to the damage healed * this value
+	heal_amount = 200
+	max_limbs = 99999 //All the limbs
+	cooldown = 3 MINUTE

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/heal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/heal.dm
@@ -1,9 +1,10 @@
 /datum/signal_ability/heal
 	name = "Reconstitute"
 	id = "reconstitute"
-	desc = "Regrows one severed limb on a target necromorph. <br>\
-	The target also recieves Lasting Damage proportional to the health of the limb, effectively reducing their maximum health."
-	target_string = "A necromorph with missing limbs (must be on corruption)"
+	desc = "Regrows one severed limb on a target necromorph, and heals up to 40 normal damage<br>\
+	The target also recieves Lasting Damage proportional to the health of the limb, effectively reducing their maximum health.<br>\
+	This ability will not heal lasting damage"
+	target_string = "A damaged necromorph, must be on corruption"
 	energy_cost = 100
 	autotarget_range = 1
 	cooldown = 1 MINUTE
@@ -42,9 +43,10 @@
 
 	name = "Rebuild"
 	id = "rebuild"
-	desc = "Fully heals the target necromorph, restoring all limbs and healing all lasting damage.<br>\
+	desc = "Fully heals the target necromorph, restoring all limbs and healing up to 200 lasting damage, as well as up to 200 normal damage.<br>\
 	 Costs biomass based on the limb health and lasting damage restored. <br>\
-	 The biomass spent in this way is invested into the necromorph, not destroyed, and thus will be gradually recovered after it dies"
+	 The biomass spent in this way is invested into the necromorph, not destroyed, and thus will be gradually recovered after it dies. <br>\
+	 Biomass costs are unpredictable and cannot be previewed, but will never be more than 1kg per 2 points of the necromorph's maximum health"
 	target_string = "A damaged necromorph, must be on corruption"
 
 
@@ -56,7 +58,6 @@
 
 /datum/extension/regenerate/rebuild
 	lasting_damage_heal = 200
-
 	biomass_limb_cost = 0.5	//When a limb is replaced, the marker transfers biomass to the mob, equal to the limb's health * this value
 	biomass_lasting_damage_cost = 0.5	//When lasting_damage is healed, the marker transfers biomass to the mob, equal to the damage healed * this value
 	heal_amount = 200

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/heal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/heal.dm
@@ -49,6 +49,13 @@
 	 Biomass costs are unpredictable and cannot be previewed, but will never be more than 1kg per 2 points of the necromorph's maximum health"
 	target_string = "A damaged necromorph, must be on corruption"
 
+/datum/signal_ability/heal/marker/can_cast_now(var/mob/user)
+	var/obj/machinery/marker/M = get_marker()
+	if (!M || M.biomass < 0)
+		return "The marker has no biomass"
+
+	.=..()
+
 
 /datum/signal_ability/heal/marker/on_cast(var/mob/user, var/mob/living/target, var/list/data)
 	var/mob/living/carbon/human/H = target

--- a/html/changelogs/necrohealth.yml
+++ b/html/changelogs/necrohealth.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Necromorphs now take 10% of incoming damage as Lasting Damage, which does not heal and effectively reduces their maximum health."
+  - tweak: "Slightly buffed the max health of divider, spitter, slasher, leaper and lurker, to partially compensate for the above."
+  - rscadd: "Added two new necromorph healing spells - one for signal, and one for marker. Both come with their own drawbacks, but can regrow lost limbs on live necromorphs."


### PR DESCRIPTION
A package of changes concerning necromorph health.
Firstly, a new mechanic. Some of the incoming damage to necromorphs is now dealt as Lasting Damage, which does not heal and effectively reduces their maximum health. This should help to prevent a necromorph from camping on corruption forever healing off damage and never dying. This applies to all of them except the ubermorph

Secondly, added two new Healing spells which signals can use on necromorphs. 
They both require the target to be standing on corruption, and immobilize them for a few seconds while the healing happens
They both come with their own special drawbacks, in addition to relatively high energy cost and longish cooldowns:

Reconstitute: Useable by signals.  Heals 40 normal damage. Regrows one missing limb, but deals Lasting Damage to the target based on the health of the missing limb. 

Rebuild: Useable only by the marker, and currently the only way to heal lasting damage in the whole game.
Heals all lasting damage, and regrows all limbs, but it invests extra biomass into the necromorph based on the quantities healed. This is regained over time after it dies like normal, biomass is never truly lost.



Lastly, buffs the max health of a few common necros to compensate for the first change

changes: 
  - rscadd: "Necromorphs now take 10% of incoming damage as Lasting Damage, which does not heal and effectively reduces their maximum health."
  - tweak: "Slightly buffed the max health of divider, spitter, slasher, leaper and lurker, to partially compensate for the above."
  - rscadd: "Added two new necromorph healing spells - one for signal, and one for marker. Both come with their own drawbacks, but can regrow lost limbs on live necromorphs."