### PR TITLE
RIG Removal Tool

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -918,6 +918,7 @@
 #include "code\game\objects\items\devices\personal_shield.dm"
 #include "code\game\objects\items\devices\pipe_painter.dm"
 #include "code\game\objects\items\devices\powersink.dm"
+#include "code\game\objects\items\devices\rig_remover.dm"
 #include "code\game\objects\items\devices\scanners.dm"
 #include "code\game\objects\items\devices\spy_bug.dm"
 #include "code\game\objects\items\devices\suit_cooling.dm"

--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -95,3 +95,7 @@
 	if(!islist(source.extensions[base_type]))
 		qdel(source.extensions[base_type])
 	LAZYREMOVE(source.extensions, base_type)
+
+
+/datum/extension/proc/remove_self()
+	remove_extension(holder, base_type)

--- a/code/game/objects/items/devices/rig_remover.dm
+++ b/code/game/objects/items/devices/rig_remover.dm
@@ -1,5 +1,5 @@
 /obj/item/device/rig_remover
-	name = "RIG Undeployer"
+	name = "RIG Retraction Device"
 	desc = "A hand held device for treatment of workers inside heavy RIG suits. Retracts the target's RIG through the Safe Retraction API,  as long as they don't object."
 	icon = 'icons\obj\hacktool.dmi'
 	icon_state = "hacktool-g"
@@ -76,18 +76,15 @@
 
 	if (state == 1)
 		if (response)
-			world << "Response recieved [response]"
 			if (response == "Yes")
 				finish()
 			if (response == "No")
 				fail()
 
 		else if (world.time < timeout_end)
-			world << "Not time yet"
 			return
 
 		else
-			world << "Timeout"
 			//No response, but its timed out, lets finish
 			finish()
 	if (state == 2)
@@ -95,7 +92,6 @@
 
 /obj/item/device/rig_remover/proc/fail()
 
-	world << "Failing"
 	//Here we just set target to null so that no toggling will be done, then call finish
 
 	to_chat(last_user, SPAN_DANGER("[current_target] refused retract request, retraction cancelled"))
@@ -105,7 +101,6 @@
 	finish()
 
 /obj/item/device/rig_remover/proc/finish()
-	world << "Finishing"
 	if (current_target && current_target.wearing_rig)
 		var/obj/item/weapon/rig/R = current_target.wearing_rig
 

--- a/code/game/objects/items/devices/rig_remover.dm
+++ b/code/game/objects/items/devices/rig_remover.dm
@@ -1,7 +1,7 @@
 /obj/item/device/rig_remover
 	name = "RIG Retraction Device"
 	desc = "A hand held device for treatment of workers inside heavy RIG suits. Retracts the target's RIG through the Safe Retraction API,  as long as they don't object."
-	icon = 'icons\obj\hacktool.dmi'
+	icon = 'icons/obj/hacktool.dmi'
 	icon_state = "hacktool-g"
 	item_state = "analyzer"
 	item_flags = ITEM_FLAG_NO_BLUDGEON

