### PR TITLE
Resolves a bug with earthgov fax

### DIFF
--- a/code/game/gamemodes/marker/earthgov_agent.dm
+++ b/code/game/gamemodes/marker/earthgov_agent.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_EMPTY(agents_list)
 	var/suspect_details = null //What this evidence shows.
 	var/suspect_type = null
 
-/datum/extension/earthgov_evidence/proc/copy_to(datum/extension/target)
+/datum/extension/earthgov_evidence/proc/copy_to(datum/extension/earthgov_evidence/target)
 	target.suspect_details = suspect_details
 	target.suspect_type = suspect_type
 

--- a/code/game/gamemodes/marker/earthgov_agent.dm
+++ b/code/game/gamemodes/marker/earthgov_agent.dm
@@ -46,6 +46,10 @@ GLOBAL_LIST_EMPTY(agents_list)
 	var/suspect_details = null //What this evidence shows.
 	var/suspect_type = null
 
+/datum/extension/earthgov_evidence/proc/copy_to(datum/extension/target)
+	target.suspect_details = suspect_details
+	target.suspect_type = suspect_type
+
 /datum/extension/earthgov_evidence/New(datum/holder, atom/movable/suspicious_object)
 	. = ..()
 	if(!istype(suspicious_object))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -286,7 +286,7 @@ var/global/photo_count = 0
 	p.desc = mobs
 	p.photo_size = size
 	p.update_icon()
-	if(earthgov_evidence))
+	if(earthgov_evidence)
 		set_extension(p, /datum/extension/earthgov_evidence, earthgov_evidence) //Mark us as valid earthgov evidence, and record details about what they saw.
 
 	return p

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -286,7 +286,7 @@ var/global/photo_count = 0
 	p.desc = mobs
 	p.photo_size = size
 	p.update_icon()
-	if(earthgov_evidence)
+	if(earthgov_evidence))
 		set_extension(p, /datum/extension/earthgov_evidence, earthgov_evidence) //Mark us as valid earthgov evidence, and record details about what they saw.
 
 	return p
@@ -308,6 +308,12 @@ var/global/photo_count = 0
 	p.pixel_y = pixel_y
 	p.photo_size = photo_size
 	p.scribble = scribble
+	//Ensure that the earthgov evidence is transferred over
+	var/datum/extension/earthgov_evidence/egov = get_extension(src, /datum/extension/earthgov_evidence)
+	if(egov)
+		set_extension(p, /datum/extension/earthgov_evidence)
+		var/datum/extension/earthgov_evidence/othergov = get_extension(p, /datum/extension/earthgov_evidence)
+		egov.copy_to(othergov)
 
 	if(copy_id)
 		p.id = id


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

* Photocopying earthgov evidence now carries over the evidence rather than ignoring it
