### PR TITLE
Limb Regen Fix

### DIFF
--- a/code/modules/mob/living/abilities/regenerate.dm
+++ b/code/modules/mob/living/abilities/regenerate.dm
@@ -50,7 +50,14 @@
 
 	//This loop counts and documents the damaged limbs, for the purpose of regrowing them and also for documenting how many there are for stun time
 	for(var/limb_type in user.species.has_limbs)
+
+		//Certain limbs cannot be regrown once lost. Lets check if this is one of those
+		var/obj/item/organ/external/abstract_E = limb_type
+		if (initial(abstract_E.can_regrow) == FALSE)
+			continue
+
 		var/obj/item/organ/external/E = user.organs_by_name[limb_type]
+
 		if (E && E.is_usable() && !E.is_stump())
 			//This organ is fine, skip it
 			continue

--- a/code/modules/mob/living/abilities/regenerate.dm
+++ b/code/modules/mob/living/abilities/regenerate.dm
@@ -49,20 +49,22 @@
 	var/list/missing_limbs = list()
 
 	//This loop counts and documents the damaged limbs, for the purpose of regrowing them and also for documenting how many there are for stun time
-	for(var/limb_type in user.species.has_limbs)
+	for(var/limb_tag in user.species.has_limbs)
 
 		//Certain limbs cannot be regrown once lost. Lets check if this is one of those
-		var/obj/item/organ/external/abstract_E = limb_type
+		var/organ_data = user.species.has_limbs[limb_tag]
+		var/typepath = organ_data["path"]
+		var/obj/item/organ/external/abstract_E = typepath
 		if (initial(abstract_E.can_regrow) == FALSE)
 			continue
 
-		var/obj/item/organ/external/E = user.organs_by_name[limb_type]
+		var/obj/item/organ/external/E = user.organs_by_name[limb_tag]
 
 		if (E && E.is_usable() && !E.is_stump())
 			//This organ is fine, skip it
 			continue
 		else if (!E || E.limb_flags & ORGAN_FLAG_CAN_AMPUTATE)
-			missing_limbs |= limb_type
+			missing_limbs |= limb_tag
 
 		if (max_limbs <= 0)
 			continue
@@ -74,7 +76,7 @@
 				qdel(E)
 				E = null
 		if(!E)
-			regenerating_organs |= limb_type
+			regenerating_organs |= limb_tag
 			max_limbs--
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/arm.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/arm.dm
@@ -1,3 +1,15 @@
+
+
+/*
+	Limb Code
+*/
+/obj/item/organ/external/arm/right/simple/divider
+	can_regrow = FALSE
+
+/obj/item/organ/external/arm/simple/divider
+	can_regrow = FALSE
+
+
 /*
 	Arm
 
@@ -56,6 +68,9 @@
 
 
 //The divider arm has an additional effect, the target is steered around randomly
+/datum/extension/mount/parasite/arm
+	damage = 6
+
 /datum/extension/mount/parasite/arm/Process()
 	.=..()
 	if (.)

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
@@ -16,7 +16,7 @@
 	)
 	has_limbs = list(
 	BP_HEAD =  list("path" = /obj/item/organ/external/head/simple/divider, "height" = new /vector2(2,2.4)),
-	BP_TORSO =  list("path" = /obj/item/organ/external/chest/simple/divider, "height" = new /vector2(1,2)),
+	BP_CHEST =  list("path" = /obj/item/organ/external/chest/simple/divider, "height" = new /vector2(1,2)),
 	BP_L_ARM =  list("path" = /obj/item/organ/external/arm/simple/divider, "height" = new /vector2(0.8,2)),
 	BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/simple/divider, "height" = new /vector2(0.8,2)),
 	BP_L_LEG =  list("path" = /obj/item/organ/external/leg/simple/divider, "height" = new /vector2(0,1)),

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
@@ -4,15 +4,23 @@
 	mob_type = /mob/living/carbon/human/necromorph/divider
 	blurb = "A bizarre walking horrorshow, slow but extremely durable. On death, it splits into five smaller creatures, in an attempt to find a new body to control. The divider is hard to kill, and has several abilities which excel at pinning down a lone target."
 	unarmed_types = list(/datum/unarmed_attack/claws/strong/divider)
-	total_health = 210
+	total_health = 225
 	biomass = 150
 	mass = 120
+	limb_health_factor = 1.0
 
 	evasion = -10	//Slow and predictable
 
 	override_limb_types = list(
+
+	)
+	has_limbs = list(
 	BP_HEAD =  list("path" = /obj/item/organ/external/head/simple/divider, "height" = new /vector2(2,2.4)),
-	BP_TORSO =  list("path" = /obj/item/organ/external/chest/simple/divider, "height" = new /vector2(1,2))
+	BP_TORSO =  list("path" = /obj/item/organ/external/chest/simple/divider, "height" = new /vector2(1,2)),
+	BP_L_ARM =  list("path" = /obj/item/organ/external/arm/simple/divider, "height" = new /vector2(0.8,2)),
+	BP_R_ARM =  list("path" = /obj/item/organ/external/arm/right/simple/divider, "height" = new /vector2(0.8,2)),
+	BP_L_LEG =  list("path" = /obj/item/organ/external/leg/simple/divider, "height" = new /vector2(0,1)),
+	BP_R_LEG =  list("path" = /obj/item/organ/external/leg/right/simple/divider, "height" = new /vector2(0,1))
 	)
 
 	view_range = 9//The world looks small from up here
@@ -24,7 +32,6 @@
 	lying_rotation = 90
 	pixel_offset_x = -8
 	single_icon = FALSE
-	evasion = 0	//No natural evasion
 	spawner_spawnable = FALSE
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/head.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/head.dm
@@ -28,6 +28,7 @@
 	leap_state = "head_leap"
 	attack_state = "head_attack"
 
+
 /mob/living/simple_animal/necromorph/divider_component/head/Initialize()
 	.=..()
 	add_modclick_verb(KEY_CTRLALT, /mob/living/simple_animal/necromorph/divider_component/head/proc/takeover_verb)
@@ -141,15 +142,17 @@
 
 
 
-/*
-	Special head subtype, used only on puppets
 
-*/
 /obj/item/organ/external/head/simple/divider
 	base_miss_chance = 45
