### PR TITLE
Increased size of rules window.

### DIFF
--- a/html/changelogs/rule-button-fix.yml
+++ b/html/changelogs/rule-button-fix.yml
@@ -1,0 +1,7 @@
+author: Jeser
+
+delete-after: True
+
+changes: 
+  - tweak: "Increased rules window size."
+  - bugfix: "Fixed rules window not loading rules."

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -41,7 +41,7 @@ client/verb/discord()
 	set name = "Rules"
 	set desc = "Show Server Rules."
 	set hidden = 1
-	src << browse(file(RULES_FILE), "window=rules;size=480x320")
+	src << browse(file(RULES_FILE), "window=rules;size=720x640")
 #undef RULES_FILE
 
 #define LORE_FILE "config/lore.html"


### PR DESCRIPTION
- tweak: "Increased rules window size." 
- bugfix: "Fixed rules window not loading rules."

Archive contains edited rules.html file that properly loads DS13 server rules page. Need to be put in /config folder by whoever has access to server.

[rules.zip](https://github.com/DS-13-Dev-Team/DS13/files/5559168/rules.zip)

![изображение](https://user-images.githubusercontent.com/43144601/99524493-8c00b300-29a9-11eb-9fda-5f0c01f9612b.png)
