### PR TITLE
Compile fix and Adjective Ordering

### DIFF
--- a/code/__defines/text.dm
+++ b/code/__defines/text.dm
@@ -2,3 +2,16 @@
 
 #define URL_HTTP_WWW	"hypertext"
 
+
+/*
+	Adjective Types
+	The rule is that multiple adjectives are always ranked accordingly: opinion, size, age, shape, colour, origin, material, purpose.
+*/
+#define	ADJECTIVE_TYPE_OPINION	1
+#define	ADJECTIVE_TYPE_SIZE	2
+#define	ADJECTIVE_TYPE_AGE	3
+#define	ADJECTIVE_TYPE_SHAPE	4
+#define	ADJECTIVE_TYPE_COLOR	5
+#define	ADJECTIVE_TYPE_ORIGIN	6
+#define	ADJECTIVE_TYPE_MATERIAL	7
+#define	ADJECTIVE_TYPE_PURPOSE	8

--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -101,7 +101,7 @@
 /decl/hierarchy/supply_pack/security/weapons
 	name = "Weapons - Security basic"
 	contains = list(/obj/item/weapon/reagent_containers/spray/pepper = 4,
-					/obj/item/weapon/melee/baton/loaded = 4,
+					/obj/item/weapon/melee/baton/loaded = 4)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "\improper Weapons crate"

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -51,7 +51,7 @@
 	var/workspeed = 1	//Worktimes are divided by this
 	var/extra_bulk = 0 	//Extra physicial volume added by certain mods
 	var/silenced = FALSE //If true the tool makes far less noise when used
-	var/list/prefixes = list()
+	var/list/adjectives = list()
 
 	//Mods that come already applied on a tool
 	var/list/preinstalled_mods = list()
@@ -782,14 +782,17 @@
 	max_modifications = base_max_modifications
 	color = initial(color)
 	sharp = initial(sharp)
-	prefixes = list()
+	adjectives = list()
 
 	//Now lets have each modification reapply its modifications
 	for (var/obj/item/weapon/tool_modification/T in modifications)
 		T.apply_values()
 
-	for (var/prefix in prefixes)
-		name = "[prefix] [name]"
+	//This sorts the adjectives into the correct order based on their type
+	sortTim(adjectives, cmp=/proc/cmp_numeric_dsc, associative = TRUE)
+
+	for (var/adjective in adjectives)
+		name = "[adjective] [name]"
 
 	//Set the fuel volume, incase any mods altered our max fuel
 	if (reagents)

--- a/code/game/objects/items/weapons/tools/mods/_modifications.dm
+++ b/code/game/objects/items/weapons/tools/mods/_modifications.dm
@@ -17,7 +17,8 @@
 	w_class = ITEM_SIZE_SMALL
 	//price_tag = 200
 
-	var/prefix = "upgraded" //Added to the tool's name
+	var/adjective = "upgraded" //Added to the tool's name
+	var/adjective_type = ADJECTIVE_TYPE_OPINION	//Defines in _defines/text.dm, determines the order that adjectives appear
 
 	//The modification can be applied to a tool that has any of these qualities
 	var/list/required_qualities = list()
@@ -182,5 +183,5 @@
 	holder.use_fuel_cost *= fuelcost_mult
 	holder.use_power_cost *= powercost_mult
 	holder.extra_bulk += bulk_mod
-	holder.prefixes |= prefix
+	holder.adjectives[adjective] = adjective_type
 	return TRUE

--- a/code/game/objects/items/weapons/tools/mods/mod_types.dm
+++ b/code/game/objects/items/weapons/tools/mods/mod_types.dm
@@ -11,7 +11,7 @@
 	desc = "A sturdy pole made of fiber tape and metal rods. Can be used to reinforce the shaft of many tools"
 	icon_state = "brace_bar"
 	required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_PRYING, QUALITY_SAWING,QUALITY_SHOVELING,QUALITY_DIGGING,QUALITY_EXCAVATION)
