### PR TITLE
AntagJobRestriction-Fix

### DIFF
--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -114,7 +114,6 @@ GLOBAL_DATUM_INIT(kellion, /datum/antagonist/ert/kellion, new)
 	landmark_id = "unitologiststeam"
 	antaghud_indicator = "hudunitologist" // Used by the ghost antagHUD.
 	antag_indicator = "hudunitologist"// icon_state for icons/mob/mob.dm visual indicator.
-	restricted_jobs = list(JOBS_SECURITY)
 	outfits = list(
 		/decl/hierarchy/outfit/faithful,
 		/decl/hierarchy/outfit/healer,

--- a/code/game/gamemodes/marker/unitologist.dm
+++ b/code/game/gamemodes/marker/unitologist.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_EMPTY(unitologists_list)
 	skill_setter = /datum/antag_skill_setter/station
 	antaghud_indicator = "hudunitologist" // Used by the ghost antagHUD.
 	antag_indicator = "hudunitologist"// icon_state for icons/mob/mob.dm visual indicator.
+	restricted_jobs = list(JOBS_SECURITY)
 	preference_candidacy_toggle = TRUE
 
 	// Spawn values (autotraitor and game mode)


### PR DESCRIPTION
Should fix an error with #1226 where the Unitologist Response Team was restricted from Security roles instead of the Unitologist antagonist traitors.