### PR TITLE
Charge tweaks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1877,6 +1877,7 @@
 #include "code\modules\mob\living\abilities\tripod_evasion.dm"
 #include "code\modules\mob\living\abilities\twitch_blink.dm"
 #include "code\modules\mob\living\abilities\wallrun.dm"
+#include "code\modules\mob\living\abilities\charge\helpers.dm"
 #include "code\modules\mob\living\abilities\execution\execution.dm"
 #include "code\modules\mob\living\abilities\execution\execution_stage.dm"
 #include "code\modules\mob\living\abilities\particles\particle.dm"

--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -80,6 +80,21 @@
 		. = construct_extension_instance(extension_data[1], extension_data[2], extension_data.Copy(3))
 		source.extensions[base_type] = .
 
+/*
+	Gets the first matching extension using istype
+*/
+/proc/get_extension_of_type(var/datum/source, var/search_type)
+	if(!source.extensions)
+		return
+	for (var/typepath in source.extensions)
+		var/datum/extension/E = source.extensions[typepath]
+		if (istype(E, search_type))
+			.=E
+			break
+	if(!. || !istype(., /datum/extension))
+		return null
+
+
 //Fast way to check if it has an extension, also doesn't trigger instantiation of lazy loaded extensions
 /proc/has_extension(var/datum/source, var/base_type)
 	return (source.extensions && source.extensions[base_type])

--- a/code/game/objects/throwing.dm
+++ b/code/game/objects/throwing.dm
@@ -123,6 +123,9 @@
 	if (mount)
 		mount.dismount()
 
+	//Cancel any charges or leaps
+	cancel_movement_abilities()
+
 	var/interval = 10 / speed
 	var/sleep_debt = 0
 	//use a modified version of Bresenham's algorithm to get from the atom's current position to that of the target

--- a/code/modules/mob/living/abilities/charge.dm
+++ b/code/modules/mob/living/abilities/charge.dm
@@ -55,6 +55,7 @@
 	var/atom/target = null //What we want to hit
 	var/atom/move_target = null //What we're actually running towards, may not be the same
 	var/speed = 5
+	var/base_speed = 5
 	var/lifespan = 0
 	var/homing = TRUE
 	var/inertia = FALSE
@@ -96,7 +97,7 @@
 
 
 	target = _target
-	speed = _speed * user.get_move_speed_factor()
+
 	lifespan = _lifespan
 	range_left = _maxrange
 	homing = _homing
@@ -115,6 +116,11 @@
 		L.face_atom(target)
 		L.disable(max_lifespan())
 		starting_locomotion_limbs = length(L.get_locomotion_limbs(FALSE))
+
+	if (_speed)
+		base_speed = speed
+	calculate_speed()
+
 	//Delay handling
 	if (!delay)
 		//If no delay, start immediately
@@ -124,6 +130,35 @@
 
 		//If positive delay, wait that long before starting
 		start_timer = addtimer(CALLBACK(src, .proc/start), _delay, TIMER_STOPPABLE)
+
+/datum/extension/charge/proc/calculate_speed()
+	speed = base_speed * user.get_move_speed_factor()
+	if (isliving(user))
+		var/mob/living/L = user
+
+		//Lets factor in lying and missing limbs
+		var/mob/living/carbon/human/H
+		if (ishuman(L))
+			H = L
+
+		var/bad_speed_factor = 0.4
+		if (H)
+			bad_speed_factor = H.species.lying_speed_factor
+
+		//If we're crawling, we have the worst speed
+		if (L.lying)
+			speed *= bad_speed_factor
+			lifespan /= bad_speed_factor
+		else if (H)
+			//If we're missing limbs but still standing, we get a penalty thats not as bad as crawling
+			var/remaining_limb_percent = H.get_locomotive_limb_percent()
+			if (remaining_limb_percent < 1)
+				//This seems complicated but i'll walk through it with an example of 0.25
+				var/bad_speed_penalty = 1 - bad_speed_factor	//0.75, aka 75% speed penalty
+				bad_speed_penalty *= 1 - remaining_limb_percent	//1 - remaining_limb_percent gives us the percentage of limbs which are missing
+				bad_speed_factor = 1 - bad_speed_penalty //Convert penalty back to factor
+				speed *= bad_speed_factor	//Multiply with charge speed
+				lifespan /= bad_speed_factor
 
 /datum/extension/charge/proc/check_limbs(var/trip = FALSE)
 	if (L)
