### PR TITLE
Cleans up psychic tracer deletion

### DIFF
--- a/code/modules/mob/observer/freelook/marker/signal_abilities/psychic_tracer.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/psychic_tracer.dm
@@ -50,7 +50,9 @@
 /obj/effect/psychic_tracer/get_visualnet_tiles(var/datum/visualnet/network)
 	return EM.get_visualnet_tiles(network)
 
-
+/obj/effect/psychic_tracer/Destroy()
+	EM = null //Clears out the ref that's about to become nulled to save GC time.
+	. = ..()
 
 /*
 	Extension: Added to the infected mob
@@ -133,10 +135,10 @@
 	remove_extension(holder, base_type)
 
 /datum/extension/psychic_tracer/Destroy()
-	QDEL_NULL(object)
+	qdel(object)
+	object = null
 	GLOB.necrovision.remove_source(src, TRUE, TRUE)
 	.=..()
-
 
 //Find out how many crew can see our source
 /datum/extension/psychic_tracer/proc/get_visible_crew()

--- a/code/modules/mob/observer/freelook/marker/signal_abilities/psychic_tracer.dm
+++ b/code/modules/mob/observer/freelook/marker/signal_abilities/psychic_tracer.dm
@@ -135,8 +135,7 @@
 	remove_extension(holder, base_type)
 
 /datum/extension/psychic_tracer/Destroy()
-	qdel(object)
-	object = null
+	QDEL_NULL(object)
 	GLOB.necrovision.remove_source(src, TRUE, TRUE)
 	.=..()
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
fixes #1040

* Psychic tracers were forcing a hard reference clear by the GC, which is a lot of work. I've shifted it to free up its memory refs in its destructor

The recursive timer based tick() system is a bit weird, I'd like to monitor that and see if it needs any work. My attempts to get those extensions processing failed for unknown reasons.