### PR TITLE
spawning menu fix verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -13,8 +13,8 @@ var/list/admin_verbs_default = list(
 	/client/proc/cmd_mentor_check_new_players,
 //	/client/proc/deadchat				//toggles deadchat on/off,
 	/client/proc/cmd_dev_bst,
-	/client/proc/cmd_dev_bse
-
+	/client/proc/cmd_dev_bse,
+	/client/proc/fix_necroshop 			//This is a completely harmless debug verb
 	)
 var/list/admin_verbs_admin = list(
 	/client/proc/activate_marker,		//Activates The Marker

--- a/code/modules/mob/observer/freelook/marker/necroshop.dm
+++ b/code/modules/mob/observer/freelook/marker/necroshop.dm
@@ -417,3 +417,23 @@
 
 	if (spawn_method == SPAWN_PLACE)
 		create_necromorph_placement_handler(usr, spawn_path, placement_type, snap = TRUE, biomass_source = caller.host, name = name, biomass_cost = price, require_corruption = TRUE)
+
+
+
+
+/*
+	Debug:
+	The necroshop unfortunately sometimes bugs out and refuses to open for anyone. The exact cause is unknown, and no reproduction exists either
+
+	As a stopgap measure, this verb will fix it
+*/
+/client/proc/fix_necroshop()
+	set name = "Spawning Menu Fix"
+	set desc = "Use if the necromorph spawning menu stops responding"
+	set category = "Debug"
+
+	for (var/obj/machinery/marker/M in world)
+		QDEL_NULL(M.shop)
+		M.shop = new(M)
+
+	message_admins("[src] fixed the necromorph spawning menu")


### PR DESCRIPTION
Since the cause of the spawning menu breaking is still unknown, this PR adds a new debug verb for admins to fix it with a single click at runtime

just look for "spawning menu fix" in the debug menu