### PR TITLE
fix lethal turrend are initialized multiple times.

### DIFF
--- a/code/game/machinery/turret/control_panel.dm
+++ b/code/game/machinery/turret/control_panel.dm
@@ -124,7 +124,6 @@
 	. = ..()
 
 /obj/machinery/turretid/Initialize()
-	. = ..()
 	if(!control_area)
 		control_area = get_area(src)
 	else if(istext(control_area))
@@ -147,7 +146,7 @@
 	//Fill out the targeting profiles list
 	var/templist = targeting_profiles.Copy()
 	targeting_profiles = list()
-	for (var/tptype in templist)
+	for(var/tptype in templist)
 		var/datum/targeting_profile/TP = tptype
 		TP = GLOB.targeting_profiles[initial(TP.id)]
 		targeting_profiles[TP.id] = TP


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
fix this:
![image](https://user-images.githubusercontent.com/49106866/107566417-2a856480-6be5-11eb-924b-e38efc2a6fd9.png)

partially reverts this: #1238

It seems that the problem with turrent lethal is more complex than I had thought and requires further study.