### PR TITLE
Round end crew check tweak

### DIFF
--- a/code/_helpers/crew.dm
+++ b/code/_helpers/crew.dm
@@ -2,16 +2,9 @@
 /proc/get_historic_crew_total()
 	return GLOB.all_crew.len
 
-//Returns the number of alive humans aboard Ishimura
+//Returns the number of live crewmembers
 /proc/get_living_crew_total()
-	var/crew_count = 0
-	for(var/datum/mind/M in GLOB.living_crew)
-		if(!M || QDELETED(M.current) || !ishuman(M.current))	//regular sanity checks
-			continue
-		var/mob/living/L = M.current
-		if(!L.client || L.stat == DEAD || !isStationLevel(L.z))	//only count alive active humans onboard Ishimura, the rest are marooned
-			continue
-		crew_count++
+	return GLOB.living_crew.len
 
 	return crew_count
 

--- a/code/_helpers/crew.dm
+++ b/code/_helpers/crew.dm
@@ -2,10 +2,18 @@
 /proc/get_historic_crew_total()
 	return GLOB.all_crew.len
 
-//Returns the number of live crewmembers
+//Returns the number of alive humans aboard Ishimura
 /proc/get_living_crew_total()
-	return GLOB.living_crew.len
+	var/crew_count = 0
+	for(var/datum/mind/M in GLOB.living_crew)
+		if(!M || QDELETED(M.current) || !ishuman(M.current))	//regular sanity checks
+			continue
+		var/mob/living/L = M.current
+		if(!L.client || L.stat == DEAD || !isStationLevel(L.z))	//only count alive active humans onboard Ishimura, the rest are marooned
+			continue
+		crew_count++
 
+	return crew_count
 
 /*
 	Returns a list of all living crewmembers whose role fits the filter

--- a/code/_helpers/crew.dm
+++ b/code/_helpers/crew.dm
@@ -6,8 +6,6 @@
 /proc/get_living_crew_total()
 	return GLOB.living_crew.len
 
-	return crew_count
-
 /*
 	Returns a list of all living crewmembers whose role fits the filter
 	If role type is true, checks special role (AKA, antag status)

--- a/code/game/gamemodes/gamemode.dm
+++ b/code/game/gamemodes/gamemode.dm
@@ -654,3 +654,15 @@ proc/get_nt_opposed()
 			if (L.stat != DEAD) //They're alive!
 				GLOB.living_crew |= M
 
+//proc returns the amount of alive active humans onboard Ishimura (space turfs are excluded), the rest are considered marooned
+/datum/game_mode/proc/get_alive_crewmates_count()
+	var/crew_count = 0
+	for(var/datum/mind/M in GLOB.living_crew)
+		var/mob/living/L = M.current
+		if(!L.client || L.client.is_afk(2 MINUTES))	//activity check
+			continue
+		if(!isStationLevel(L.z) || istype(get_turf(L), /turf/space))	//location check
+			continue
+		crew_count++
+
+	return crew_count

--- a/code/game/gamemodes/gamemode.dm
+++ b/code/game/gamemodes/gamemode.dm
@@ -655,7 +655,7 @@ proc/get_nt_opposed()
 				GLOB.living_crew |= M
 
 //proc returns the amount of alive active humans onboard Ishimura (space turfs are excluded), the rest are considered marooned
-/datum/game_mode/proc/get_alive_crewmates_count()
+/datum/game_mode/proc/get_living_active_crew_aboard_ship()
 	var/crew_count = 0
 	for(var/datum/mind/M in GLOB.living_crew)
 		var/mob/living/L = M.current

--- a/code/game/gamemodes/marker/gamemodes.dm
+++ b/code/game/gamemodes/marker/gamemodes.dm
@@ -143,7 +143,7 @@ Non-critical characters like any ghost-roles you may wish to add, or even antags
 	if(marker_active)	//Marker must be active
 		if (get_historic_crew_total() >= minimum_historic_crew)	//We need to have had a minimum total crewcount
 			var/minimum_living_crew = Ceiling(get_historic_crew_total() * minimum_alive_percentage)	//This many crew players at least, need to be left alive
-			if (get_living_crew_total() < minimum_living_crew)
+			if (get_alive_crewmates_count() < minimum_living_crew)
 				return TRUE
 
 	return ..() //Fallback to the default game end conditions like all antags dying, shuttles being docked, etc.

--- a/code/game/gamemodes/marker/gamemodes.dm
+++ b/code/game/gamemodes/marker/gamemodes.dm
@@ -143,7 +143,7 @@ Non-critical characters like any ghost-roles you may wish to add, or even antags
 	if(marker_active)	//Marker must be active
 		if (get_historic_crew_total() >= minimum_historic_crew)	//We need to have had a minimum total crewcount
 			var/minimum_living_crew = Ceiling(get_historic_crew_total() * minimum_alive_percentage)	//This many crew players at least, need to be left alive
-			if (get_alive_crewmates_count() < minimum_living_crew)
+			if (get_living_active_crew_aboard_ship() < minimum_living_crew)
 				return TRUE
 
 	return ..() //Fallback to the default game end conditions like all antags dying, shuttles being docked, etc.

--- a/html/changelogs/round-end-crew-check-tweak.yml
+++ b/html/changelogs/round-end-crew-check-tweak.yml
@@ -3,4 +3,4 @@ author: Jeser
 delete-after: True
 
 changes: 
-  - tweak: "Round end check for alive crewmates changed: only alive active humans on Ishimura count now."
+  - tweak: "Round end check for alive crewmates changed: only alive active humans onboard Ishimura count now."

--- a/html/changelogs/round-end-crew-check-tweak.yml
+++ b/html/changelogs/round-end-crew-check-tweak.yml
@@ -1,0 +1,6 @@
+author: Jeser
+
+delete-after: True
+
+changes: 
+  - tweak: "Round end check for alive crewmates changed: only alive active humans on Ishimura count now."


### PR DESCRIPTION
tweak: "Round end check for alive crewmates changed: only alive active humans on Ishimura count now."

Closes: https://github.com/DS-13-Dev-Team/DS13/issues/1114