### PR TITLE
BridgeStaffFirearms

### DIFF
--- a/code/datums/outfits/jobs/cargo.dm
+++ b/code/datums/outfits/jobs/cargo.dm
@@ -1,9 +1,9 @@
 /decl/hierarchy/outfit/job/cargo
+	hierarchy_type = /decl/hierarchy/outfit/job/cargo
 	uniform = /obj/item/clothing/under/deadspace/cargo
 	l_ear = /obj/item/device/radio/headset/headset_cargo
 	glasses = /obj/item/clothing/glasses/sunglasses
 	shoes = /obj/item/clothing/shoes/dutyboots
-	hierarchy_type = /decl/hierarchy/outfit/job/cargo
 
 /decl/hierarchy/outfit/job/cargo/so
 	name = OUTFIT_JOB_NAME("Supply Officer")

--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -1,6 +1,6 @@
 /decl/hierarchy/outfit/job/service
-	l_ear = /obj/item/device/radio/headset/headset_service
 	hierarchy_type = /decl/hierarchy/outfit/job/service
+	l_ear = /obj/item/device/radio/headset/headset_service
 
 /decl/hierarchy/outfit/job/service/bar
 	name = OUTFIT_JOB_NAME("Bartender")

--- a/code/datums/outfits/jobs/command.dm
+++ b/code/datums/outfits/jobs/command.dm
@@ -1,11 +1,12 @@
 /decl/hierarchy/outfit/job/command
-	shoes = /obj/item/clothing/shoes/dutyboots
 	hierarchy_type = /decl/hierarchy/outfit/job/command
+	shoes = /obj/item/clothing/shoes/dutyboots
 
 /decl/hierarchy/outfit/job/command/cap
 	name = OUTFIT_JOB_NAME("Captain")
 	uniform = /obj/item/clothing/under/deadspace/captain
 	l_ear = /obj/item/device/radio/headset/heads/captain
+	belt = /obj/item/weapon/storage/belt/holster/general
 	id_type = /obj/item/weapon/card/id/holo/command/captain
 	pda_type = /obj/item/modular_computer/pda/captain
 
@@ -14,6 +15,7 @@
 	name = OUTFIT_JOB_NAME("First Lieutenant")
 	uniform = /obj/item/clothing/under/deadspace/first_lieutenant
 	l_ear = /obj/item/device/radio/headset/heads/fl
+	belt = /obj/item/weapon/storage/belt/holster/general/command
 	id_type = /obj/item/weapon/card/id/holo/command/first_lieutenant
 	pda_type = /obj/item/modular_computer/pda/heads/fl
 
@@ -22,5 +24,6 @@
 	name = OUTFIT_JOB_NAME("Bridge Ensign")
 	uniform = /obj/item/clothing/under/deadspace/bridge_officer
 	l_ear = /obj/item/device/radio/headset/headset_com
+	belt = /obj/item/weapon/storage/belt/holster/general/command
 	id_type = /obj/item/weapon/card/id/holo/command
 	pda_type = /obj/item/modular_computer/pda

--- a/code/datums/outfits/jobs/mining.dm
+++ b/code/datums/outfits/jobs/mining.dm
@@ -1,7 +1,7 @@
 /decl/hierarchy/outfit/job/mining
+	hierarchy_type = /decl/hierarchy/outfit/job/mining
 	l_ear = /obj/item/device/radio/headset/headset_mining
 	pda_type = /obj/item/modular_computer/pda/mining
-	hierarchy_type = /decl/hierarchy/outfit/job/mining
 
 /decl/hierarchy/outfit/job/mining/dom
 	name = OUTFIT_JOB_NAME("Director of Mining")

--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -1,8 +1,9 @@
 /decl/hierarchy/outfit/job/security
 	hierarchy_type = /decl/hierarchy/outfit/job/security
