### PR TITLE
Riot helmet pill fix

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -42,9 +42,11 @@
 	if(src.icon_state == initial(icon_state))
 		src.icon_state = "[icon_state]_up"
 		to_chat(user, "You raise the visor on the [src].")
+		body_parts_covered &= ~(FACE|EYES)
 	else
 		src.icon_state = initial(icon_state)
 		to_chat(user, "You lower the visor on the [src].")
+		body_parts_covered |= (EYES|FACE)
 	update_clothing_icon()
 
 /obj/item/clothing/head/helmet/ballistic

--- a/html/changelogs/riot-shield-pill-fix.yml
+++ b/html/changelogs/riot-shield-pill-fix.yml
@@ -1,0 +1,6 @@
+author: Jeser
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed feeding pills being prevented by riot helmet with raised visor."


### PR DESCRIPTION
bugfix: "Fixed feeding pills being prevented by riot helmet with raised visor."

_No idea why I named branch riot shield_

Closes https://github.com/DS-13-Dev-Team/DS13/issues/1140