### PR TITLE
OCD Description Fixes, Absorbable Mice

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -1,5 +1,5 @@
 /obj/machinery/optable
-	name = "Operating Table"
+	name = "operating table"
 	desc = "Used for advanced medical procedures."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "table2-idle"

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -1,6 +1,6 @@
 /obj/machinery/portable_atmospherics/powered/pump
 	name = "portable air pump"
-
+	desc = "A machine that either fills or sucks air from the surrounding environment."
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "psiphon:0"
 	density = 1

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -1,6 +1,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber
-	name = "Portable Air Scrubber"
-
+	name = "portable air scrubber"
+	desc = "A machine that filters out gases from the surrounding environment."
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "pscrubber:0"
 	density = 1

--- a/code/game/machinery/ds13/bpl/growth_tank.dm
+++ b/code/game/machinery/ds13/bpl/growth_tank.dm
@@ -7,6 +7,7 @@
 */
 /obj/machinery/growth_tank
 	name = "growth tank"
+	desc = "A vat for growing organic components."
 	icon = 'icons/obj/machines/ds13/bpl.dmi'
 	icon_state = "base"
 

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -1,7 +1,8 @@
 //these are probably broken
 
 /obj/machinery/floodlight
-	name = "Emergency Floodlight"
+	name = "emergency floodlight"
+	desc = "A battery-powered lighting machine. Useful for blackouts."
 	icon = 'icons/obj/machines/floodlight.dmi'
 	icon_state = "flood00"
 	density = 1

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -4,7 +4,7 @@
 
 
 /obj/machinery/suit_storage_unit
-	name = "Suit Storage Unit"
+	name = "suit storage unit"
 	desc = "An industrial U-Stor-It Storage unit designed to accomodate all kinds of space suits. Its on-board equipment also allows the user to decontaminate the contents through a UV-ray purging cycle. There's a warning label dangling from the control pad, reading \"STRICTLY NO BIOLOGICALS IN THE CONFINES OF THE UNIT\"."
 	icon = 'icons/obj/suitstorage.dmi'
 	icon_state = "close"

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -41,7 +41,7 @@
 
 /obj/item/weapon/storage/pouch/small_generic
 	name = "small generic pouch"
-	desc = "A small pouch which expands a pocket slot, allowing it to hold a couple of little things"
+	desc = "A small pouch which expands a pocket slot, allowing it to hold a couple of little things."
 	icon_state = "small_generic"
 	item_state = "small_generic"
 	storage_slots = null //Uses generic capacity
@@ -50,7 +50,7 @@
 
 /obj/item/weapon/storage/pouch/medium_generic
 	name = "medium generic pouch"
-	desc = "A small pouch which expands a pocket slot, allowing it to hold several little things"
+	desc = "A small pouch which expands a pocket slot, allowing it to hold several little things."
 	icon_state = "medium_generic"
 	item_state = "medium_generic"
 	storage_slots = null //Uses generic capacity
@@ -58,7 +58,7 @@
 
 /obj/item/weapon/storage/pouch/large_generic
 	name = "large generic pouch"
-	desc = "A mini satchel. Can hold a fair bit, worn around the waist"
+	desc = "A mini satchel. Can hold a fair bit, worn around the waist."
 	icon_state = "large_generic"
 	item_state = "large_generic"
 	w_class = ITEM_SIZE_NORMAL
@@ -161,7 +161,7 @@
 //Basically for holding forcegun and contact beam ammo
 /obj/item/weapon/storage/pouch/cell
 	name = "energy cell pouch"
-	desc = "Can hold two bulky power cells, whether for devices or the bulky ammunition cells for heavy weapons"
+	desc = "Can hold two bulky power cells, whether for devices or the bulky ammunition cells for heavy weapons."
 	icon_state = "energy"
 	item_state = "energy"
 

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -172,6 +172,7 @@
 
 /obj/item/weapon/storage/secure/safe
 	name = "secure safe"
+	desc = "A wall-mounted safe with a digital locking system."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "safe"
 	icon_opened = "safe0"

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -26,7 +26,7 @@
  */
 /obj/item/weapon/hemostat
 	name = "hemostat"
-	desc = "You think you have seen this before."
+	desc = "A surgical clamp to stop bleeding."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "hemostat"
 	matter = list(MATERIAL_STEEL = 5000, MATERIAL_GLASS = 2500)
@@ -40,7 +40,7 @@
  */
 /obj/item/weapon/cautery
 	name = "cautery"
