### PR TITLE
Banning writing in blood and drawing runes in line of sight

### DIFF
--- a/code/modules/mob/observer/freelook/marker/signal_abilities/blood_writing.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/blood_writing.dm
@@ -6,7 +6,7 @@
 	energy_cost = 15
 	require_corruption = FALSE
 	autotarget_range = 0
-	LOS_block = FALSE	//This is for spooking people, we want them to see it happen
+	LOS_block = TRUE
 	target_types = list(/turf/simulated)
 
 

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/blood_writing.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/blood_writing.dm
@@ -19,14 +19,26 @@
 		return
 	return TRUE
 
+/datum/signal_ability/writing/proc/middle_check(var/mob/user, var/turf/target)
+	if(LOS_block) //copied from is_valid_target
+		var/mob/M = target.is_seen_by_crew()
+		if (M)
+			to_chat(user, SPAN_WARNING("Casting here is blocked because the tile is seen by [M]."))
+			refund(user)
+			return FALSE
+	return TRUE
+
 /datum/signal_ability/writing/on_cast(var/mob/user, var/atom/target, var/list/data)
 	var/message = sanitize(input("Write a message", "Blood writing", ""))
 	if (!message)
-		refund()
+		refund(user)
+		return
+
+	if(!middle_check(user, target))
+		to_chat(user, SPAN_WARNING("You wrote: \"[message]\"."))
 		return
 
 	var/obj/effect/decal/cleanable/blood/writing/W = new(target)
 	W.transform = W.transform.Scale(2)
 	W.message = message
 	W.visible_message("<span class='warning'>Invisible fingers crudely paint something in blood on \the [target].</span>")
-

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/runes.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/runes.dm
@@ -6,7 +6,7 @@
 	energy_cost = 16
 	require_corruption = FALSE
 	autotarget_range = 0
-	LOS_block = FALSE	//This is for spooking people, we want them to see it happen
+	LOS_block = TRUE
 	target_types = list(/turf/simulated)
 
 /datum/signal_ability/runes/on_cast(var/mob/user, var/atom/target, var/list/data)

--- a/html/changelogs/terror4000rus-rlb.yml
+++ b/html/changelogs/terror4000rus-rlb.yml
@@ -1,0 +1,4 @@
+author: Terror4000rus
+delete-after: True
+changes: 
+  - rscadd: "Signals can't write in blood and draw runes in line of human sight."


### PR DESCRIPTION
  - rscadd: "Signals can't write in blood and draw runes in line of human sight."

Why?
It looks strange and frustrating in game. You are trying to play your role while some signal decides to write under your feets "DIE DIE DIE" or 2-3 runes at walls and floor.
...And just unfitting. It makes more sense for a theory that a mad crewmember wrote them than the marke~~t~~r's invisible hand.