-	glasses = /obj/item/clothing/glasses/sunglasses/sechud
-	l_ear = /obj/item/device/radio/headset/headset_sec
 	uniform = /obj/item/clothing/under/deadspace/security
+	l_ear = /obj/item/device/radio/headset/headset_sec
+	glasses = /obj/item/clothing/glasses/sunglasses/sechud
+	belt = /obj/item/weapon/storage/belt/holster/security
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/ds_securityboots
 	backpack_contents = list(/obj/item/weapon/handcuffs = 1)
@@ -15,18 +16,15 @@
 	name = OUTFIT_JOB_NAME("Chief Security Officer")
 	suit = /obj/item/clothing/suit/armor/vest/ds_jacket
 	l_ear = /obj/item/device/radio/headset/heads/cseco
-	belt = /obj/item/weapon/storage/belt/holster/security
 	id_type = /obj/item/weapon/card/id/holo/security/cseco
 	pda_type = /obj/item/modular_computer/pda/heads/hos
 
 /decl/hierarchy/outfit/job/security/sso
 	name = OUTFIT_JOB_NAME("Senior Security Officer")
-	belt = /obj/item/weapon/storage/belt/holster/security
 	id_type = /obj/item/weapon/card/id/holo/security/sso
 	pda_type = /obj/item/modular_computer/pda/security
 
 /decl/hierarchy/outfit/job/security/officer
 	name = OUTFIT_JOB_NAME("Security Officer")
-	belt = /obj/item/weapon/storage/belt/holster/security
 	id_type = /obj/item/weapon/card/id/holo/security
 	pda_type = /obj/item/modular_computer/pda/security

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -290,6 +290,44 @@
 		/obj/item/device/destTagger
 		)
 
+/obj/item/weapon/storage/belt/holster/general/command
+	name = "holster belt"
+	desc = "Can hold general equipment such as tablets, folders, and other office supplies. Comes with a holster."
+	icon_state = "commandbelt"
+	item_state = "command"
+	storage_slots = 6
+	overlay_flags = BELT_OVERLAY_ITEMS|BELT_OVERLAY_HOLSTER
+	can_hold = list(
+		/obj/item/device/flash,
+		/obj/item/weapon/melee/telebaton,
+		/obj/item/device/taperecorder,
+		/obj/item/weapon/folder,
+		/obj/item/weapon/paper,
+		/obj/item/weapon/clipboard,
+		/obj/item/modular_computer/tablet,
+		/obj/item/device/flash,
+		/obj/item/device/flashlight,
+		/obj/item/modular_computer/pda,
+		/obj/item/device/radio/headset,
+		/obj/item/device/megaphone,
+		/obj/item/taperoll,
+		/obj/item/device/holowarrant,
+		/obj/item/device/radio,
+		/obj/item/device/tape,
+		/obj/item/weapon/pen,
+		/obj/item/weapon/stamp,
+		/obj/item/stack/package_wrap,
+		/obj/item/device/binoculars,
+		/obj/item/weapon/marshalling_wand,
+		/obj/item/device/camera,
+		/obj/item/device/destTagger
+		)
+
+/obj/item/weapon/storage/belt/holster/general/command/New()
+	..()
+	new /obj/item/weapon/gun/projectile/divet(src)
+	update_icon()
+
 /obj/item/weapon/storage/belt/holster/forensic
 	name = "forensic belt"
 	desc = "Can hold forensic gear like fingerprint powder and luminol."

--- a/html/changelogs/Snypehunter007-PR-933.yml
+++ b/html/changelogs/Snypehunter007-PR-933.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Snypehunter007
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Given all bridge staff general belts."
+  - rscadd: "Added a divet to the First Lieutenant and Bridge Ensigns belts."


### PR DESCRIPTION
- Gave the FL and BE's a new type of belt with a divet in it + changelog.
- Reorganized the hierarchy type to be at the top of the list in the various job outfit files.
- Moved the security belt to be part of the security hierarchy type instead of defining it for each role in Security.