### PR TITLE
Embedding and Regen tweaks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -19,6 +19,8 @@
 	var/hitsound = null
 	var/blocksound = 'sound/weapons/Genhit.ogg'
 
+	var/biomaterial = FALSE	//If true, this item does not cause pain or damage when it is embedded or implanted in a human body
+
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	var/equip_slot = slot_none	//What slot this item was last equipped into
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -13,6 +13,7 @@
 	var/implant_color = "b"
 	var/malfunction = 0
 	var/known //if advanced scanners would name these in results
+	biomaterial = TRUE	//These are allowed to be in a person
 
 /obj/item/weapon/implant/proc/trigger(emote, source)
 	return

--- a/code/modules/admin/bluespacetech.dm
+++ b/code/modules/admin/bluespacetech.dm
@@ -44,7 +44,6 @@
 	bst.equip_to_slot_or_del(new /obj/item/device/t_scanner(bst.back), slot_in_backpack)
 	bst.equip_to_slot_or_del(new /obj/item/modular_computer/pda/captain(bst.back), slot_in_backpack)
 
-	bst.put_in_hands(new /obj/item/weapon/gun/spray/hydrazine_torch(bst.loc))
 
 	var/obj/item/weapon/storage/box/pills = new /obj/item/weapon/storage/box(null, TRUE)
 	pills.name = "adminordrazine"

--- a/code/modules/mob/living/abilities/regenerate.dm
+++ b/code/modules/mob/living/abilities/regenerate.dm
@@ -173,6 +173,8 @@
 			var/obj/item/organ/O = new organ_type(user)
 			user.internal_organs_by_name[organ_tag] = O
 
+	//Lastly, lets get rid of any shrapnel and harmful objects in the user's body
+	user.expel_shrapnel(0)	//Value of zero allows an infinite quantity
 
 	user.update_body()
 	stop()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -351,6 +351,17 @@ meteor_act
 	if(affecting)
 		affecting.embed(O, supplied_wound = supplied_wound)
 
+/mob/proc/unembed(var/obj/item/I, var/atom/new_location, var/silent = 0, var/supplied_message)
+	return
+
+/mob/living/carbon/human/unembed(var/obj/item/I, var/atom/new_location, var/silent = 0, var/supplied_message)
+	if (!(I in implants))
+		return
+	for (var/obj/item/organ/external/affecting in src)
+		if (I in affecting.implants)
+			affecting.unembed(I, new_location, silent, supplied_message)
+			return
+
 /mob/living/carbon/human/proc/bloody_hands(var/mob/living/source, var/amount = 2)
 	if (gloves)
 		gloves.add_blood(source)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -11,8 +11,7 @@
 			return -2
 		return -1
 
-	if(embedded_flag || (stomach_contents && stomach_contents.len))
-		handle_embedded_and_stomach_objects() //Moving with objects stuck in you can cause bad times.
+
 
 	if(CE_SPEEDBOOST in chem_effects)
 		tally -= chem_effects[CE_SPEEDBOOST]
@@ -148,6 +147,10 @@
 /mob/living/carbon/human/proc/handle_exertion()
 	if(isSynthetic())
 		return
+
+	if(LAZYLEN(implants) || (stomach_contents && stomach_contents.len))
+		handle_embedded_and_stomach_objects() //Moving with objects stuck in you can cause bad times.
+
 	var/lac_chance =  10 * encumbrance()
 	if(lac_chance && prob(skill_fail_chance(SKILL_HAULING, lac_chance)))
 		make_reagent(1, /datum/reagent/lactate)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -534,9 +534,11 @@
 		// Check everything else.
 
 		//Periodically double-check embedded_flag
-		if(embedded_flag && !(life_tick % 10))
+		/*
+		if(LAZYLEN(implants) && !(life_tick % 10))
 			if(!embedded_needs_process())
 				embedded_flag = 0
+		*/
 
 		//Resting
 		if(resting)

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
@@ -22,7 +22,7 @@
 	var/spawner_spawnable = FALSE	//If true, a nest can be upgraded to autospawn this unit
 	var/necroshop_item_type = /datum/necroshop_item //Give this a subtype if you want to have special behaviour for when this necromorph is spawned from the necroshop
 	var/global_limit = 0	//0 = no limit