-	desc = "This stops bleeding."
+	desc = "This cauterises and closes incisions."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "cautery"
 	matter = list(MATERIAL_STEEL = 5000, MATERIAL_GLASS = 2500)
@@ -80,7 +80,7 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	throwforce = 5.0
-	
+
 	throw_range = 5
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
 	matter = list(MATERIAL_STEEL = 10000, MATERIAL_GLASS = 5000)
@@ -137,11 +137,11 @@
 
 /obj/item/weapon/bonesetter
 	name = "bone setter"
+	desc = "Sets bones back to their healthy positions."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "bone setter"
 	force = 8.0
 	throwforce = 9.0
-	
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("attacked", "hit", "bludgeoned")

--- a/code/game/objects/items/weapons/tools/bonesetters.dm
+++ b/code/game/objects/items/weapons/tools/bonesetters.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/tool/bonesetter
 	name = "bone setter"
+	desc = "Sets bones back to their healthy positions."
 	icon_state = "bone setter"
-	
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
 	attack_verb = list("attacked", "hit", "bludgeoned")

--- a/code/game/objects/items/weapons/tools/cauterys.dm
+++ b/code/game/objects/items/weapons/tools/cauterys.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/tool/cautery
 	name = "cautery"
-	desc = "This stops bleeding."
+	desc = "This cauterises and closes incisions."
 	icon_state = "cautery"
 	matter = list(MATERIAL_STEEL = 500, MATERIAL_GLASS = 200)
 	obj_flags = OBJ_FLAG_CONDUCTIBLE

--- a/code/game/objects/items/weapons/tools/crowbars.dm
+++ b/code/game/objects/items/weapons/tools/crowbars.dm
@@ -31,7 +31,7 @@
 
 /obj/item/weapon/tool/crowbar/improvised
 	name = "rebar"
-	desc = "A pair of metal rods laboriously twisted into a useful shape"
+	desc = "A pair of metal rods laboriously twisted into a useful shape."
 	icon_state = "impro_crowbar"
 	item_state = "crowbar"
 	tool_qualities = list(QUALITY_PRYING = 10, QUALITY_DIGGING = 10)

--- a/code/game/objects/items/weapons/tools/hemostats.dm
+++ b/code/game/objects/items/weapons/tools/hemostats.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/tool/hemostat
 	name = "hemostat"
-	desc = "You think you have seen this before."
+	desc = "A surgical clamp to stop bleeding."
 	icon_state = "hemostat"
 	matter = list(MATERIAL_STEEL = 200)
 	obj_flags = OBJ_FLAG_CONDUCTIBLE

--- a/code/game/objects/items/weapons/tools/misc.dm
+++ b/code/game/objects/items/weapons/tools/misc.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/tool/omnitool
 	name = "Asters \"Munchkin 5000\""
-	desc = "Fuel powered monster of a tool. Its weldier part is most advanced one, capable of welding things without harmfull glow and sparks, so no protection needed."
+	desc = "Fuel-powered monster of a tool. The advanced welding bit is spark and glow free, thus completely safe."
 	icon_state = "omnitool"
 	w_class = ITEM_SIZE_NORMAL
 	worksound = WORKSOUND_DRIVER_TOOL

--- a/code/game/objects/items/weapons/tools/oldificator.dm
+++ b/code/game/objects/items/weapons/tools/oldificator.dm
@@ -69,7 +69,7 @@
 /obj/item/weapon/storage/pill_bottle/make_old()
 	if (prob(85))
 		name = "bottle of [pick("generic ", "unknown ", "")]pills"
-		desc = "Contains pills of some kind. The label has long since worn away"
+		desc = "Contains pills of some kind. The label has long since worn away."
 		for (var/obj/item/weapon/reagent_containers/pill/P in contents)
 			P.make_old()
 
@@ -78,7 +78,7 @@
 //Make sure old pills always hide their contents too
 /obj/item/weapon/reagent_containers/pill/make_old()
 	name = "pill"
-	desc = "some kind of pill. The imprints have worn away"
+	desc = "some kind of pill. The imprints have worn away."
 	.=..()
 
 /obj/structure/reagent_dispensers/make_old()
@@ -174,7 +174,7 @@
 
 /obj/item/weapon/aiModule/broken
 	name = "\improper broken core AI module"
-	desc = "broken Core AI Module: 'Reconfigures the AI's core laws.'"
+	desc = "broken Core AI Module: 'Reconfigures the AI's core laws."
 
 /obj/machinery/broken/Initialize()
 	..()

