### PR TITLE
fix: Runtime in gun.dm, line 302

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -299,7 +299,7 @@
 		Cooldown times/overheating
 */
 /obj/item/weapon/gun/proc/can_ever_fire(mob/living/user)
-	if(safety() || (current_firemode.req_ammo && !has_ammo()))
+	if(safety() || ((!current_firemode || current_firemode.req_ammo) && !has_ammo()))
 		return FALSE
 
 	//We'll only do the special check if a user is supplied
@@ -312,7 +312,7 @@
 	if (require_held && !is_held())
 		return FALSE
 
-	if(!current_firemode.can_fire(user))
+	if(current_firemode && !current_firemode.can_fire(user))
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
fix: Runtime in gun.dm, line 302: Cannot read null.req_ammo

:cl:
fix: energy guns now fire.
/:cl: