### PR TITLE
Evidence bag and rig storage fix

### DIFF
--- a/code/datums/observation/exited.dm
+++ b/code/datums/observation/exited.dm
@@ -1,13 +1,13 @@
 //	Observer Pattern Implementation: Exited
 //		Registration type: /atom
 //
-//		Raised when: An /atom/movable instance has exited an atom.
+//		Raised when: An /atom/movable instance has exited the event source.
 //
 //		Arguments that the called proc should expect:
-//			/atom/entered: The atom that was exited from
-//			/atom/movable/enterer: The instance that exited the atom
-//			/atom/new_loc: The atom the exitee is now residing in
-//
+//			/atom/exited: The atom that was exited from (this will be the event source)
+//			/atom/movable/exiter: The instance that exited the atom
+//			/atom/new_loc: The atom the exiter is now residing in
+//	(var/atom/exited, var/atom/movable/exiter, var/atom/new_loc)
 
 GLOBAL_DATUM_INIT(exited_event, /decl/observ/exited, new)
 
@@ -19,6 +19,6 @@ GLOBAL_DATUM_INIT(exited_event, /decl/observ/exited, new)
 * Exited Handling *
 ******************/
 
-/atom/Exited(atom/movable/exitee, atom/new_loc)
+/atom/Exited(atom/movable/exiter, atom/new_loc)
 	. = ..()
-	GLOB.exited_event.raise_event(src, exitee, new_loc)
+	GLOB.exited_event.raise_event(src, exiter, new_loc)

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -40,7 +40,13 @@
 		to_chat(user, "You [open ? "open" : "close"] the access panel.")
 		return
 
-	if((open || hotswap) && can_modify())
+	else if (hotswap && can_modify())
+		if(istype(W,/obj/item/rig_module))
+			attempt_install(W, user, FALSE)
+
+			return 1
+
+	if(open && can_modify())
 
 		// Hacking.
 		if(isWirecutter(W) || isMultitool(W))
@@ -147,7 +153,7 @@
 			else
 				to_chat(user, "You don't see any use for \the [S].")
 
-		return
+			return
 
 	// If we've gotten this far, all we have left to do before we pass off to root procs
 	// is check if any of the loaded modules want to use the item we've been given.

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -53,14 +53,34 @@
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return
 
-	user.visible_message("[user] puts [I] into [src]", "You put [I] inside [src].",\
-	"You hear a rustle as someone puts something into a plastic bag.")
-	if(!user.skill_check(SKILL_COMPUTER, SKILL_BASIC))
-		I.add_fingerprint(user)
+
+	insert_stored_item(I)
+
+
+
+
+/obj/item/weapon/evidencebag/proc/insert_stored_item(var/obj/item/I, var/mob/living/user)
 	I.forceMove(src)
+	if (I.loc != src)
+		return
+
 	stored_item = I
+	GLOB.exited_event.register(src, src, /obj/item/weapon/evidencebag/proc/item_removed)
 	w_class = I.w_class
 	update_icon()
+	if (user)
+		user.visible_message("[user] puts [I] into [src]", "You put [I] inside [src].",\
+		"You hear a rustle as someone puts something into a plastic bag.")
+		if(!user.skill_check(SKILL_COMPUTER, SKILL_BASIC))
+			I.add_fingerprint(user)
+
+
+/obj/item/weapon/evidencebag/proc/item_removed(var/atom/exited, var/atom/movable/exiter, var/atom/new_loc)
+	if (!stored_item || exiter == stored_item)
+		GLOB.exited_event.unregister(src, src, /obj/item/weapon/evidencebag/proc/item_removed)
+		stored_item = null
+		w_class = initial(w_class)
+		update_icon()
 
 /obj/item/weapon/evidencebag/update_icon()
 	overlays.Cut()
@@ -87,9 +107,6 @@
 		"You hear someone rustle around in a plastic bag, and remove something.")
 
 		user.put_in_hands(stored_item)
-		stored_item = null
-		w_class = initial(w_class)
-		update_icon()
 	else
 		to_chat(user, "[src] is empty.")
 		update_icon()

--- a/html/changelogs/storage_evidence.yml
+++ b/html/changelogs/storage_evidence.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed evidence bag not updating when things are removed from it, falsely giving the impression of duplication"
+  - bugfix: "Fixed being unable to insert things into rig storage by using them on it"


### PR DESCRIPTION
changes: 
  - bugfix: "Fixed evidence bag not updating when things are removed from it, falsely giving the impression of duplication"
  - bugfix: "Fixed being unable to insert things into rig storage by using them on it"