--- a/code/game/objects/items/weapons/tools/saws.dm
+++ b/code/game/objects/items/weapons/tools/saws.dm
@@ -20,7 +20,7 @@
 
 /obj/item/weapon/tool/saw/improvised
 	name = "choppa"
-	desc = "A wicked serrated blade made of whatever nasty sharp things you could find. It would make a pretty decent weapon"
+	desc = "A wicked serrated blade made of whatever nasty sharp things you could find. It would make a pretty decent weapon."
 	icon_state = "impro_saw"
 	force = WEAPON_FORCE_PAINFUL
 	tool_qualities = list(QUALITY_SAWING = 15, QUALITY_CUTTING = 10, QUALITY_WIRE_CUTTING = 10)

--- a/code/game/objects/items/weapons/tools/tape.dm
+++ b/code/game/objects/items/weapons/tools/tape.dm
@@ -42,7 +42,7 @@
 				user << SPAN_WARNING("\The [H] doesn't have any eyes.")
 				return
 			if(H.glasses)
-				user << SPAN_WARNING("\The [H] is already wearing somethign on their eyes.")
+				user << SPAN_WARNING("\The [H] is already wearing something on their eyes.")
 				return
 			if(H.head && (H.head.body_parts_covered & FACE))
 				user << SPAN_WARNING("Remove their [H.head] first.")

--- a/code/game/objects/items/weapons/tools/weldingtools.dm
+++ b/code/game/objects/items/weapons/tools/weldingtools.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/tool/weldingtool
 	name = "welding tool"
+	desc = "An industrial torch for cutting and welding."
 	icon_state = "welder"
 	item_state = "welder"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
@@ -28,7 +29,7 @@
 
 /obj/item/weapon/tool/weldingtool/improvised
 	name = "jury-rigged torch"
-	desc = "An assembly of pipes attached to a little gas tank. Serves capably as a welder, though a bit risky"
+	desc = "An assembly of pipes attached to a little gas tank. Serves capably as a welder, though a bit risky."
 	icon_state = "legacywelder"
 	item_state = "legacywelder"
 	switched_on_force = WEAPON_FORCE_PAINFUL * 0.8
@@ -69,6 +70,7 @@
 
 /obj/item/weapon/tool/weldingtool/advanced
 	name = "advanced welding tool"
+	desc = "An industrial torch for cutting and welding. This newer model has a better tank."
 	icon_state = "adv_welder"
 	item_state = "adv_welder"
 	glow_color = COLOR_BLUE_LIGHT

--- a/code/game/objects/items/weapons/tools/wirecutters.dm
+++ b/code/game/objects/items/weapons/tools/wirecutters.dm
@@ -26,7 +26,7 @@
 
 /obj/item/weapon/tool/wirecutters/armature
 	name = "armature cutter"
-	desc = "Bigger brother of wirecutter. Can't do much in terms of emergency surgery, but dose its main job better."
+	desc = "Bigger brother of the wirecutter. Can't do much in terms of emergency surgery, but does its main job better."
 	icon_state = "arm-cutter"
 	force = WEAPON_FORCE_NORMAL
 	matter = list(MATERIAL_STEEL = 1200, MATERIAL_PLASTIC = 600)

--- a/code/game/objects/items/weapons/tools/workbench.dm
+++ b/code/game/objects/items/weapons/tools/workbench.dm
@@ -1,6 +1,7 @@
 //A workbench for upgrading things
 /obj/structure/table/workbench
 	name = "Nanocircuit Repair Bench"
+	desc = "For repairing and upgrading devices and tools."
 	tool_qualities = list(QUALITY_WORKBENCH = 1)
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "deadspace_workbench"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -103,7 +103,7 @@
 
 /obj/item/clothing/gloves/latex/nitrile
 	name = "nitrile gloves"
-	desc = "Sterile nitrile gloves"
+	desc = "Sterile nitrile gloves."
 	icon_state = "nitrile"
 	item_state = "ngloves"
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -30,6 +30,7 @@
 	possession_candidate = 1
 	can_escape = 1
 	speed = 5
+	biomass = 0.2
 
 	can_pull_size = ITEM_SIZE_TINY
 	can_pull_mobs = MOB_PULL_NONE

--- a/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_tablet.dm
@@ -1,6 +1,6 @@
 /obj/item/modular_computer/tablet
 	name = "tablet computer"
-	desc = "A small portable microcomputer"
+	desc = "A small portable microcomputer."
 	icon = 'icons/obj/modular_tablet.dmi'
 	icon_state = "tablet"
 	icon_state_unpowered = "tablet"

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -1,11 +1,12 @@
 /obj/item/weapon/clipboard
 	name = "clipboard"
