### PR TITLE
Torch and Particle Fixes

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -29,7 +29,8 @@
 	var/biomass = 0
 
 /obj/Destroy()
-	STOP_PROCESSING(SSobj, src)
+	if (is_processing)
+		STOP_PROCESSING(global.vars[is_processing], src)
 	.=..()
 
 /obj/item/proc/is_used_on(obj/O, mob/user)

--- a/code/modules/mob/living/abilities/particles/system.dm
+++ b/code/modules/mob/living/abilities/particles/system.dm
@@ -9,7 +9,7 @@
 	var/vector2/direction
 	var/atom/origin
 	var/turf/origin_turf
-	var/tick_delay = 0.2 SECONDS
+	//var/tick_delay = 0.2 SECONDS
 	var/particles_per_tick = 3
 	var/particle_lifetime = 0.85 SECONDS
 	var/particle_travel_distance = 3
@@ -60,19 +60,22 @@
 	//A duration of zero lasts until manually stopped
 	if (duration > 0)
 		addtimer(CALLBACK(src, /obj/effect/particle_system/proc/end), duration)
-	tick()
+
+	START_PROCESSING(SSfastprocess, src)
+	//tick()
 
 /obj/effect/particle_system/proc/end()
+	STOP_PROCESSING(SSfastprocess, src)
 	qdel(src)
 
-/obj/effect/particle_system/proc/tick()
+/obj/effect/particle_system/Process()
 	if (QDELETED(origin))
 		end()
 		return
 
 	for (var/i in 1 to particles_per_tick)
 		spawn_particle()
-	addtimer(CALLBACK(src, /obj/effect/particle_system/proc/tick), tick_delay)
+	//addtimer(CALLBACK(src, /obj/effect/particle_system/proc/tick), tick_delay)
 
 /obj/effect/particle_system/proc/set_direction(var/vector2/new_direction)
 	if (!direction)

--- a/code/modules/mob/living/abilities/spray/fire.dm
+++ b/code/modules/mob/living/abilities/spray/fire.dm
@@ -42,7 +42,6 @@
 /obj/effect/particle_system/spray/fire
 	particle_type = /obj/effect/particle/flame
 	autostart = FALSE
-	tick_delay = 0.10 SECONDS
 	particles_per_tick = 2
 	randpixel = 12
 	base_offset = new /vector2(-16, -16)
@@ -72,7 +71,6 @@
 /obj/effect/particle_system/spray/fire/blue
 	particle_type = /obj/effect/particle/flame/blue
 	autostart = FALSE
-	tick_delay = 0.08 SECONDS
 	randpixel = 12
 	particles_per_tick = 3
 

--- a/code/modules/mob/living/abilities/spray/spray.dm
+++ b/code/modules/mob/living/abilities/spray/spray.dm
@@ -24,7 +24,6 @@
 	var/angle
 	var/length
 
-	var/tick_delay
 	var/stun
 	var/duration
 	var/cooldown
@@ -233,7 +232,6 @@ Vars/
 /obj/effect/particle_system/spray
 	particle_type = /obj/effect/particle/spray
 	autostart = FALSE
-	tick_delay = 0.15 SECONDS
 	particles_per_tick = 6
 	randpixel = 12
 

--- a/code/modules/necromorph/corruption/harvester.dm
+++ b/code/modules/necromorph/corruption/harvester.dm
@@ -424,7 +424,7 @@
 	//In case of multiple nearby harvesters, we will loop through them in hopes of finding one off cooldown
 	for (var/obj/structure/corruption_node/harvester/H in harvesters)
 		var/list/spraydata = list("reagent" = /datum/reagent/acid/necromorph, "volume" = 5)
-		fired = H.spray_ability(subtype = /datum/extension/spray/reagent, target = target, angle = 25, length = 6, tick_delay = 0.2 SECONDS, stun = TRUE, duration = 2 SECONDS, cooldown = HARVESTER_ACID_COOLDOWN, windup = 0, override_user = user, extra_data = spraydata)
+		fired = H.spray_ability(subtype = /datum/extension/spray/reagent, target = target, angle = 25, length = 6,  stun = TRUE, duration = 2 SECONDS, cooldown = HARVESTER_ACID_COOLDOWN, windup = 0, override_user = user, extra_data = spraydata)
 
 		if (fired)
 			break

--- a/code/modules/projectiles/guns/ds13/flamethrower.dm
+++ b/code/modules/projectiles/guns/ds13/flamethrower.dm
@@ -105,6 +105,8 @@
 
 		if(!tank.vacuum_burn)
 			var/turf/T = get_turf(src)
+			if (!T)
+				return FALSE //Something is wrong, where are we??
 			var/datum/gas_mixture/G = T.return_air()
 			if (!G || !G.can_support_fire())
 				return FALSE


### PR DESCRIPTION
Fixes two runtime errors with the flamethrower which are almost certainly causing the controller crash.

Fixes a bad assumption in object destroy code (and makes it more efficient generally)

Migrates particles to use fastprocess