-	prefix = "braced"
+	adjective = "braced"
 	degradation_mult = 0.65
 	force_mod = 1
 	//price_tag = 120
@@ -22,7 +22,8 @@
 	name = "heatsink"
 	desc = "An array of aluminium fins which dissipates heat, reducing damage and extending the lifespan of power tools."
 	icon_state = "heatsink"
-	prefix = "heatsunk"
+	adjective = "heatsunk"
+	adjective_type = ADJECTIVE_TYPE_PURPOSE
 	degradation_mult = 0.65
 
 
@@ -37,21 +38,22 @@
 	name = "reinforced plating"
 	desc = "A sturdy bit of metal that can be bolted onto any tool to protect it. Tough, but bulky"
 	icon_state = "plate"
-	prefix = "reinforced"
+	adjective = "reinforced"
 	degradation_mult = 0.55
 	force_mod = 1
 	precision = -5
 	bulk_mod = 1
-
+	adjective_type = ADJECTIVE_TYPE_MATERIAL
 
 /obj/item/weapon/tool_modification/reinforcement/guard
 	name = "metal guard"
 	desc = "A bent piece of metal that wraps around sensitive parts of a tool, protecting it from impacts, debris, and stray fingers."
 	icon_state = "guard"
 	required_qualities = list(QUALITY_CUTTING,QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION, QUALITY_WELDING)
-	prefix = "shielded"
+	adjective = "shielded"
 	degradation_mult = 0.75
 	precision = 5
+	adjective_type = ADJECTIVE_TYPE_SHAPE
 
 
 
@@ -63,8 +65,9 @@
 	name = "ergonomic grip"
 	desc = "A replacement grip for a tool which allows it to be more precisely controlled with one hand"
 	icon_state = "ergonomic"
-	prefix = "ergonomic"
+	adjective = "ergonomic"
 	workspeed = 0.15
+	adjective_type = ADJECTIVE_TYPE_OPINION
 
 
 /obj/item/weapon/tool_modification/productivity/ratchet
@@ -72,17 +75,19 @@
 	desc = "A mechanical modification for wrenches and screwdrivers which allows the tool to only turn in one direction"
 	icon_state = "ratchet"
 	required_qualities = list(QUALITY_BOLT_TURNING,QUALITY_SCREW_DRIVING)
-	prefix = "ratcheting"
+	adjective = "ratcheting"
 	workspeed = 0.25
+	adjective_type = ADJECTIVE_TYPE_PURPOSE
 
 /obj/item/weapon/tool_modification/productivity/red_paint
 	name = "red paint"
 	desc = "Do red tools really work faster, or is the effect purely psychological"
 	icon_state = "paint_red"
-	prefix = "red"
+	adjective = "red"
 	workspeed = 0.20
 	precision = -10
 	recoverable = FALSE //What are you gonna do, scrape it off and glue the paint flakes onto something else?
+	adjective_type = ADJECTIVE_TYPE_COLOR
 
 /obj/item/weapon/tool_modification/productivity/red_paint/apply_values()
 	if (..())
@@ -93,7 +98,7 @@
 	desc = "A rough single-use block to sharpen a blade. The honed edge cuts smoothly"
 	icon_state = "whetstone"
 	required_qualities = list(QUALITY_CUTTING,QUALITY_SAWING, QUALITY_WIRE_CUTTING)
-	prefix = "sharpened"
+	adjective = "sharpened"
 	workspeed = 0.15
 	precision = 5
 	force_mult = 1.15
@@ -106,12 +111,13 @@
 	desc = "An adaptable industrial grade cutting disc, with diamond dust worked into the metal. Exceptionally durable"
 	icon_state = "diamond_blade"
 	required_qualities = list(QUALITY_CUTTING,QUALITY_SAWING, QUALITY_WIRE_CUTTING, QUALITY_PRYING)
