### PR TITLE
Disables check for initial var in proc arguments.

### DIFF
--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -106,10 +106,12 @@ while read f; do
         st=1
     fi;
 done < <(find . -type f -name '*.dm')
-if grep -nP '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' code/**/*.dm; then
-    echo "changed files contains proc argument starting with 'var'"
-    st=1
-fi;
+#Disabled because #1187 was closed.
+#TODO: Re-enable at later date.
+#if grep -nP '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' code/**/*.dm; then
+#    echo "changed files contains proc argument starting with 'var'"
+#    st=1
+#fi;
 if grep -ni 'nanotransen' code/**/*.dm; then
     echo "Misspelling(s) of nanotrasen detected in code, please remove the extra N(s)."
     st=1


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
In lieu of merging #1187, this is also acceptable to suppress these errors.
The rationale:
While some codebases (TGstation and its forks, I believe) view an initial `var/` in proc arguments to be bad form, it doesn't actually affect the code. Additionally, Bay forks tend to view removing it as unnecessary and argue that it increases visibility.
It is not an issue that warrants a CI block, therefore it can safely be disabled until a consensus is reached on whether or not `var/` is verboten or required in proc arguments.