### PR TITLE
Ubermorph, Linecutter, BPL, balance and bugfixing

### DIFF
--- a/code/game/machinery/ds13/bpl/growth_tank.dm
+++ b/code/game/machinery/ds13/bpl/growth_tank.dm
@@ -10,7 +10,7 @@
 	icon = 'icons/obj/machines/ds13/bpl.dmi'
 	icon_state = "base"
 
-	var/max_biomass = 100	//1 Litre
+	var/max_biomass = 150	//1.5 Litre
 	var/current_biomass
 
 	var/obj/item/organ/current_growth_atom
@@ -23,9 +23,9 @@
 	var/list/valid_reagents = list(/datum/reagent/nutriment/biomass,
 	/datum/reagent/nutriment/stemcells)	//TODO: Add stem cells and blood to this
 
-	var/growth_rate = 0.5	//This many units of refined biomass are added to the forming organ each tick
+	var/growth_rate = 0.6	//This many units of refined biomass are added to the forming organ each tick
 
-	var/sustain_rate = 0.04	//This many units of refined biomass are consumed each tick to keep alive an already-fully-grown organ
+	var/sustain_rate = 0.03	//This many units of refined biomass are consumed each tick to keep alive an already-fully-grown organ
 
 	var/efficiency = 0.9	//Some of the biomass is wasted
 

--- a/code/game/machinery/ds13/bpl/recycling_tank.dm
+++ b/code/game/machinery/ds13/bpl/recycling_tank.dm
@@ -13,8 +13,8 @@
 	var/list/content_atoms = list()
 
 
-	var/breakdown_rate = 0.0007	//Remove this many units of biomass per tick, and convert it into purified biomass
-	var/reagent_breakdown_rate = 0.04	//Remove this many units of reagents per tick and convert to biomass
+	var/breakdown_rate = 0.001	//Remove this many units of biomass per tick, and convert it into purified biomass
+	var/reagent_breakdown_rate = 0.065	//Remove this many units of reagents per tick and convert to biomass
 
 	var/obj/structure/reagent_dispensers/biomass/storage
 	density = TRUE

--- a/code/modules/mob/living/abilities/lunge.dm
+++ b/code/modules/mob/living/abilities/lunge.dm
@@ -19,11 +19,11 @@
 	cached_pixels = get_new_vector(user.pixel_x, user.pixel_y)
 	animate(user, pixel_x = user.pixel_x + pixel_offset.x, pixel_y = user.pixel_y + pixel_offset.y, time = delay, easing = BACK_EASING)
 
-	release_vector(cached_pixels)
+
 
 /datum/extension/charge/lunge/start()
 	animate(user, pixel_y = cached_pixels.y, pixel_x = cached_pixels.x, time = 0.5 SECONDS, easing = BACK_EASING)
-
+	release_vector(cached_pixels)
 	..()
 
 

--- a/code/modules/mob/living/abilities/regenerate.dm
+++ b/code/modules/mob/living/abilities/regenerate.dm
@@ -198,7 +198,7 @@
 	set category = "Abilities"
 
 
-	return regenerate_ability(heal_amount = 40, _duration = 4 SECONDS, _max_limbs = 1, _cooldown = 0)
+	return regenerate_ability(subtype = /datum/extension/regenerate, _duration = 4 SECONDS, _cooldown = 0)
 
 
 /mob/living/carbon/human/proc/can_regenerate(var/error_messages = TRUE)

--- a/code/modules/mob/living/abilities/sense.dm
+++ b/code/modules/mob/living/abilities/sense.dm
@@ -40,7 +40,9 @@
 			if (L == S)
 				continue //Don't see yourself
 			var/obj/screen/movable/tracker/TR = new (S,L, duration)
-			TR.appearance = new /mutable_appearance(L)
+			var/mutable_appearance/ma = new /mutable_appearance(L)
+			ma.verbs.Cut()
+			TR.appearance = ma
 			trackers += TR
 
 	addtimer(CALLBACK(src, /datum/extension/sense/proc/finish), duration)

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -177,7 +177,7 @@ Best used near the end, when all seems quiet, to help the necromorphs hunt down 
 	set category = "Abilities"
 	set desc = "Regrows a missing limb and restores some of your health."
 
-	.= regenerate_ability(_heal_amount = 40, _duration = 4 SECONDS, _cooldown = 0)
+	.= regenerate_ability(subtype = /datum/extension/regenerate, _duration = 4 SECONDS, _cooldown = 0)
 	if (.)
 		play_species_audio(src, SOUND_PAIN, VOLUME_HIGH, 1, 3)
 

--- a/code/modules/projectiles/guns/ds13/line_cutter.dm
+++ b/code/modules/projectiles/guns/ds13/line_cutter.dm
@@ -84,13 +84,13 @@
 	Cutting Wave
 --------------------------*/
 /obj/item/projectile/wave/linecutter
-	damage = 34
+	damage = 32
 	accuracy = 130
 	penetrating = TRUE
 	edge = TRUE
 	icon = 'icons/obj/weapons/ds13_projectiles_large.dmi'
 	icon_state = "linecutter_48"
-	step_delay = 2
+	step_delay = 3
 	kill_count = 9	//Short ranged
 	height = 0.1	//10cm thick wave
 
@@ -166,7 +166,7 @@
 	.=..()
 
 /obj/effect/mine/plasma/explode(obj)
-	explosion(3, 3)
+	explosion(3, 5)
 	spawn(0)
 		qdel(src)
 


### PR DESCRIPTION
changes: 
  - tweak: "Buffed the bioprosthetic lab modestly all around. Organs grow slightly faster, the growth tank holds more biomass, recycling tank breaks down organic matter more quickly, and grown organs require less to maintain."
  - tweak: "Significantly reduced the flight speed of line cutter projectiles, making them easier to dodge. Damage slightly reduced"
  - bugfix: "Fixed the ubermorph's lunge, regen and sense abilities all being broken"

Closes #936