### PR TITLE
Loadout Rework

### DIFF
--- a/code/datums/outfits/equipment/backpacks.dm
+++ b/code/datums/outfits/equipment/backpacks.dm
@@ -13,31 +13,9 @@
 	return
 
 /decl/backpack_outfit/backpack
-	name = "Backpack"
-	path = /obj/item/weapon/storage/backpack
+	name = "Civilian CEC Rig"
+	path = /obj/item/weapon/rig/civilian
 	is_default = TRUE
-
-/decl/backpack_outfit/rucksack
-	name = "Rucksack"
-	path = /obj/item/weapon/storage/backpack/rucksack
-	flags = BACKPACK_HAS_TYPE_SELECTION
-
-/decl/backpack_outfit/satchel
-	name = "Satchel"
-	path = /obj/item/weapon/storage/backpack/satchel
-
-/decl/backpack_outfit/satchel/New()
-	..()
-	tweaks += new/datum/backpack_tweak/selection/specified_types_as_list(typesof(/obj/item/weapon/storage/backpack/satchel/leather) + /obj/item/weapon/storage/backpack/satchel/grey)
-
-/decl/backpack_outfit/messenger_bag
-	name = "Messenger bag"
-	path = /obj/item/weapon/storage/backpack/messenger
-
-/decl/backpack_outfit/pocketbook
-	name = "Pocketbook"
-	path = /obj/item/weapon/storage/backpack/satchel/pocketbook
-	flags = BACKPACK_HAS_TYPE_SELECTION
 
 /* Code */
 /decl/backpack_outfit

--- a/code/datums/outfits/jobs/_defines.dm
+++ b/code/datums/outfits/jobs/_defines.dm
@@ -1,31 +1,34 @@
 #define OUTFIT_JOB_NAME(job_name) ("Job - " + job_name)
 
 #define BACKPACK_OVERRIDE_CHEMISTRY \
-backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/chemistry; \
-backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_chem; \
-backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/chem;
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/civilian; \
 
 #define BACKPACK_OVERRIDE_ENGINEERING \
-backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/industrial; \
-backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_eng; \
-backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/engi;
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/engineering; \
+
+#define BACKPACK_OVERRIDE_ENGINEERINGCHIEF \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/advanced; \
 
 #define BACKPACK_OVERRIDE_MEDICAL \
-backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/medic; \
-backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_med; \
-backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/med;
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/civilian; \
 
 #define BACKPACK_OVERRIDE_RESEARCH \
-backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/toxins; \
-backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_tox; \
-backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/viro;
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/civilian; \
 
 #define BACKPACK_OVERRIDE_SECURITY \
-backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/security; \
-backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_sec; \
-backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/sec;
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/security; \
+
+#define BACKPACK_OVERRIDE_SECURITYCHIEF \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/riot; \
 
 #define BACKPACK_OVERRIDE_VIROLOGY \
-backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/storage/backpack/virology; \
-backpack_overrides[/decl/backpack_outfit/satchel]       = /obj/item/weapon/storage/backpack/satchel_vir; \
-backpack_overrides[/decl/backpack_outfit/messenger_bag] = /obj/item/weapon/storage/backpack/messenger/viro;
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/civilian; \
+
+#define BACKPACK_OVERRIDE_MINING \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/mining; \
+
+#define BACKPACK_OVERRIDE_MININGSUPERVISOR \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/vintage; \
+
+#define BACKPACK_OVERRIDE_MININGCHIEF \
+backpack_overrides[/decl/backpack_outfit/backpack]      = /obj/item/weapon/rig/civilian; \

--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -10,6 +10,10 @@
 	..()
 	BACKPACK_OVERRIDE_ENGINEERING
 
+/decl/hierarchy/outfit/job/engineering/ce/New()
+	..()
+	BACKPACK_OVERRIDE_ENGINEERINGCHIEF
+
 /decl/hierarchy/outfit/job/engineering/ce
 	name = OUTFIT_JOB_NAME("Chief Engineer")
 	head = /obj/item/clothing/head/hardhat/white