--- a/code/game/objects/items/devices/rig_remover.dm
+++ b/code/game/objects/items/devices/rig_remover.dm
@@ -1,0 +1,143 @@
+/obj/item/device/rig_remover
+	name = "RIG Undeployer"
+	desc = "A hand held device for treatment of workers inside heavy RIG suits. Retracts the target's RIG through the Safe Retraction API,  as long as they don't object."
+	icon = 'icons\obj\hacktool.dmi'
+	icon_state = "hacktool-g"
+	item_state = "analyzer"
+	item_flags = ITEM_FLAG_NO_BLUDGEON
+	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	slot_flags = SLOT_BELT
+	throwforce = 3
+	w_class = ITEM_SIZE_SMALL
+
+	throw_range = 10
+	matter = list(MATERIAL_STEEL = 200)
+	origin_tech = list(TECH_MAGNET = 1, TECH_BIO = 1)
+	var/state = 0	//0 = ready, 1 = awaiting response, 2 = awaiting unsealing
+
+	var/mob/living/carbon/human/current_target
+	var/mob/living/carbon/human/last_user
+	var/response = null
+
+	var/timeout = 10 SECONDS
+
+	var/timeout_end
+
+
+/obj/item/device/rig_remover/afterattack(var/mob/living/carbon/human/target, mob/user, proximity)
+	if (!is_valid_target(target,user, proximity))
+		return
+
+	start(target, user)
+
+
+/obj/item/device/rig_remover/proc/is_valid_target(var/mob/living/carbon/human/target, mob/user, proximity)
+	if (current_target)
+		to_chat(user, SPAN_WARNING("Currently operating on [current_target], please wait!"))
+		return
+
+	if(!proximity)
+		return
+
+	if (!istype(target))
+		return
+
+	if (!target.wearing_rig)
+		to_chat(user, SPAN_WARNING("[target] is not wearing a RIG"))
+		return
+
+	if (get_extension(target.wearing_rig, /datum/extension/rig_remover_cooldown))
+		to_chat(user, SPAN_WARNING("[target] has recently refused a removal request, and cannot be asked again for a minute"))
+		return
+
+	var/obj/item/weapon/rig/R = target.wearing_rig
+
+	//In process already
+	if (R.sealing)
+		return
+
+	return TRUE
+
+
+
+/obj/item/device/rig_remover/proc/start(var/target, var/user)
+	current_target = target
+	last_user = user
+	response = null
+	timeout_end = world.time + timeout
+	state = 1
+	spawn()
+		response = alert(target, "[user] is requesting to disengage your RIG for medical treatment. To give consent, please either select yes, or do nothing.",
+		"RIG Undeploy Request", "Yes", "No")
+
+	START_PROCESSING(SSobj, src)
+
+/obj/item/device/rig_remover/Process()
+
+	if (state == 1)
+		if (response)
+			world << "Response recieved [response]"
+			if (response == "Yes")
+				finish()
+			if (response == "No")
+				fail()
+
+		else if (world.time < timeout_end)
+			world << "Not time yet"
+			return
+
+		else
+			world << "Timeout"
+			//No response, but its timed out, lets finish
+			finish()
+	if (state == 2)
+		finish()
+
+/obj/item/device/rig_remover/proc/fail()
+
+	world << "Failing"
+	//Here we just set target to null so that no toggling will be done, then call finish
+
+	to_chat(last_user, SPAN_DANGER("[current_target] refused retract request, retraction cancelled"))
+	if (current_target && current_target.wearing_rig)
+		set_extension(current_target.wearing_rig, /datum/extension/rig_remover_cooldown)
+	current_target = null
+	finish()
+
+/obj/item/device/rig_remover/proc/finish()
+	world << "Finishing"
+	if (current_target && current_target.wearing_rig)
+		var/obj/item/weapon/rig/R = current_target.wearing_rig
+
+		//Okay first up, if the rig is active, unseal it
+		if (state == 1)
+			if (R.active)
+				R.toggle_seals(last_user, FALSE)
+			state = 2
+			return
+
+		//In state 2, we're waiting for toggle seals to finish
+		else if (state == 2)
+			if (R.sealing)
+				//Not finished yet, continue waiting
+				return
+			//Next, undeploy all the pieces
+			R.retract()
+
+	current_target = null
+	last_user = null
+	response = null
+	timeout_end = null
+	state = 0
+	STOP_PROCESSING(SSobj, src)
+
+
+
+/datum/extension/rig_remover_cooldown
+	flags = EXTENSION_FLAG_IMMEDIATE
+	base_type = /datum/extension/rig_remover_cooldown
+
+
+/datum/extension/rig_remover_cooldown/New()
+	.=..()
+	addtimer(CALLBACK(src, /datum/extension/proc/remove_self), 1 MINUTE)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -41,7 +41,8 @@
 /obj/structure/closet/secure_closet/medical2/WillContain()
 	return list(
 		/obj/item/weapon/tank/anesthetic = 3,
-		/obj/item/clothing/mask/breath/medical = 3
+		/obj/item/clothing/mask/breath/medical = 3,
+		/obj/item/device/rig_remover = 2
 	)
 
 /obj/structure/closet/secure_closet/medical3
@@ -66,7 +67,8 @@
 		/obj/item/device/healthanalyzer,
 		/obj/item/taperoll/medical,
 		/obj/item/weapon/storage/belt/medical,
-		/obj/item/clothing/glasses/hud/health
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/device/rig_remover
 	)
 
 /obj/structure/closet/secure_closet/medical4
@@ -91,7 +93,8 @@
 		/obj/item/device/healthanalyzer,
 		/obj/item/taperoll/medical,
 		/obj/item/weapon/storage/belt/medical,
-		/obj/item/clothing/glasses/hud/health
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/device/rig_remover
 	)
 
 /obj/structure/closet/secure_closet/SMO
@@ -122,7 +125,8 @@
 		/obj/item/device/healthanalyzer,
 		/obj/item/weapon/storage/belt/medical,
 		/obj/item/clothing/glasses/hud/health,
-		/obj/item/weapon/reagent_containers/hypospray/vial
+		/obj/item/weapon/reagent_containers/hypospray/vial,
+		/obj/item/device/rig_remover
 	)
 
 /obj/structure/closet/secure_closet/chemical

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -24,6 +24,8 @@
 /obj/structure/closet/emcloset/New()
 	..()
 	new /obj/random/loot/often(src)
+	if (prob(20))
+		new /obj/item/device/rig_remover(src)
 	switch (pickweight(list("small" = 50, "aid" = 25, "tank" = 10, "large" = 5, "both" = 10)))
 		if ("small")
 			new /obj/item/weapon/tank/emergency/oxygen(src)

--- a/code/modules/admin/bluespacetech.dm
+++ b/code/modules/admin/bluespacetech.dm
@@ -115,6 +115,8 @@
 	bst.equip_to_slot_or_del(new /obj/item/device/t_scanner(bst.back), slot_in_backpack)
 	bst.equip_to_slot_or_del(new /obj/item/modular_computer/pda/captain(bst.back), slot_in_backpack)
 
