### PR TITLE
fix bad initialize toolbox.

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -38,7 +38,7 @@
 	startswith = list( /obj/random/tool, /obj/item/weapon/tool/screwdriver, /obj/item/weapon/tool/wrench, /obj/item/weapon/tool/weldingtool, /obj/item/weapon/tool/crowbar, /obj/item/device/analyzer, /obj/item/weapon/tool/wirecutters)
 
 /obj/item/weapon/storage/toolbox/mechanical/Initialize()
-	..()
+	. = ..()
 	if (prob(40))
 		new /obj/random/tool_upgrade(src)
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
the toolboxes were giving an error message in the atom subsystem.