--- a/code/datums/outfits/jobs/mining.dm
+++ b/code/datums/outfits/jobs/mining.dm
@@ -22,3 +22,15 @@
 	uniform = /obj/item/clothing/under/deadspace/planet_cracker
 	shoes = /obj/item/clothing/shoes/black
 	id_type = /obj/item/weapon/card/id/holo/mining
+
+/decl/hierarchy/outfit/job/mining/New()
+	..()
+	BACKPACK_OVERRIDE_MINING
+
+/decl/hierarchy/outfit/job/mining/foreman/New()
+	..()
+	BACKPACK_OVERRIDE_MININGSUPERVISOR
+
+/decl/hierarchy/outfit/job/mining/dom/New()
+	..()
+	BACKPACK_OVERRIDE_MININGCHIEF

--- a/code/datums/outfits/jobs/security.dm
+++ b/code/datums/outfits/jobs/security.dm
@@ -12,6 +12,10 @@
 	..()
 	BACKPACK_OVERRIDE_SECURITY
 
+/decl/hierarchy/outfit/job/security/cseco/New()
+	..()
+	BACKPACK_OVERRIDE_SECURITYCHIEF
+
 /decl/hierarchy/outfit/job/security/cseco
 	name = OUTFIT_JOB_NAME("Chief Security Officer")
 	suit = /obj/item/clothing/suit/armor/vest/ds_jacket

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -13,7 +13,6 @@
 		new/datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/industrial, /obj/item/weapon/storage/backpack/satchel_eng)),
 		new/datum/atom_creator/simple(/obj/item/weapon/storage/backpack/dufflebag/eng, 50),
 		/obj/item/blueprints,
-		/obj/item/weapon/rig/advanced,
 		/obj/item/clothing/under/deadspace/engineer,
 		/obj/item/clothing/head/hardhat/white,
 		/obj/item/clothing/head/welding,
@@ -89,8 +88,7 @@
 		/obj/item/device/radio/headset/headset_eng,
 		/obj/item/taperoll/engineering,
 		/obj/item/device/flashlight,
-		/obj/item/weapon/storage/belt/utility/full,
-		/obj/item/weapon/rig/engineering
+		/obj/item/weapon/storage/belt/utility/full
 	)
 
 /obj/structure/closet/secure_closet/atmos_personal

--- a/code/game/objects/structures/crates_lockers/closets/secure/mining.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/mining.dm
@@ -59,7 +59,6 @@
 		return list(
 		/obj/item/device/radio/headset/headset_cargo,
 		/obj/item/clothing/under/deadspace/planet_cracker,
-		/obj/item/weapon/rig/mining,
 		/obj/item/clothing/shoes/dutyboots,
 		/obj/item/clothing/glasses/meson,
 		/obj/item/clothing/gloves/thick,

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -93,8 +93,7 @@
 		/obj/item/weapon/storage/box/holobadge,
 		/obj/item/device/holowarrant,
 		/obj/random/tool,
-		/obj/item/weapon/gun/energy/taser,
-		/obj/item/weapon/rig/riot
+		/obj/item/weapon/gun/energy/taser
 	)
 
 /obj/structure/closet/secure_closet/security
@@ -124,8 +123,7 @@
 		/obj/item/clothing/under/deadspace/security,
 		/obj/item/weapon/gun/energy/taser,
 		/obj/item/device/holowarrant,
-//		/obj/item/device/flash,
-		/obj/item/weapon/rig/security
+//		/obj/item/device/flash
 	)
 
 /obj/structure/closet/secure_closet/security/cargo/WillContain()
@@ -238,10 +236,7 @@
 		/obj/item/device/flashlight/maglight,
 		/obj/item/device/tape/random = 3,
 		/obj/item/weapon/storage/belt/holster/forensic,