+	can_regrow = FALSE
 
+/*
+	Special head subtype, used only on puppets
+*/
 /obj/item/organ/external/head/simple/divider/human
 	icon_name = "head_human"
+	can_regrow = FALSE
 
 
 /obj/item/organ/external/head/simple/divider/New(var/mob/living/carbon/holder, var/datum/dna/given_dna)

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/leg.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/leg.dm
@@ -1,4 +1,13 @@
 /*
+	Limb Code
+*/
+/obj/item/organ/external/leg/right/simple/divider
+	can_regrow = FALSE
+
+/obj/item/organ/external/leg/simple/divider
+	can_regrow = FALSE
+
+/*
 	Leg
 	Kicks mobs and bounces off
 */
@@ -36,7 +45,7 @@
 		var/mob/living/L = charge.last_obstacle
 		L.shake_animation(15)
 		shake_camera(L,10,6) //Smack
-		launch_strike(L, damage = 15, used_weapon = src, damage_flags = 0, armor_penetration = 10, damage_type = BRUTE, armor_type = "melee", target_zone = get_zone_sel(src), difficulty = 50)
+		launch_strike(L, damage = 18, used_weapon = src, damage_flags = 0, armor_penetration = 10, damage_type = BRUTE, armor_type = "melee", target_zone = get_zone_sel(src), difficulty = 50)
 		//We are briefly stunned
 		Stun(1)
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/tongue.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/tongue.dm
@@ -350,7 +350,7 @@
 */
 /datum/execution_stage/strangle
 	var/head_damage_threshold = 0.33
-	var/damage_per_hit = 6
+	var/damage_per_hit = 7
 	duration = 2 SECONDS
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
@@ -178,6 +178,7 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 	base_miss_chance = -5	//Big  target
 	var/exploded = FALSE
+	can_regrow = FALSE	//This is once only
 
 //The pustule casts soft yellow light in a broad area
 /obj/item/organ/external/hand/exploder_pustule/Initialize()

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -149,16 +149,27 @@ var/global/list/sparring_attack_cache = list()
 			H.apply_effect(3, WEAKEN, strike.blocked)
 
 /datum/unarmed_attack/proc/show_attack(var/datum/strike/strike)
+	var/fallback = FALSE
 	if (ishuman(strike.target))
 		var/mob/living/carbon/human/H = strike.target
 		var/obj/item/organ/external/affecting = H.get_organ(strike.target_zone)
-		if (strike.blocker)
-			var/obj/item/organ/external/original = H.get_organ(strike.original_target_zone)
-			strike.user.visible_message("<span class='minorwarning'>[strike.user] tried to [pick(attack_noun)] [strike.target] in the [original.name] but was blocked by [H.get_pronoun(POSESSIVE_ADJECTIVE)] [strike.blocker.name]!</span>")
+		if (affecting)
+			if (strike.blocker)
+				var/obj/item/organ/external/original = H.get_organ(strike.original_target_zone)
+				if (original)
+					strike.user.visible_message("<span class='minorwarning'>[strike.user] tried to [pick(attack_noun)] [strike.target] in the [original.name] but was blocked by [H.get_pronoun(POSESSIVE_ADJECTIVE)] [strike.blocker.name]!</span>")
+				else
+					fallback = TRUE
+			else
+				strike.user.visible_message("<span class='warning'>[strike.user] [pick(attack_verb)] [strike.target] in the [affecting.name]!</span>")
 		else
-			strike.user.visible_message("<span class='warning'>[strike.user] [pick(attack_verb)] [strike.target] in the [affecting.name]!</span>")
+			fallback = TRUE
 	else
+		fallback = TRUE
+
+	if (fallback)
 		strike.user.visible_message("<span class='warning'>[strike.user] [pick(attack_verb)] [strike.target][strike.damage_done?"":", to no effect"]!</span>")
+
 	if (strike.luser)
 		strike.luser.do_attack_animation(strike.target)
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -25,6 +25,7 @@ var/list/organ_cache = list()
 	var/min_broken_damage = 30        // Damage before becoming broken
 	var/max_damage = 30               // Damage cap
 	var/rejecting                     // Is this organ already being rejected?
+	var/can_regrow = TRUE			  // If false, this organ cannot be regrown using regeneration effects, once severed or destroyed
 
 	var/death_time
 	var/severed_time = 0	//If this organ was cut off/out of a humanoid mob, when did that happen?

--- a/html/changelogs/limb_regrow.yml
+++ b/html/changelogs/limb_regrow.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Unknown
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Certain limbs can no longer be regrown with healing spells. This applies to divider limbs/head, and exploder pustule"


### PR DESCRIPTION
changes: 
  - bugfix: "Certain limbs can no longer be regrown with healing spells. This applies to divider limbs/head, and exploder pustule"