### PR TITLE
fix Detonator Mine Retriever

### DIFF
--- a/code/modules/projectiles/firemode.dm
+++ b/code/modules/projectiles/firemode.dm
@@ -17,6 +17,7 @@
 
 	var/mob/user
 	var/atom/target
+	var/req_ammo = TRUE
 
 /datum/firemode/New(obj/item/weapon/gun/_gun, list/properties = null)
 	..()
@@ -148,7 +149,7 @@
 /*
 	This only handles additional checks that the gun itself may not handle
 */
-/datum/firemode/proc/can_fire()
+/datum/firemode/proc/can_fire(mob/living/user)
 	return TRUE
 
 //Override in subtypes

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -299,7 +299,7 @@
 		Cooldown times/overheating
 */
 /obj/item/weapon/gun/proc/can_ever_fire(mob/living/user)
-	if(safety() || !has_ammo())
+	if(safety() || (current_firemode.req_ammo && !has_ammo()))
 		return FALSE
 
 	//We'll only do the special check if a user is supplied
@@ -310,6 +310,9 @@
 		return FALSE
 
 	if (require_held && !is_held())
+		return FALSE
+
+	if(!current_firemode.can_fire(user))
 		return FALSE
 
 	return TRUE

--- a/code/modules/projectiles/guns/ds13/detonator.dm
+++ b/code/modules/projectiles/guns/ds13/detonator.dm
@@ -45,6 +45,7 @@
 */
 /datum/firemode/tripmine
 	override_fire = TRUE
+	req_ammo = FALSE
 
 /datum/firemode/tripmine/fire(var/atom/target, var/mob/living/user, var/clickparams, var/pointblank=0, var/reflex=0)
 	var/obj/item/weapon/gun/projectile/detonator/R = gun


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
:cl:
fix: retrieval mode cannot be used without ammunition
/:cl:
