### PR TITLE
puker and gun tweaks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -117,6 +117,7 @@
 #include "code\_helpers\mob_status_effects.dm"
 #include "code\_helpers\mobs.dm"
 #include "code\_helpers\names.dm"
+#include "code\_helpers\necromorph.dm"
 #include "code\_helpers\pixels.dm"
 #include "code\_helpers\plot_vector.dm"
 #include "code\_helpers\sanitize_values.dm"

--- a/code/_helpers/necromorph.dm
+++ b/code/_helpers/necromorph.dm
@@ -1,0 +1,10 @@
+/proc/get_historic_major_vessel_total()
+	var/total = 0
+	for (var/typepath in SSnecromorph.spawned_necromorph_types)
+		//Currently, only human subtypes are major vessels
+		if (!ispath(typepath, /mob/living/carbon/human))
+			continue
+
+		total += SSnecromorph.spawned_necromorph_types[typepath]
+
+	return total

--- a/code/datums/craft/recipes/fortification.dm
+++ b/code/datums/craft/recipes/fortification.dm
@@ -14,7 +14,7 @@
 		list(CRAFT_TOOL, QUALITY_BOLT_TURNING, 10, 80),
 		list(CRAFT_MATERIAL, MATERIAL_STEEL, 10),
 		list(CRAFT_TOOL, QUALITY_WELDING, 10, 150),
-		list(CRAFT_STACK, /obj/item/stack/power_node, 2),
+		list(CRAFT_STACK, /obj/item/stack/power_node, 1),
 		list(CRAFT_TOOL, QUALITY_SCREW_DRIVING, 10, 80)
 	)
 

--- a/code/modules/clothing/spacesuits/rig/suits/advanced.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/advanced.dm
@@ -40,7 +40,9 @@
 	restricted_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_S)
 
 /obj/item/clothing/gloves/rig/advanced
-	name = "gloves"
+	name = "insulated gloves"
+	desc = "These gloves will protect the wearer from electric shocks."
+	siemens_coefficient = 0
 
 /obj/item/clothing/shoes/magboots/rig/advanced
 	name = "shoes"

--- a/code/modules/clothing/spacesuits/rig/suits/hacker.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/hacker.dm
@@ -32,7 +32,9 @@
 	name = "suit"
 
 /obj/item/clothing/gloves/rig/hacker
-	name = "gloves"
+	name = "insulated gloves"
+	desc = "These gloves will protect the wearer from electric shocks."
+	siemens_coefficient = 0
 
 /obj/item/clothing/shoes/magboots/rig/hacker
 	name = "shoes"

--- a/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
@@ -194,7 +194,7 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 		return
 	face_atom(A)
 	var/vangle = 70
-	var/vlength = 5
+	var/vlength = 5.5
 	if (!has_organ(BP_HEAD))
 		to_chat(src, SPAN_WARNING("Without a mouth to focus it, the pressure of your acid is reduced!"))
 		vangle = 100
@@ -203,13 +203,13 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 	//It plays a series of gurgling sounds over the 1.5 sec windup time
 	play_species_audio(src, SOUND_PAIN, VOLUME_MID, 1, 3)
 	shake_animation(30)
-	spawn(10)
+	spawn(9)
 		play_species_audio(src, SOUND_PAIN, VOLUME_HIGH, 1, 3)
 		shake_animation(30)
-	spawn(20)
+	spawn(18)
 		play_species_audio(src, SOUND_SHOUT_LONG, VOLUME_HIGH, 1, 3)
 	var/list/spraydata = list("reagent" = /datum/reagent/acid/necromorph, "volume" = 5.5)
-	.= spray_ability(subtype = /datum/extension/spray/reagent, target = A , angle = vangle, length = vlength, stun = TRUE, duration = 3 SECONDS, cooldown = 12 SECONDS, windup = 2 SECOND, extra_data = spraydata)
+	.= spray_ability(subtype = /datum/extension/spray/reagent, target = A , angle = vangle, length = vlength, stun = TRUE, duration = 3 SECONDS, cooldown = 12 SECONDS, windup = 1.8 SECOND, extra_data = spraydata)
 
 
 

--- a/code/modules/projectiles/guns/ds13/plasma_cutter.dm
+++ b/code/modules/projectiles/guns/ds13/plasma_cutter.dm
@@ -70,7 +70,7 @@
 
 /obj/item/projectile/beam/cutter/plasma
 	damage = 21
-	kill_count = 9 //an upgrade over the mining cutter, used for engineering work, but still not a proper firearm
+	kill_count = 7 //an upgrade over the mining cutter, used for engineering work, but still not a proper firearm
 	dig_power = 900
 
 

--- a/code/modules/reagents/Chemistry-Reagents/acid.dm
+++ b/code/modules/reagents/Chemistry-Reagents/acid.dm
@@ -99,8 +99,8 @@
 	taste_description = "acid"
 	reagent_state = LIQUID
 	color = NECROMORPH_ACID_COLOR
-	metabolism = 0.5
-	touch_met = 0.5	//Slow burn
+	metabolism = 0.65
+	touch_met = 0.65	//Slow burn
 	power = NECROMORPH_ACID_POWER
 	meltdose = 30 // How much is needed to melt
 

--- a/html/changelogs/example.yml
+++ b/html/changelogs/example.yml
@@ -22,7 +22,7 @@
 #################################
 
 # Your name.  
-author: Unknown
+author: Nanako
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -33,5 +33,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - rscadd: "Advanced and hacker rig now both have insulated gloves"
+  - rscadd: "Slightly increased the range of puker's vomit"
+  - rscadd: "Necromorph acid now metabolises a little faster, thus dealing damage faster. The total damage is unaffected"

--- a/html/changelogs/puker_tweaks.yml
+++ b/html/changelogs/puker_tweaks.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Advanced and hacker rig now both have insulated gloves"
+  - tweak: "Slightly increased the range of puker's vomit, and reduced its windup time, both by 10%"
+  - tweak: "Necromorph acid now metabolises a little faster, thus dealing damage faster. The total damage is unaffected"
+  - tweak: "Pulse turrets now only require one power node to create. Formerly two"
+  - tweak: "Slightly reduced the max range of the plasma cutter, it may not reach the screen edge when firing diagonally now."


### PR DESCRIPTION
A small package of changes based on feedback
changes: 
  - rscadd: "Advanced and hacker rig now both have insulated gloves"
  - tweak: "Slightly increased the range of puker's vomit, and reduced its windup time, both by 10%"
  - tweak: "Necromorph acid now metabolises a little faster, thus dealing damage faster. The total damage is unaffected"
  - tweak: "Pulse turrets now only require one power node to create. Formerly two"
  - tweak: "Slightly reduced the max range of the plasma cutter, it may not reach the screen edge when firing diagonally now."