@@ -561,7 +596,7 @@
 
 	return ..()
 
-/atom/movable/proc/charge_attack(var/atom/_target, var/_speed = 7, var/_lifespan = 2 SECONDS, var/_maxrange = null, var/_homing = TRUE, var/_inertia = FALSE, var/_power = 0, var/_cooldown = 20 SECONDS, var/_delay = 0)
+/atom/movable/proc/charge_attack(var/atom/_target, var/_speed = 7, var/_lifespan = 3 SECONDS, var/_maxrange = null, var/_homing = TRUE, var/_inertia = FALSE, var/_power = 0, var/_cooldown = 20 SECONDS, var/_delay = 0)
 	//First of all, lets check if we're currently able to charge
 	if (!can_charge(_target, TRUE))
 		return FALSE
@@ -572,4 +607,16 @@
 	set_extension(src, /datum/extension/charge, _target, _speed, _lifespan, _maxrange, _homing, _inertia, _power, _cooldown, _delay)
 
 	return TRUE
+
+
+
+//This is only for debugging
+/mob/proc/autocharge()
+	for (var/mob/living/L in view())
+		if (!L.client)
+			continue
+		charge_attack(_target = L, _speed = 5,  _cooldown = 20, _delay = 2 SECONDS)
+		break
+
+
 

--- a/code/modules/mob/living/abilities/charge/helpers.dm
+++ b/code/modules/mob/living/abilities/charge/helpers.dm
@@ -1,0 +1,11 @@
+/*
+	Called when a mob gets launched
+	This cancels any ongoing abilities which make the mob move. Including:
+		Charge/Lunge
+		Leap
+		High Leap
+*/
+/atom/movable/proc/cancel_movement_abilities()
+	var/datum/extension/charge/C = get_extension_of_type(src, /datum/extension/charge)
+	if (C)
+		C.stop_peter_out()

--- a/code/modules/mob/living/abilities/leap.dm
+++ b/code/modules/mob/living/abilities/leap.dm
@@ -23,6 +23,11 @@
 	.=..()
 	homing = FALSE
 
+//Leap does not get any speed penalties from missing limbs
+
+/datum/extension/charge/leap/calculate_speed()
+	speed = base_speed * user.get_move_speed_factor()
+
 
 
 /datum/extension/charge/leap/start()

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -93,7 +93,7 @@
 				return H.grab(src)
 
 		if(I_HURT)
-			var/hit_zone = H.zone_sel.selecting
+			var/hit_zone = get_zone_sel(H)
 			var/datum/unarmed_attack/attack = H.get_unarmed_attack(src, hit_zone)
 			if(!attack)
 				return 0

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -79,7 +79,8 @@
 
 	tally += config.human_delay
 	tally /= get_move_speed_factor()
-
+	if(lying) //Crawling, it's slower
+		tally /= species.lying_speed_factor
 	return tally
 
 /mob/living/carbon/human/size_strength_mod()
@@ -166,3 +167,15 @@
 /mob/living/carbon/human/set_move_intent(var/decl/move_intent/M)
 	. = ..()
 	step_interval = M.footstep_interval
+
+
+//Returns what percentage of the limbs we use for movement, are still attached
+/mob/living/carbon/human/proc/get_locomotive_limb_percent()
+
+	var/current = length(get_locomotion_limbs(FALSE))
+	var/max = LAZYLEN(species.locomotion_limbs)
+
+	if (max > 0)
+		return current / max
+
+	return 1

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -16,7 +16,7 @@
 	mob_type	=	/mob/living/carbon/human/necromorph/leaper
 	blurb = "A long range ambusher, the leaper can leap on unsuspecting victims from afar, knock them down, and tear them apart with its bladed tail. Not good for prolonged combat though."
 	unarmed_types = list(/datum/unarmed_attack/claws) //Bite attack is a backup if blades are severed
-	total_health = 100
+	total_health = 110
 	biomass = 75
 
 	//Normal necromorph flags plus no slip
@@ -173,7 +173,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 
 //The leaper has a tail instead of legs
 /obj/item/organ/external/tail/leaper
-	max_damage = 75
+	max_damage = 65
 	min_broken_damage = 40
 	throwforce = 30 //The leaper's tail makes an excellent weapon if thrown after severing
 	edge = TRUE