-	lasting_damage_factor = 0.15	//Necromorphs take lasting damage based on incoming hits
+	lasting_damage_factor = 0.2	//Necromorphs take lasting damage based on incoming hits
 
 	strength    = STR_MEDIUM
 	show_ssd = "dead" //If its not moving, it looks like a corpse

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/heal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/heal.dm
@@ -2,6 +2,7 @@
 	name = "Reconstitute"
 	id = "reconstitute"
 	desc = "Regrows one severed limb on a target necromorph, and heals up to 40 normal damage<br>\
+	Also removes any embedded shrapnel and weapons in the target's body<br>\
 	The target also recieves Lasting Damage proportional to the health of the limb, effectively reducing their maximum health.<br>\
 	This ability will not heal lasting damage"
 	target_string = "A damaged necromorph, must be on corruption"
@@ -44,6 +45,7 @@
 	name = "Rebuild"
 	id = "rebuild"
 	desc = "Fully heals the target necromorph, restoring all limbs and healing up to 200 lasting damage, as well as up to 200 normal damage.<br>\
+	 Also removes any embedded shrapnel and weapons in the target's body<br>\
 	 Costs biomass based on the limb health and lasting damage restored. <br>\
 	 The biomass spent in this way is invested into the necromorph, not destroyed, and thus will be gradually recovered after it dies. <br>\
 	 Biomass costs are unpredictable and cannot be previewed, but will never be more than 1kg per 2 points of the necromorph's maximum health"

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -354,7 +354,7 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	flags = EXTENSION_FLAG_IMMEDIATE
 
 	//Effects on necromorphs
-	var/healing_per_tick = 1.2	//Passive Healing
+	var/healing_per_tick = 1	//Passive Healing
 	var/speedup = 1.25	//Bonus movespeed
 	var/incoming_damage_mod = 0.85	//Incoming damage reduction
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1215,13 +1215,44 @@ obj/item/organ/external/proc/remove_clamps()
 
 	supplied_wound.embedded_objects += W
 	implants += W
-	owner.embedded_flag = 1
+	LAZYADD(owner.implants,W)
 	owner.verbs += /mob/proc/yank_out_object
 	W.add_blood(owner)
 	if(ismob(W.loc))
 		var/mob/living/H = W.loc
 		H.drop_from_inventory(W)
 	W.loc = owner
+
+
+/obj/item/organ/external/proc/unembed(var/obj/item/I, var/atom/new_location, var/silent = 0, var/supplied_message)
+	if (owner)
+		LAZYREMOVE(owner.implants,I)
+		if (!LAZYLEN(owner.implants))
+			owner.implants = null
+	if (!(I in implants))
+		return
+
+	implants -= I
+	for(var/datum/wound/wound in wounds)
+		if(I in wound.embedded_objects)
+			wound.embedded_objects -= I
+			break
+
+	if(istype(I,/obj/item/weapon/implant))
+		var/obj/item/weapon/implant/imp = I
+		imp.removed()
+
+	if(!silent && owner)
+		if(supplied_message)
+			owner.visible_message("<span class='danger'>[supplied_message]</span>")
+		else
+			owner.visible_message("<span class='danger'>\The [I] falls out of [owner]'s [src]!</span>")
+
+	if (!new_location)
+		new_location = get_turf(src)
+
+	I.forceMove(new_location)
+
 
 /obj/item/organ/external/removed(var/mob/living/user, var/ignore_children = 0)
 

--- a/code/modules/projectiles/guns/ds13/pulse_rifle.dm
+++ b/code/modules/projectiles/guns/ds13/pulse_rifle.dm
@@ -22,6 +22,8 @@ The Pulse Rifle is the standard-issue service rifle of the Earth Defense Force a
 	one_hand_penalty = 6	//Don't try to fire this with one hand
 	accuracy = 5	//Slight accuracy increase
 
