### PR TITLE
Removes EW from rotation as non-votable.

### DIFF
--- a/code/game/gamemodes/marker/gamemodes.dm
+++ b/code/game/gamemodes/marker/gamemodes.dm
@@ -24,7 +24,7 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	round_description = "The USG Ishimura has discovered a strange artifact on Aegis VII, but it is not whole. Some piece of it has been broken off and smuggled aboard"
 	extended_round_description = "The crew must holdout until help arrives"
 	config_tag = "enemy_within"
-	votable = TRUE
+	votable = FALSE
 	antag_tags = list(MODE_UNITOLOGIST_SHARD)
 
 /datum/game_mode/marker/enemy_within/get_marker_location()


### PR DESCRIPTION
🆑 
rscdel: Removed Enemy Within from voting temporarily, until it is fixed.
/🆑 

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
