### PR TITLE
Necromorph Tier Costs

### DIFF
--- a/code/__defines/necromorph.dm
+++ b/code/__defines/necromorph.dm
@@ -51,3 +51,8 @@
 
 #define PLACEMENT_FLOOR	"floor"
 #define PLACEMENT_WALL	"wall"
+
+
+#define BIOMASS_REQ_T2	600
+#define BIOMASS_REQ_T3	1000
+#define BIOMASS_REQ_T4	3825

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -164,6 +164,7 @@ var/global/list/image/splatter_cache=list()
 	var/message
 	biomass = 0
 	appearance_flags = PIXEL_SCALE
+	var/creator
 
 /obj/effect/decal/cleanable/blood/writing/New()
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1053,6 +1053,7 @@
 		W.basecolor = (hand_blood_color) ? hand_blood_color : COLOR_BLOOD_HUMAN
 		W.update_icon()
 		W.message = message
+		W.creator = "[src.name]_[src.ckey]"
 		W.add_fingerprint(src)
 
 #define CAN_INJECT 1

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -23,7 +23,7 @@
 	pixel_offset_x = -16
 	plane = LARGE_MOB_PLANE
 	layer = LARGE_MOB_LAYER
-
+	require_total_biomass	=	BIOMASS_REQ_T3
 	biomass = 400
 	mass = 250
 	biomass_reclamation_time	=	15 MINUTES

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
@@ -6,6 +6,7 @@
 	unarmed_types = list(/datum/unarmed_attack/claws/strong/divider)
 	total_health = 225
 	biomass = 150
+	require_total_biomass	=	BIOMASS_REQ_T2
 	mass = 120
 	limb_health_factor = 1.0
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/hunter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/hunter.dm
@@ -31,6 +31,7 @@
 	healing_factor = 4	//Minor constant healing
 	dismember_mult = 1
 	biomass = 400
+	require_total_biomass	=	BIOMASS_REQ_T3
 	mass = 250
 	limb_health_factor = 1	//Not as fragile as a slasher
 	virus_immune = 1

--- a/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/necromorph_species.dm
@@ -14,7 +14,7 @@
 	var/marker_spawnable = TRUE	//Set this to true to allow the marker to spawn this type of necro. Be sure to unset it on the enhanced version unless desired
 	var/preference_settable = TRUE
 	biomass = 80	//This var is defined for all species
-	var/use_total_biomass = FALSE
+	var/require_total_biomass = 0	//If set, this can only be spawned when total biomass is above this value
 	var/biomass_reclamation	=	1	//The marker recovers cost*reclamation
 	var/biomass_reclamation_time	=	8 MINUTES	//How long does it take for all of the reclaimed biomass to return to the marker? This is a pseudo respawn timer
 	var/spawn_method = SPAWN_POINT	//What method of spawning from marker should be used? At a point or manual placement? check _defines/necromorph.dm

--- a/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
@@ -4,6 +4,7 @@
 	name_plural = "pukers"
 	total_health = 160
 	biomass = 130
+	require_total_biomass	=	BIOMASS_REQ_T2
 	mass = 120
 	view_range = 9
 	limb_health_factor = 1.15

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -115,6 +115,7 @@
 	total_health = 225
 	slowdown = 2.8
 	biomass = 125
+	require_total_biomass	=	BIOMASS_REQ_T2
 	view_range = 8
 	mass = 120
 	mob_size	= MOB_LARGE

--- a/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
@@ -31,6 +31,7 @@
 	layer = LARGE_MOB_LAYER
 
 	biomass = 400
+	require_total_biomass	=	BIOMASS_REQ_T3
 	mass = 250
 	biomass_reclamation_time	=	15 MINUTES
 	marker_spawnable = TRUE

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -26,6 +26,7 @@
 	spawner_spawnable = FALSE
 	virus_immune = 1
 	biomass	=	120
+	require_total_biomass	=	BIOMASS_REQ_T2
 	lying_rotation = 90
 	total_health = 100
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/ubermorph.dm
@@ -8,8 +8,8 @@
 	total_health = INFINITY	//This number doesn't matter, it won't ever be used
 	can_obliterate = FALSE
 	healing_factor = 4	//Lots of constant healing
-	biomass	=	3825	//Endgame, real expensive -- Lowered from 4500 to 3825 = 15% on 14/10/2020
-	use_total_biomass = TRUE
+	require_total_biomass	=	BIOMASS_REQ_T4	//Endgame, real expensive -- Lowered from 4500 to 3825 = 15% on 14/10/2020
+	biomass = 0	//IT has no cost when you meet the requirement
 	global_limit = 1
 	mass = 130
 	limb_health_factor = 1	//Not as fragile as a slasher

