### PR TITLE
Necro list null entries

### DIFF
--- a/code/modules/client/player.dm
+++ b/code/modules/client/player.dm
@@ -53,6 +53,8 @@
 		return
 
 	var/datum/player/me = get_or_create_player(ckey)
+	if (!ckey)
+		return null
 	me.client = "\ref[src.client]"
 	me.mob = "\ref[src]"
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
@@ -283,7 +283,7 @@
 // Used to update alien icons for aliens.
 /datum/species/necromorph/handle_login_special(var/mob/living/carbon/human/H)
 	.=..()
-	SSnecromorph.necromorph_players[H.ckey] = get_or_create_player(H.ckey)
+	H.set_necromorph(TRUE)
 	to_chat(H, "You are a [name]. \n\
 	[blurb]\n\
 	\n\


### PR DESCRIPTION
Fixes some possible issues where null entries could get into the necromorph list.
This is certain to solve some of the issues with necrochat though maybe not all.

It will probably solve issues of messages being lost or dropped.
Will probably not help with the issue of people seeing necrochat when they shouldn't