### PR TITLE
Seeindark bugfix

### DIFF
--- a/code/game/machinery/wishgranter.dm
+++ b/code/game/machinery/wishgranter.dm
@@ -44,7 +44,6 @@
 		if (!(XRAY in user.mutations))
 			user.mutations.Add(XRAY)
 			user.set_sight(user.sight|SEE_MOBS|SEE_OBJS|SEE_TURFS)
-			user.set_see_in_dark(8)
 			user.set_see_invisible(SEE_INVISIBLE_LEVEL_TWO)
 
 		if (!(COLD_RESISTANCE in user.mutations))

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -63,7 +63,6 @@
 	jitteriness = 0
 
 	set_sight(sight|SEE_TURFS|SEE_MOBS|SEE_OBJS)
-	set_see_in_dark(8)
 	set_see_invisible(SEE_INVISIBLE_LEVEL_TWO)
 
 	drop_r_hand()

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -643,7 +643,6 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		return 1
 
 	if(!H.druggy)
-		H.set_see_in_dark((H.sight == (SEE_TURFS|SEE_MOBS|SEE_OBJS)) ? 8 : min(darksight_range + H.equipment_darkness_modifier, 8))
 		if(H.equipment_see_invis)
 			H.set_see_invisible(min(H.see_invisible, H.equipment_see_invis))
 

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -12,7 +12,6 @@
 	update_icon = 0
 	nutrition = 800
 
-	see_in_dark = 8
 	update_slimes = 0
 
 	// canstun and canweaken don't affect slimes because they ignore stun and weakened variables

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -202,12 +202,10 @@
 
 /mob/living/proc/update_living_sight()
 	set_sight(sight&(~(SEE_TURFS|SEE_MOBS|SEE_OBJS)))
-	set_see_in_dark(initial(see_in_dark))
 	set_see_invisible(initial(see_invisible))
 
 /mob/living/proc/update_dead_sight()
 	set_sight(sight|SEE_TURFS|SEE_MOBS|SEE_OBJS)
-	set_see_in_dark(8)
 	set_see_invisible(SEE_INVISIBLE_LEVEL_TWO)
 
 /mob/living/proc/handle_hud_icons()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -1,5 +1,5 @@
 /mob/living
-	see_in_dark = 2
+	see_in_dark = 255
 	see_invisible = SEE_INVISIBLE_LIVING
 
 	//Health and life related vars

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -52,7 +52,6 @@
 		update_icon()
 		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 		set_sight(sight&(~SEE_TURFS)&(~SEE_MOBS)&(~SEE_OBJS))
-		set_see_in_dark(0)
 		set_see_invisible(SEE_INVISIBLE_LIVING)
 	else
 		clear_fullscreen("blind")

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -261,26 +261,20 @@
 
 	if (src.stat == DEAD || (XRAY in mutations) || (src.sight_mode & BORGXRAY))
 		set_sight(sight|SEE_TURFS|SEE_MOBS|SEE_OBJS)
-		set_see_in_dark(8)
 		set_see_invisible(SEE_INVISIBLE_LEVEL_TWO)
 	else if ((src.sight_mode & BORGMESON) && (src.sight_mode & BORGTHERM))
 		set_sight(sight|SEE_TURFS|SEE_MOBS)
-		set_see_in_dark(8)
 		set_see_invisible(SEE_INVISIBLE_NOLIGHTING)
 	else if (src.sight_mode & BORGMESON)
 		set_sight(sight|SEE_TURFS)
-		set_see_in_dark(8)
 		set_see_invisible(SEE_INVISIBLE_NOLIGHTING)
 	else if (src.sight_mode & BORGMATERIAL)
 		set_sight(sight|SEE_OBJS)
-		set_see_in_dark(8)
 	else if (src.sight_mode & BORGTHERM)
 		set_sight(sight|SEE_MOBS)
-		set_see_in_dark(8)
 		set_see_invisible(SEE_INVISIBLE_LEVEL_TWO)
 	else if (src.stat != DEAD)
 		set_sight(sight&(~SEE_TURFS)&(~SEE_MOBS)&(~SEE_OBJS))
-		set_see_in_dark(8) 			 // see_in_dark means you can FAINTLY see in the dark, humans have a range of 3 or so, tajaran have it at 8
 		set_see_invisible(SEE_INVISIBLE_LIVING) // This is normal vision (25), setting it lower for normal vision means you don't "see" things like darkness since darkness
 							 // has a "invisible" value of 15
 

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -22,7 +22,6 @@
 	show_stat_health = 1
 	faction = "cult"
 	supernatural = 1
-	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	var/nullblock = 0
 