+	desc = "Useful for holding documents or pretending to look busy."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "clipboard"
 	item_state = "clipboard"
 	throwforce = 0
 	w_class = ITEM_SIZE_SMALL
-	
+
 	throw_range = 10
 	var/obj/item/weapon/pen/haspen		//The stored pen.
 	var/obj/item/weapon/toppaper	//The topmost piece of paper.

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -5,6 +5,7 @@ GLOBAL_LIST_EMPTY(adminfaxes)	//cache for faxes that have been sent to admins
 
 /obj/machinery/photocopier/faxmachine
 	name = "fax machine"
+	desc = "For secure document transmission. Somehow not obsolete yet."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "fax"
 	insert_anim = "faxsend"

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -1,5 +1,6 @@
 /obj/item/weapon/hand_labeler
 	name = "hand labeler"
+	desc = "A multipurpose tagger for labelling various objects."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	item_state = "flight"

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -1,12 +1,13 @@
 /obj/item/weapon/paper_bin
 	name = "paper bin"
+	desc = "For holding paper, unsurprisingly."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper_bin1"
 	item_state = "sheet-metal"
 	randpixel = 0
 	throwforce = 1
 	w_class = ITEM_SIZE_NORMAL
-	
+
 	throw_range = 7
 	layer = BELOW_OBJ_LAYER
 	var/amount = 30					//How much paper is in the bin.

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -1,5 +1,6 @@
 /obj/machinery/photocopier
 	name = "photocopier"
+	desc = "This machine scans and copies papers. Usually."
 	icon = 'icons/obj/library.dmi'
 	icon_state = "bigscanner"
 	var/insert_anim = "bigscanner1"
@@ -230,5 +231,6 @@
 
 /obj/item/device/toner
 	name = "toner cartridge"
+	desc = "A component consumed by printing devices."
 	icon_state = "tonercartridge"
 	var/toner_amount = 30

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -73,7 +73,7 @@
 
 //Dispensers
 /obj/structure/reagent_dispensers/watertank
-	name = "watertank"
+	name = "water tank"
 	desc = "A tank containing water."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "watertank"
@@ -206,7 +206,7 @@
 	new /obj/effect/decal/cleanable/liquid_fuel(src.loc, amount,1)
 
 /obj/structure/reagent_dispensers/peppertank
-	name = "Pepper Spray Refiller"
+	name = "pepper spray refiller"
 	desc = "Refills pepper spray canisters."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "peppertank"
@@ -217,7 +217,7 @@
 
 
 /obj/structure/reagent_dispensers/water_cooler
-	name = "Water-Cooler"
+	name = "water cooler"
 	desc = "A machine that dispenses water to drink."
 	amount_per_transfer_from_this = 5
 	icon = 'icons/obj/vending.dmi'
@@ -253,7 +253,7 @@
 	atom_flags = ATOM_FLAG_CLIMBABLE
 
 /obj/structure/reagent_dispensers/virusfood
-	name = "Virus Food Dispenser"
+	name = "virus food dispenser"
 	desc = "A dispenser of virus food."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "virusfoodtank"
@@ -262,7 +262,7 @@
 	initial_reagent_types = list(/datum/reagent/nutriment/virus_food = 1)
 
 /obj/structure/reagent_dispensers/acid
-	name = "Sulphuric Acid Dispenser"
+	name = "sulphuric acid dispenser"
 	desc = "A dispenser of acid for industrial processes."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "acidtank"

--- a/html/changelogs/descandmicefix.yml
+++ b/html/changelogs/descandmicefix.yml
@@ -1,0 +1,15 @@
+# Your name.  
+author: REsident55
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed grammar for some item descriptions, and added some missing ones."
+  - bugfix: "Fixed random capitalisation of some objects."
+  - tweak: "Mice can now be absorbed for a little bit of biomass."


### PR DESCRIPTION
  - bugfix: "Fixed grammar for some item descriptions, and added some missing ones."
  - bugfix: "Fixed random capitalisation of some objects."
  - tweak: "Mice can now be absorbed for a little bit of biomass."

This is perhaps not the most useful thing to work on but it annoys me. ; )

Fixed some missing descriptions, and ones that lack full stops etc. I doubt it's all, but the ones I could find.

Also mice can now be absorbed. If you don't like this okay, but it seems strange to me that corruption can't absorb dead mice. Only for a little bit: mice are small. 0.2kg.