--- a/code/modules/mob/observer/freelook/marker/necroshop.dm
+++ b/code/modules/mob/observer/freelook/marker/necroshop.dm
@@ -52,7 +52,7 @@
 		I.spawn_method = initial(N.spawn_method)
 		I.spawn_path = N.mob_type
 		I.queue_fill = N.major_vessel
-		I.require_total_biomass = N.use_total_biomass
+		I.require_total_biomass = N.require_total_biomass
 		I.global_limit = N.global_limit
 
 		//Check if its allowed, based on global limits
@@ -306,11 +306,11 @@
 	//For total mass requirements, we check but don't pay
 	if (params["reqtotal"])
 		if (host.get_total_biomass() < params["price"])
-			to_chat(params["user"], SPAN_DANGER("ERROR: Not enough biomass to spawn [params["name"]]"))
+			to_chat(params["user"], SPAN_DANGER("ERROR: Not enough total biomass to spawn [params["name"]]"))
 			return
 
 	//This line actually takes the biomass in most cases
-	else if (!host_pay_biomass(params["name"], params["price"]))
+	if (!host_pay_biomass(params["name"], params["price"]))
 		to_chat(params["user"], SPAN_DANGER("ERROR: Not enough biomass to spawn [params["name"]]"))
 		return
 
@@ -348,6 +348,10 @@
 //Attempts to subtract the relevant quantity of biomass from the host marker or whatever else
 //Make sure this is the last step before spawning, it can't be allowed to fail after this
 /datum/necroshop/proc/host_pay_biomass(var/purpose, var/amount)
+	//If the cost is zero, don't even trouble the marker, we're sure it can pay
+	if (!amount)
+		return TRUE
+
 	if (host.pay_biomass(purpose, amount))
 		return TRUE
 
@@ -383,10 +387,10 @@
 		return FALSE
 
 	if (require_total_biomass)
-		if (caller.host.get_total_biomass() < price)
+		if (caller.host.get_total_biomass() < require_total_biomass)
 			return FALSE
 
-	else if (caller.host.biomass < price)
+	if (caller.host.biomass < price)
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/blood_writing.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/blood_writing.dm
@@ -28,5 +28,6 @@
 	var/obj/effect/decal/cleanable/blood/writing/W = new(target)
 	W.transform = W.transform.Scale(2)
 	W.message = message
+	W.creator = "[user.name]_[user.ckey]"
 	W.visible_message("<span class='warning'>Invisible fingers crudely paint something in blood on \the [target].</span>")
 

--- a/html/changelogs/necrotier.yml
+++ b/html/changelogs/necrotier.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "Tier II and III necromorphs now have minimum requirements of total biomass, meaning they can't be spawned at the beginning of the outbreak."

--- a/nano/templates/necroshop.tmpl
+++ b/nano/templates/necroshop.tmpl
@@ -45,9 +45,9 @@ h3 {
 				<h1>{{:data.current.name}}</h1>
 				{{if data.current.reqtotal}}
 					<hr>
-					<span class="notice" style="padding: 4px">Total Biomass: {{:data.total}}/{{:data.current.price}}    </br>
+					<span class="notice" style="padding: 4px">Total Biomass: {{:data.total}}/{{:data.current.reqtotal}}   </br>
 					Total Biomass includes biomass currently invested in necromorphs and corruption nodes, whether they are alive, or dead and being reclaimed </br>
-					This can be spawned for free when you accumulate enough total mass.</span>
+					This can be spawned for {{:data.current.price}}kg biomass when you accumulate enough total mass.</span>
 					<hr>
 				{{/if}}
 				<div style="line-height: 120%; font-size: 11px;">{{:data.current.desc}}</div>


### PR DESCRIPTION
changes: 
  - experiment: "Tier II and III necromorphs now have minimum requirements of total biomass, meaning they can't be spawned at the beginning of the outbreak."

These values are currently 600 and 1000, though will likely be tweaked in response to feedback.

This PR is something that's been long requested, the goal is to make the necromorphs scale up gradually, fighting with T1s at first, then unlocking higher tiers as they go. We'll see how it works out.

Also includes one small change lion requested, blood writing now has a var showing the name and key of the player who wrote it. Only visible in var viewer, intended for admin use