+
+
 	aiming_modes = list(/datum/extension/aim_mode/rifle)
 
 	screen_shake = 0	//It is good with recoil
@@ -53,7 +55,7 @@ The Pulse Rifle is the standard-issue service rifle of the Earth Defense Force a
 	icon_state = "empshell"
 	spent_icon = "empshell-spent"
 	projectile_type  = /obj/item/projectile/bullet/pulse
-
+	embed_mult = 0	//No embedding
 
 
 /obj/item/projectile/bullet/pulse
@@ -63,7 +65,7 @@ The Pulse Rifle is the standard-issue service rifle of the Earth Defense Force a
 	structure_damage_factor = 0.5
 	penetration_modifier = 0
 	penetrating = FALSE
-	step_delay = 1.35
+	step_delay = 1.3
 	expiry_method = EXPIRY_FADEOUT
 	muzzle_type = /obj/effect/projectile/pulse/muzzle/light
 	fire_sound='sound/weapons/guns/fire/pulse_shot.ogg'

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -142,7 +142,7 @@
 	if (tool.w_class > affected.cavity_max_w_class/2 && prob(50) && !BP_IS_ROBOTIC(affected) && affected.sever_artery())
 		to_chat(user, "<span class='warning'>You tear some blood vessels trying to fit such a big object in this cavity.</span>")
 		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1,affecting = affected)
-	affected.implants += tool
+	affected.embed(tool, silent = TRUE)
 	affected.cavity = 0
 
 //////////////////////////////////////////////////////////////////
@@ -207,11 +207,8 @@
 		if (prob(find_prob))
 			user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [affected.name] with \the [tool].</span>", \
 			"<span class='notice'>You take [obj] out of incision on [target]'s [affected.name]s with \the [tool].</span>" )
-			affected.implants -= obj
-			for(var/datum/wound/wound in affected.wounds)
-				if(obj in wound.embedded_objects)
-					wound.embedded_objects -= obj
-					break
+
+
 
 			BITSET(target.hud_updateflag, IMPLOYAL_HUD)
 
@@ -223,12 +220,10 @@
 				worm.detatch()
 				worm.leave_host()
 			else
-				obj.dropInto(target.loc)
+				affected.unembed(obj, silent = TRUE)
 				obj.add_blood(target)
 				obj.update_icon()
-				if(istype(obj,/obj/item/weapon/implant))
-					var/obj/item/weapon/implant/imp = obj
-					imp.removed()
+
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 15, 1)
 		else
 			user.visible_message("<span class='notice'>[user] removes \the [tool] from [target]'s [affected.name].</span>", \

--- a/html/changelogs/enbeddubg.yml
+++ b/html/changelogs/enbeddubg.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Unknown
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Necromorph healing and regeneration abilities now remove embedded shrapnel in their body"
+  - tweak: "Pulse rounds will no longer embed in victims"
+  - tweak: "Pulse rounds are slightly faster"
+  - tweak: "Necromorph healing on corruption reduced from 1.2 to 1 per second"
+  - tweak: "Necromorph lasting damage ratio from hits increased from 15% to 20%"


### PR DESCRIPTION
Primary change here is the shrapnel, necromorph players complain about it constantly. Now they have a way to remove it.
Some tweaks to pulse rounds, i'd always intended to make them not embed

And some minor nerfs to necromorph regen and lasting damage, they are winning a bit too hard lately

changes: 
  - tweak: "Necromorph healing and regeneration abilities now remove embedded shrapnel in their body"
  - tweak: "Pulse rounds will no longer embed in victims"
  - tweak: "Pulse rounds are slightly faster"
  - tweak: "Necromorph healing on corruption reduced from 1.2 to 1 per second"
  - tweak: "Necromorph lasting damage ratio from hits increased from 15% to 20%"