-	prefix = "diamond-edged"
+	adjective = "dikoted"
 	//price_tag = 300
 	workspeed = 0.25
 	degradation_mult = 0.85
 	force_mult = 1.10
 	matter = list(MATERIAL_STEEL = 1, MATERIAL_DIAMOND = 1)
+	adjective_type = ADJECTIVE_TYPE_MATERIAL
 
 /obj/item/weapon/tool_modification/productivity/diamond_blade/can_apply(var/obj/item/weapon/tool/T, var/mob/user)
 	.=..()
@@ -127,10 +133,11 @@
 	desc = "A canister of pure, compressed oxygen with adapters for mounting onto a welding tool. Used alongside fuel, it allows for higher burn temperatures"
 	icon_state = "oxyjet"
 	required_qualities = list(QUALITY_WELDING)
-	prefix = "oxyjet"
+	adjective = "oxyjet"
 	workspeed = 0.20
 	force_mult = 1.15
 	degradation_mult = 1.15
+	adjective_type = ADJECTIVE_TYPE_PURPOSE
 
 
 //Enhances power tools majorly, but also increases costs
@@ -139,7 +146,7 @@
 	desc = "A motor for power tools with a higher horsepower than usually expected. Significantly enhances productivity and lifespan, but more expensive to run and harder to control"
 	icon_state = "motor"
 	required_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_DRILLING, QUALITY_SAWING, QUALITY_DIGGING, QUALITY_EXCAVATION)
-	prefix = "high-power"
+	adjective = "high-power"
 	workspeed = 0.50
 	force_mult = 1.15
 
@@ -166,9 +173,10 @@
 	name = "Asters \"Guiding Light\" laser guide"
 	desc = "A small visible laser which can be strapped onto any tool, giving an accurate representation of its target. Helps improve precision"
 	icon_state = "laser_guide"
-	prefix = "laser-guided"
+	adjective = "laser-guided"
 	precision = 10
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_URANIUM = 1)
+	adjective_type = ADJECTIVE_TYPE_PURPOSE
 
 
 //Fits onto generally small tools that require precision, especially surgical tools
@@ -179,7 +187,8 @@
 	icon_state = "stabilizing"
 	required_qualities = list(QUALITY_CUTTING,QUALITY_WIRE_CUTTING, QUALITY_SCREW_DRIVING, QUALITY_WELDING,
 	QUALITY_PULSING, QUALITY_CLAMPING, QUALITY_CAUTERIZING, QUALITY_BONE_SETTING, QUALITY_LASER_CUTTING)
-	prefix = "stabilized"
+	adjective = "stabilized"
+	adjective_type = ADJECTIVE_TYPE_PURPOSE
 	precision = 10
 
 /obj/item/weapon/tool_modification/refinement/magbit
@@ -187,8 +196,9 @@
 	desc = "Magnetises tools used for handling small objects, reducing instances of dropping screws and bolts."
 	icon_state = "magnetic"
 	required_qualities = list(QUALITY_SCREW_DRIVING, QUALITY_BOLT_TURNING, QUALITY_CLAMPING, QUALITY_BONE_SETTING)
-	prefix = "magnetic"
+	adjective = "magnetic"
 	precision = 10
+	adjective_type = ADJECTIVE_TYPE_PURPOSE
 
 
 /obj/item/weapon/tool_modification/refinement/ported_barrel
@@ -196,10 +206,11 @@
 	desc = "A barrel extension for a welding tool which helps manage gas pressure and keep the torch steady."
 	icon_state = "ported_barrel"
 	required_qualities = list(QUALITY_WELDING)
-	prefix = "ported"
+	adjective = "ported"
 	precision = 12
 	degradation_mult = 1.15
 	bulk_mod = 1
+	adjective_type = ADJECTIVE_TYPE_SHAPE
 
 
 
@@ -220,9 +231,10 @@
 	icon_state = "cell_mount"
 	desc = "A bulky adapter which allows oversized power cells to be installed into small tools"
 	req_cell = TRUE
