### PR TITLE
Spawn menu fix

### DIFF
--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -274,12 +274,11 @@
 	if (shop)
 		for (var/datum/necrospawn/N in shop.possible_spawnpoints)
 			if (N.spawnpoint == source)
+				shop.possible_spawnpoints.Remove(N)
 				if (shop.selected_spawn == N)
 					var/datum/necrospawn/N_Marker = shop.possible_spawnpoints[1]
 					shop.selected_spawn = N_Marker
 					message_necromorphs("<span class='necromarker'>[source] was destroyed, current spawnpoint was set to [N_Marker.spawnpoint].</span>")
-
-				shop.possible_spawnpoints.Remove(N)
 				break
 		SSnano.update_uis(shop)
 

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -275,11 +275,9 @@
 		for (var/datum/necrospawn/N in shop.possible_spawnpoints)
 			if (N.spawnpoint == source)
 				if (shop.selected_spawn == N)
-					for (var/datum/necrospawn/N_Marker in shop.possible_spawnpoints)
-						if (N_Marker.spawnpoint == src)
-							shop.selected_spawn = N_Marker
-							message_necromorphs("<span class='necromarker'>[source] was destroyed, current spawnpoint was set to the [src].</span>")
-							break
+					var/datum/necrospawn/N_Marker = shop.possible_spawnpoints[1]
+					shop.selected_spawn = N_Marker
+					message_necromorphs("<span class='necromarker'>[source] was destroyed, current spawnpoint was set to [N_Marker.spawnpoint].</span>")
 
 				shop.possible_spawnpoints.Remove(N)
 				break

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -279,9 +279,11 @@
 						if (N_Marker.spawnpoint == src)
 							shop.selected_spawn = N_Marker
 							message_necromorphs("<span class='necromarker'>[source] was destroyed, current spawnpoint was set to the [src].</span>")
+							break
 
 				shop.possible_spawnpoints.Remove(N)
-				SSnano.update_uis(shop)
+				break
+		SSnano.update_uis(shop)
 
 
 //Marker spawning landmarks

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -274,10 +274,14 @@
 	if (shop)
 		for (var/datum/necrospawn/N in shop.possible_spawnpoints)
 			if (N.spawnpoint == source)
+				if (shop.selected_spawn == N)
+					for (var/datum/necrospawn/N_Marker in shop.possible_spawnpoints)
+						if (N_Marker.spawnpoint == src)
+							shop.selected_spawn = N_Marker
+							message_necromorphs("<span class='necromarker'>[source] was destroyed, current spawnpoint was set to the [src].</span>")
+
 				shop.possible_spawnpoints.Remove(N)
-
-
-
+				SSnano.update_uis(shop)
 
 
 //Marker spawning landmarks

--- a/html/changelogs/spawn_menu_fix.yml
+++ b/html/changelogs/spawn_menu_fix.yml
@@ -1,0 +1,7 @@
+author: Jeser
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed Spawn Menu bugging out and refusing to open."
+  - rscadd: "In case of destruction of current spawn point, Marker will be set as one and a warning will be shown in necrochat."


### PR DESCRIPTION
- bugfix: "Fixed Spawn Menu bugging out and refusing to open." 
- rscadd: "In case of destruction of current spawn point, Marker will be set as one and a warning will be shown in necrochat."