+	bst.put_in_hands(new /obj/item/device/rig_remover)
+
 	var/obj/item/weapon/storage/box/pills = new /obj/item/weapon/storage/box(null, TRUE)
 	pills.name = "adminordrazine"
 	for(var/i = 1, i < 12, i++)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -277,21 +277,16 @@
 		time_taken *= 0.5
 
 	if(seal_target && !suit_is_deployed())
-		world << "Fail, suit is not deployed"
 		wearer.visible_message("<span class='danger'>[wearer]'s suit flashes an error light.</span>","<span class='danger'>Your suit flashes an error light. It can't function properly without being fully deployed.</span>")
 		failed_to_seal = 1
-
-	world << "Starting seal or unseal"
 
 	if(!failed_to_seal)
 		wearer.visible_message("<font color='blue'>[wearer]'s suit emits a quiet hum as it begins to adjust its seals.</font>","<font color='blue'>With a quiet hum, the suit begins running checks and adjusting components.</font>")
 		if(time_taken && !do_after(wearer,time_taken, src, incapacitation_flags = INCAPACITATION_NONE))
-			world << "Failed doafter"
 			if(wearer) to_chat(wearer, "<span class='warning'>You must remain still while the suit is adjusting the components.</span>")
 			failed_to_seal = 1
 
 		if(!wearer)
-			world << "starting unseal 4 [wearer]"
 			failed_to_seal = 1
 		else
 			for(var/list/piece_data in list(list(wearer.shoes,boots,"boots",boot_type),list(wearer.gloves,gloves,"gloves",glove_type),list(wearer.head,helmet,"helmet",helm_type),list(wearer.wear_suit,chest,"chest",chest_type)))
@@ -305,7 +300,6 @@
 					continue
 
 				if(!istype(wearer) || !istype(piece) || !istype(compare_piece) || !msg_type)
-					world << "Piece fail 1"
 					if(wearer) to_chat(wearer, "<span class='warning'>You must remain still while the suit is adjusting the components.</span>")
 					failed_to_seal = 1
 					break
@@ -339,19 +333,9 @@
 						piece.armor["bio"] = src.armor["bio"]
 
 				else
-					world << "Failed to seal piece [dump_list(piece_data)]"
 					failed_to_seal = 1
 
 		if(!istype(wearer) || wearer.wearing_rig != src || (seal_target && !suit_is_deployed()))
-			world << "Failed end check"
-			if(!istype(wearer))
-				world << "Wearer not there"
-
-			if(wearer.wearing_rig != src)
-				world << "Rig not worn"
-
-			if(seal_target && !suit_is_deployed())
-				world << "ST:[seal_target], deployed [suit_is_deployed()]"
 			failed_to_seal = 1
 
 	sealing = FALSE
@@ -723,7 +707,6 @@
 		return
 
 	if(initiator == wearer && wearer.incapacitated(INCAPACITATION_KNOCKOUT)) // If the initiator isn't wearing the suit it's probably an AI.
-		world << "Wearer incapacitated"
 		return
 
 	if (active && !(piece in toggleable_while_active))
@@ -827,7 +810,6 @@
 	if(H.wearing_rig != src)
 		return
 	for(var/piece in list("helmet","gauntlets","chest","boots"))
-		world << "retracting [piece]"
 		toggle_piece(piece, null, ONLY_RETRACT)
 
 /obj/item/weapon/rig/dropped(var/mob/user)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -52,10 +52,6 @@
 	// update the current life tick, can be used to e.g. only do something every 4 ticks
 	life_tick++
 
-	// This is not an ideal place for this but it will do for now.
-	if(wearing_rig && wearing_rig.offline)
-		wearing_rig = null
-
 	..()
 
 	if(life_tick%30==15)

--- a/html/changelogs/rig_remover.yml
+++ b/html/changelogs/rig_remover.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added the RIG retraction device, which allows powering down and retracting someone else's rig, as long as they don't object. Intended for medical use, and found in medical, surgery and emergency closets"
+  - tweak: "Powering down a RIG now takes half as much time as sealing"

--- a/html/changelogs/shard_tether.yml
+++ b/html/changelogs/shard_tether.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed kinesis tether not visually attaching to the target"
+  - bugfix: "Fixed punishment not working correctly when using kinesis to throw a marker shard into disposals."


### PR DESCRIPTION
Long planned, but accelerated due to concerns over other recent changes

changes: 
  - rscadd: "Added the RIG retraction device, which allows powering down and retracting someone else's rig, as long as they don't object. Intended for medical use, and found in medical, surgery and emergency closets"
  - tweak: "Powering down a RIG now takes half as much time as sealing"


The device asks the wearer for permission to remove their rig. And it proceeds if they give that permission, OR if they don't respond within a 10 second window, thus ensuring it can be used on unconscious patients.
If the target refuses, farther requests are blocked for a minute, preventing it from being exploitable in combat


Also includes a changelog from an earlier PR that didn't get uploaded previously