### PR TITLE
Executive shuttle can now only be launched during EVAC procedures.

### DIFF
--- a/html/changelogs/Kmc2000-PR-956.yml
+++ b/html/changelogs/Kmc2000-PR-956.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.
+author: Kmc2000
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Executive shuttle can now only be launched during or after evacuation procedures."

--- a/maps/DeadSpace/code/structures/executive_shuttle.dm
+++ b/maps/DeadSpace/code/structures/executive_shuttle.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_INIT(executive_shuttle_controllers, list())
 	for(var/obj/machinery/computer/shuttle_control/executive/E in GLOB.executive_shuttle_controllers)
 		if(E.authorised)
 			authcount ++
-	return authcount >= requisite
+	return (evacuation_controller.state >= EVAC_PREPPING) && authcount >= requisite
 
 /obj/machinery/computer/shuttle_control/executive
 	name = "Executive Shuttle Authorisation Console"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
* Executive shuttle can no longer launch whenever it wants, it has to be done during / after evac.
