### PR TITLE
Magazine restock fix

### DIFF
--- a/code/modules/projectiles/guns/ds13/bullpup.dm
+++ b/code/modules/projectiles/guns/ds13/bullpup.dm
@@ -37,6 +37,7 @@
 /obj/item/ammo_casing/bullpup
 	name = "bullpup round"
 	desc = "A low caliber round designed for the SWS motorized pulse rifle"
+	caliber = "bullpup"
 	icon_state = "rifle_casing"
 	spent_icon = "rifle_casing-spent"
 	projectile_type  = /obj/item/projectile/bullet/bullpup

--- a/code/modules/projectiles/guns/ds13/pulse_rifle.dm
+++ b/code/modules/projectiles/guns/ds13/pulse_rifle.dm
@@ -98,12 +98,14 @@ The Pulse Rifle is the standard-issue service rifle of the Earth Defense Force a
 /obj/item/ammo_casing/pulse/hv
 	name = "high velocity pulse round"
 	desc = "A low caliber hypersonic round designed for the SWS motorized pulse rifle"
+	caliber = "high velocity pulse"
 	projectile_type  = /obj/item/projectile/bullet/pulse/hv
 
 
 /obj/item/ammo_magazine/pulse/hv
 	name = "magazine (high velocity rounds)"
 	desc = "With a distinctive \"bell and stock\" design, pulse magazines can be inserted and removed from the Pulse Rifle with minimal effort and risk. This one contains hypersonic rounds, unsafe for naval usage."
+	caliber = "high velocity pulse"
 	ammo_type = /obj/item/ammo_casing/pulse/hv
 	max_ammo = 100
 

--- a/code/modules/projectiles/guns/ds13/pulse_rifle.dm
+++ b/code/modules/projectiles/guns/ds13/pulse_rifle.dm
@@ -50,6 +50,7 @@ The Pulse Rifle is the standard-issue service rifle of the Earth Defense Force a
 /obj/item/ammo_casing/pulse
 	name = "pulse round"
 	desc = "A low caliber round designed for the SWS motorized pulse rifle"
+	caliber = "pulse"
 	icon_state = "empshell"
 	spent_icon = "empshell-spent"
 	projectile_type  = /obj/item/projectile/bullet/pulse

--- a/html/changelogs/magazine-restock-fix.yml
+++ b/html/changelogs/magazine-restock-fix.yml
@@ -1,0 +1,6 @@
+author: Jeser
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed being unable to restock SCAF Bullpup and SWS Motorized Pulse Rifle magazines with appropriate ammunition."


### PR DESCRIPTION
bugfix: "Fixed being unable to restock SCAF Bullpup and SWS Motorized Pulse Rifle magazines with appropriate ammunition."

Both had their ammo missing respective calibers set.