### PR TITLE
Fix for guns auto firing

### DIFF
--- a/code/_onclick/click_handlers/full_auto.dm
+++ b/code/_onclick/click_handlers/full_auto.dm
@@ -39,6 +39,8 @@
 /datum/click_handler/fullauto/MouseDown(object,location,control,params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["left"])
+		if(modifiers["ctrl"] || modifiers["alt"] || modifiers["shift"]) //no firing after using hotkeys
+			return TRUE
 		left_mousedown = TRUE
 		object = resolve_world_target(object, params)
 		if (object)

--- a/html/changelogs/terror4000rus-af.yml
+++ b/html/changelogs/terror4000rus-af.yml
@@ -1,0 +1,4 @@
+author: Terror4000rus
+delete-after: True
+changes: 
+  - bugfix: "Guns with automatic firing shouldn't shoot after examing, pulling or checking a tile's content via hotkeys."


### PR DESCRIPTION
 - bugfix: "Guns with automatic firing shouldn't shoot after examing, pulling or checking a tile's content via hotkeys."
