### PR TITLE
Meddle, Debug Messages and Balance Tweaks

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -23,7 +23,6 @@
 	var/heat_proof = 0 // For glass airlocks/opacity firedoors
 	var/air_properties_vary_with_direction = 0
 	max_health = 150
-	health
 
 	var/destroy_hits = 10 //How many strong hits it takes to destroy the door
 	var/min_force = 10 //minimum amount of force needed to damage the door with a melee weapon or unarmed attack
@@ -50,6 +49,7 @@
 	//A list of areas we are on or bordering
 	var/list/border_areas = list()
 
+/* //Too many balance problems, needs some reconsidering
 /obj/machinery/door/meddle()
 	if (!density)
 		close()
@@ -61,6 +61,7 @@
 
 	.=..()
 
+*/
 
 /obj/machinery/door/attack_generic(var/mob/user, var/damage, var/attack_verb, var/environment_smash)
 	if(environment_smash >= 1)

--- a/code/modules/mob/living/abilities/false_death.dm
+++ b/code/modules/mob/living/abilities/false_death.dm
@@ -15,7 +15,7 @@
 	var/mob/living/carbon/human/user
 	var/power = 1
 	var/cooldown = 2 MINUTES
-	var/duration = 20 SECONDS
+	var/duration = 30 SECONDS
 
 	var/started_at
 	var/stopped_at

--- a/code/modules/mob/living/abilities/false_death.dm
+++ b/code/modules/mob/living/abilities/false_death.dm
@@ -46,14 +46,12 @@
 
 	//This must be an integer, and we do -2 since it takes a tick or two to stand up, after awaking
 	var/paralyse_duration = Floor(duration / (MOB_PROCESS_INTERVAL))-2
-	world << "Paralysing for A: [paralyse_duration] B: [duration / (MOB_PROCESS_INTERVAL)] C: [Floor(duration / (MOB_PROCESS_INTERVAL))]"
 	user.Paralyse(paralyse_duration	)
 
 	//Lets schedule the regen
 	var/datum/extension/regenerate/R = regen_type
 	var/regen_time = initial(R.duration)
 
-	world << "Setting do regen in [(duration-regen_time)]"
 	addtimer(CALLBACK(src, /datum/extension/false_death/proc/do_regen), (duration-regen_time))
 
 /datum/extension/false_death/proc/stop()
@@ -73,7 +71,6 @@
 
 
 /datum/extension/false_death/proc/do_regen()
-	world << "Doing regen"
 	set_extension(user, regen_type)
 
 
@@ -84,7 +81,6 @@
 /mob/living/proc/can_false_death()
 	var/datum/extension/false_death/E = get_extension(src, /datum/extension/false_death)
 	if(istype(E))
-		world << "Cant do FD, exists"
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -24,7 +24,7 @@
 	plane = LARGE_MOB_PLANE
 	layer = LARGE_MOB_LAYER
 
-	biomass = 350
+	biomass = 400
 	mass = 250
 	biomass_reclamation_time	=	15 MINUTES
 	virus_immune = 1

--- a/code/modules/mob/living/carbon/human/species/necromorph/hunter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/hunter.dm
@@ -25,12 +25,12 @@
 	Avoid fire though."
 
 	//Health and Defense
-	total_health = 250
+	total_health = 225
 	torso_damage_mult = 0.5 //Hitting centre mass more fine for hunter
 	can_obliterate = FALSE
 	healing_factor = 4	//Minor constant healing
 	dismember_mult = 1
-	biomass = 350
+	biomass = 400
 	mass = 250
 	limb_health_factor = 1	//Not as fragile as a slasher
 	virus_immune = 1

--- a/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
@@ -30,7 +30,7 @@
 	plane = LARGE_MOB_PLANE
 	layer = LARGE_MOB_LAYER
 
-	biomass = 350
+	biomass = 400
 	mass = 250
 	biomass_reclamation_time	=	15 MINUTES
 	marker_spawnable = TRUE

--- a/code/modules/mob/observer/freelook/marker/marker.dm
+++ b/code/modules/mob/observer/freelook/marker/marker.dm
@@ -6,7 +6,7 @@
 	name = "Marker"
 	icon = 'icons/obj/marker_giant.dmi'
 	icon_state = "marker_giant_dormant"
-	pixel_x = -70 //Previously 33
+	pixel_x = -33
 	plane = ABOVE_HUMAN_PLANE
 	density = TRUE
 	anchored = TRUE

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/meddle.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/meddle.dm
@@ -8,7 +8,7 @@
 	id = "meddle"
 	desc = "A context sensitive spell which does different things depending on the target. Interfaces with machines, moves items, messes with computers and office appliances. Try it on lots of things!"
 	target_string = "any object"
-	energy_cost = 99999
+	energy_cost = 8
 	require_corruption = FALSE
 	require_necrovision = TRUE
 	autotarget_range = 0

--- a/html/changelogs/meddle_hunter.yml
+++ b/html/changelogs/meddle_hunter.yml
@@ -1,0 +1,39 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Increased the biomass cost of T3 Necromorphs from 350 to 400"
+  - tweak: "Reduced hunter's max health from 250 to 225."
+  - tweak: "When health hits 0, hunter is now downed for 30 seconds, previously 20."
+  - tweak: "Meddle signal ability no longer affects airlocks, doors, or shutters."


### PR DESCRIPTION
Removes more debug messages related to hunter
Re-adds meddle spell, with significant balance fixing

Other changes in response to feedback
changes: 
  - tweak: "Increased the biomass cost of T3 Necromorphs from 350 to 400"
  - tweak: "Reduced hunter's max health from 250 to 225."
  - tweak: "When health hits 0, hunter is now downed for 30 seconds, previously 20."
  - tweak: "Meddle signal ability no longer affects airlocks, doors, or shutters."