@@ -202,6 +202,21 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	var/mob/living/carbon/human/H = src
 
 	if (!H.can_charge(A))
+		return
+
+	var/organ_check = FALSE
+	//The leaper can't leap if its missing too many limbs. Specifically, it must have either:
+	//Its tail
+	//OR
+	//Both arms
+	if (H.has_organ(BP_TAIL))
+		organ_check = TRUE
+
+	else if (H.has_organ(BP_R_ARM) && H.has_organ(BP_L_ARM))
+		organ_check = TRUE
+
+	if (!organ_check)
+		to_chat(src, SPAN_DANGER("You need your tail or both arms to perform a leap!"))
 		return
 
 	//Do a chargeup animation. Pulls back and then launches forwards

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -245,7 +245,7 @@ Dodge is a skill that requires careful timing, but if used correctly, it can all
 		A = autotarget_enemy_mob(A, 2, src, 999)
 
 
-	.= charge_attack(A, _delay = 1 SECONDS, _speed = 5.0, _lifespan = 6 SECONDS)
+	.= charge_attack(A, _delay = 1 SECONDS, _speed = 5.0, _lifespan = 4 SECONDS)
 	if (.)
 		var/mob/H = src
 		if (istype(H))
@@ -267,7 +267,7 @@ Dodge is a skill that requires careful timing, but if used correctly, it can all
 	if (!isliving(A))
 		A = autotarget_enemy_mob(A, 2, src, 999)
 
-	.= charge_attack(A, _delay = 0.75 SECONDS, _speed = 5.5, _lifespan = 6 SECONDS)
+	.= charge_attack(A, _delay = 0.75 SECONDS, _speed = 5.5, _lifespan = 4 SECONDS)
 	if (.)
 		var/mob/H = src
 		if (istype(H))

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -197,6 +197,8 @@
 	var/slowdown = 0              // Passive movement speed malus (or boost, if negative)
 	var/slow_turning = FALSE		//If true, mob goes on move+click cooldown when rotating in place, and can't turn+move in the same step
 	var/list/locomotion_limbs = list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)	//What limbs does this species use to move? It goes slower when these are missing/broken/splinted
+	var/lying_speed_factor = 0.25	//Our speed is multiplied by this when crawling
+
 
 	//Interaction
 	var/limited_click_arc = 0	  //If nonzero, the mob is limited to clicking on things in X degrees arc infront of it. Best combined with slow turning. Recommended values, 45 or 90

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -191,8 +191,7 @@
 
 	if ((drowsyness > 0) && !MOVING_DELIBERATELY(src))
 		. += 6
-	if(lying) //Crawling, it's slower
-		. += 8 + (weakened * 2)
+
 	. += move_intent.move_delay
 	. += encumbrance() * (0.5 + 1.5 * (SKILL_MAX - get_skill_value(SKILL_HAULING))/(SKILL_MAX - SKILL_MIN)) //Varies between 0.5 and 2, depending on skill
 

--- a/code/modules/projectiles/guns/ds13/line_cutter/wave.dm
+++ b/code/modules/projectiles/guns/ds13/line_cutter/wave.dm
@@ -228,8 +228,13 @@
 				candidates = list()
 			candidates += W
 
-		//Randomly pick from those that are joint top in number of connections
-		master = pick(candidates)
+		if (candidates.len)
+			//Randomly pick from those that are joint top in number of connections
+			master = pick(candidates)
+		else
+			//If we just lost our last projectile, we have no more reason to exist
+			qdel(src)
+			return
 
 
 	master.designated_master()

--- a/html/changelogs/charge.yml
+++ b/html/changelogs/charge.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Necromorphs which are missing legs or laying down, will now charge at a much slower speed to reflect their mobility"
+  - tweak: "Necromorphs which are charging or leaping can now be knocked out of it by anything that would launch them. Such as force gun."
+  - tweak: "Slightly increased leaper's max health, but reduced the health of its tail."


### PR DESCRIPTION
changes: 
  - tweak: "Necromorphs which are missing legs or laying down, will now charge at a much slower speed to reflect their mobility"
  - tweak: "Necromorphs which are charging or leaping can now be knocked out of it by anything that would launch them. Such as force gun."
  - tweak: "Slightly increased leaper's max health, but reduced the health of its tail."

Closes #803 
Closes #1082
Closes #1162 