-	prefix = "medium-cell"
+	adjective = "medium-cell"
 	bulk_mod = 1
 	degradation_mult = 1.15
+	adjective_type = ADJECTIVE_TYPE_SIZE
 
 /obj/item/weapon/tool_modification/augment/cell_mount/can_apply(var/obj/item/weapon/tool/T, var/mob/user)
 	.=..()
@@ -240,10 +252,10 @@
 		return
 	if (holder.suitable_cell == /obj/item/weapon/cell)
 		holder.suitable_cell = /obj/item/weapon/cell
-		prefix = "large-cell"
+		adjective = "large-cell"
 	else if (holder.suitable_cell == /obj/item/weapon/cell)
 		holder.suitable_cell = /obj/item/weapon/cell
-		prefix = "medium-cell"
+		adjective = "medium-cell"
 	..()
 */
 
@@ -255,8 +267,9 @@
 	desc = "An auxiliary tank which stores 30 extra units of fuel"
 	icon_state = "canister"
 	req_fuel = TRUE
-	prefix = "expanded"
+	adjective = "expanded"
 	bulk_mod = 1
+	adjective_type = ADJECTIVE_TYPE_SIZE
 
 /obj/item/weapon/tool_modification/augment/fuel_tank/apply_values()
 	if (..())
@@ -268,10 +281,11 @@
 	name = "expansion port"
 	icon_state = "expand"
 	desc = "A bulky adapter which more modifications to be attached to the tool.  A bit fragile but you can compensate"
-	prefix = "custom"
+	adjective = "custom"
 	bulk_mod = 2
 	degradation_mult = 1.3
 	precision = -10
+	adjective_type = ADJECTIVE_TYPE_ORIGIN
 
 /obj/item/weapon/tool_modification/augment/expansion/apply_values()
 	if (..())
@@ -282,11 +296,12 @@
 	name = "spikes"
 	icon_state = "spike"
 	desc = "An array of sharp bits of metal, seemingly adapted for easy affixing to a tool. Would make it into a better weapon, but won't do much for productivity."
-	prefix = "spiked"
+	adjective = "spiked"
 	force_mod = 4
 	precision = -5
 	degradation_mult = 1.15
 	workspeed = -0.15
+	adjective_type = ADJECTIVE_TYPE_SHAPE
 	//price_tag = 100
 
 /obj/item/weapon/tool_modification/augment/spikes/apply_values()
@@ -298,7 +313,8 @@
 	name = "aural dampener"
 	desc = "This aural dampener is a cutting edge tool attachment which mostly nullifies sound waves within a tiny radius. It minimises the noise created during use, perfect for stealth operations"
 	icon_state = "dampener"
-	prefix = "silenced"
+	adjective = "silenced"
+	adjective_type = ADJECTIVE_TYPE_PURPOSE
 
 
 /obj/item/weapon/tool_modification/augment/dampener/apply_values()

--- a/code/modules/modular_computers/hardware/storage/autolathe_disks.dm
+++ b/code/modules/modular_computers/hardware/storage/autolathe_disks.dm
@@ -230,7 +230,6 @@
 		/datum/design/autolathe/gun/combat_shotgun,
 		/datum/design/autolathe/gun/heavysniper,
 		/datum/design/autolathe/gun/grenade_launcher,
-		/datum/design/autolathe/gun/taser,
 		/datum/design/autolathe/gun/sniperrifle
 	)
 

--- a/html/changelogs/tool_adjective.yml
+++ b/html/changelogs/tool_adjective.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Unknown
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The adjectives on modded tools are now organised. The rule is that multiple adjectives are always ranked accordingly: opinion, size, age, shape, colour, origin, material, purpose."


### PR DESCRIPTION
changes: 
  - rscadd: "The adjectives on modded tools are now organised. The rule is that multiple adjectives are always ranked accordingly: opinion, size, age, shape, colour, origin, material, purpose."

also fixes a compile error added in a recent taser PR