@@ -160,7 +159,6 @@
 	attacktext = "slashed"
 	speed = -1
 	environment_smash = 1
-	see_in_dark = 7
 	attack_sound = 'sound/weapons/rapidslice.ogg'
 	construct_spells = list(/spell/targeted/ethereal_jaunt/shift)
 
@@ -240,7 +238,6 @@
 	attacktext = "violently stabbed"
 	speed = -1
 	environment_smash = 1
-	see_in_dark = 7
 	attack_sound = 'sound/weapons/pierce.ogg'
 
 	construct_spells = list(

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -12,7 +12,6 @@
 	emote_see = list("shakes their head", "shivers")
 	speak_chance = 1
 	turns_per_move = 5
-	see_in_dark = 6
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -17,7 +17,6 @@
 	response_help  = "pets"
 	response_disarm = "bops"
 	response_harm   = "kicks"
-	see_in_dark = 5
 	mob_size = 8
 	possession_candidate = 1
 	holder_type = /obj/item/weapon/holder/corgi

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -11,7 +11,6 @@
 	emote_see = list("shakes its head", "stamps a foot", "glares around")
 	speak_chance = 1
 	turns_per_move = 5
-	see_in_dark = 6
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/goat
 	meat_amount = 4
 	response_help  = "pets"
@@ -98,7 +97,6 @@
 	emote_see = list("shakes its head")
 	speak_chance = 1
 	turns_per_move = 5
-	see_in_dark = 6
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/beef
 	meat_amount = 6
 	response_help  = "pets"

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -13,7 +13,6 @@
 	pass_flags = PASS_FLAG_TABLE
 	speak_chance = 1
 	turns_per_move = 5
-	see_in_dark = 6
 	max_health = 5
 	health = 5
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -12,7 +12,6 @@
 	emote_see = list("stares ferociously", "stomps")
 	speak_chance = 1
 	turns_per_move = 5
-	see_in_dark = 6
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/bearmeat
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -15,7 +15,6 @@
 	emote_hear = list("chitters")
 	speak_chance = 5
 	turns_per_move = 5
-	see_in_dark = 10
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/xenomeat
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"

--- a/code/modules/mob/observer/freelook/eye.dm
+++ b/code/modules/mob/observer/freelook/eye.dm
@@ -14,7 +14,6 @@
 	var/acceleration = 1
 	var/owner_follows_eye = 0
 
-	see_in_dark = 7
 	invisibility = INVISIBILITY_EYE
 
 	ghost_image_flag = GHOST_IMAGE_ALL

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -34,7 +34,6 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	var/list/hud_images // A list of hud images
 
 /mob/observer/ghost/New(mob/body)
-	see_in_dark = 100
 	verbs += /mob/proc/toggle_antag_pool
 
 	var/turf/T

--- a/code/modules/mob/observer/virtual/base.dm
+++ b/code/modules/mob/observer/virtual/base.dm
@@ -3,7 +3,6 @@ var/list/all_virtual_listeners = list()
 /mob/observer/virtual
 	icon = 'icons/mob/virtual.dmi'
 	invisibility = INVISIBILITY_SYSTEM
-	see_in_dark = SEE_IN_DARK_DEFAULT
 	see_invisible = SEE_INVISIBLE_LIVING
 	sight = SEE_SELF
 

--- a/code/modules/mob/observer/virtual/mob.dm
+++ b/code/modules/mob/observer/virtual/mob.dm
@@ -19,4 +19,4 @@
 /mob/observer/virtual/mob/proc/sync_sight(var/mob/mob_host)
 	sight = mob_host.sight
 	see_invisible = mob_host.see_invisible
-	see_in_dark = mob_host.see_in_dark
+

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -67,7 +67,6 @@
 	if (!(XRAY in user.mutations))
 		user.mutations.Add(XRAY)
 		user.set_sight(user.sight|SEE_MOBS|SEE_OBJS|SEE_TURFS)
-		user.set_see_in_dark(8)
 		user.set_see_invisible(SEE_INVISIBLE_LEVEL_TWO)
 		to_chat(user, "<span class='notice'>The walls suddenly disappear.</span>")
 		return 1

--- a/html/changelogs/seeindark_bugfix.yml
+++ b/html/changelogs/seeindark_bugfix.yml
@@ -1,0 +1,6 @@
+author: Jeser
+
+delete-after: True
+
+changes: 
+  - bugfix: "Removed see_in_dark value changes that resulted in necromorphs not having dark vision."


### PR DESCRIPTION
bugfix: "Removed see_in_dark value changes that resulted in necromorphs not having dark vision."

Removed any found see_in_dark changes and set it to 255 for mob/living.

Closes #1027 