-		/obj/item/weapon/storage/belt/holster/security,
-		/obj/item/weapon/rig/security,
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel_sec)),
-		new /datum/atom_creator/weighted(list(/obj/item/weapon/storage/backpack/dufflebag/sec, /obj/item/weapon/storage/backpack/messenger/sec))
+		/obj/item/weapon/storage/belt/holster/security
 	)
 
 /obj/structure/closet/secure_closet/military

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -95,7 +95,7 @@
 				. += " <a href='?src=\ref[src];underwear=[UWC.name];tweak=\ref[gt]'>[gt.get_contents(get_underwear_metadata(UWC.name, gt))]</a>"
 
 		. += "<br>"
-	. += "Backpack Type: <a href='?src=\ref[src];change_backpack=1'><b>[pref.backpack.name]</b></a>"
+	. += "RIG Type: <a href='?src=\ref[src];change_backpack=1'><b>[pref.backpack.name]</b></a>"
 	for(var/datum/backpack_tweak/bt in pref.backpack.tweaks)
 		. += " <a href='?src=\ref[src];backpack=[pref.backpack.name];tweak=\ref[bt]'>[bt.get_ui_content(get_backpack_metadata(pref.backpack, bt))]</a>"
 	. += "<br>"
@@ -177,12 +177,7 @@
 	if(preferences["version"]  <= 16)
 		var/list/old_index_to_backpack_type = list(
 			/decl/backpack_outfit/nothing,
-			/decl/backpack_outfit/backpack,
-			/decl/backpack_outfit/satchel,
-			/decl/backpack_outfit/messenger_bag,
-			/decl/backpack_outfit/satchel,
-			/decl/backpack_outfit/satchel,
-			/decl/backpack_outfit/pocketbook
+			/decl/backpack_outfit/backpack // Actually Civ Rig.
 		)
 
 		var/old_index

--- a/code/modules/client/preference_setup/loadout/lists/rig.dm
+++ b/code/modules/client/preference_setup/loadout/lists/rig.dm
@@ -31,13 +31,13 @@
 		. += "	-[initial(RM.name)]\n"
 
 */
-
+/* Temp removed. Not sure if we want this entirely gone yet. -- Lion, feb 5th 2021
 /datum/gear/RIG/frame/civilian
 	display_name = "civilian RIG"
 	path = /obj/item/weapon/rig/civilian
 
 	cost = 0
-
+*/
 
 
 /datum/gear/RIG/frame/hacker

--- a/html/changelogs/TheLion1675-LoadoutOverhaul.yml
+++ b/html/changelogs/TheLion1675-LoadoutOverhaul.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: TheLion1675
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Made all departmentally-related jobs now spawn automatically with their RIG on their back. Despite what one has selected, if an override is present for job-specific RIGs, this will now take precedence."
+  - rscadd: "Jobs with specific rigtypes that differ from their subordinate counterpart, will now spawn with the rig as designated."
+  - rscdel: "Removed Civilian RIG from loadout options and instead added it to the new RIG Type."
+  - rscdel: "Removed the ability to spawn with backpacks."
+  - rscdel: "Removed RIGs from lockers."
+  - tweak: "Renamed Backpack Type in loadout to RIG Type."
+  - tweak: "Default RIG is now the CEC Civilian RIG, which will spawn on your back if you do not have a job with an override present."


### PR DESCRIPTION
Changes:
  - rscadd: "Made all departmentally-related jobs now spawn automatically with their RIG on their back. Despite what one has selected, if an override is present for job-specific RIGs, this will now take precedence."
  - rscadd: "Jobs with specific rigtypes that differ from their subordinate counterpart, will now spawn with the rig as designated."
  - rscdel: "Removed Civilian RIG from loadout options and instead added it to the new RIG Type."
  - rscdel: "Removed the ability to spawn with backpacks."
  - rscdel: "Removed RIGs from lockers."
  - tweak: "Renamed Backpack Type in loadout to RIG Type."
  - tweak: "Default RIG is now the CEC Civilian RIG, which will spawn on your back if you do not have a job with an override present."

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
