### PR TITLE
Divider and Signal fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/arm.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/arm.dm
@@ -22,7 +22,7 @@
 	icon_dead = list("arm_dead_1", "arm_dead_2")
 	speed = 2.25
 	melee_damage_lower = 2
-	melee_damage_upper = 4
+	melee_damage_upper = 3.5
 	attacktext = "scratched"
 	attack_sound = 'sound/weapons/bite.ogg'
 	leap_range = 5
@@ -69,7 +69,7 @@
 
 //The divider arm has an additional effect, the target is steered around randomly
 /datum/extension/mount/parasite/arm
-	damage = 6
+	damage = 8
 
 /datum/extension/mount/parasite/arm/Process()
 	.=..()

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
@@ -4,11 +4,11 @@
 	mob_type = /mob/living/carbon/human/necromorph/divider
 	blurb = "A bizarre walking horrorshow, slow but extremely durable. On death, it splits into five smaller creatures, in an attempt to find a new body to control. The divider is hard to kill, and has several abilities which excel at pinning down a lone target."
 	unarmed_types = list(/datum/unarmed_attack/claws/strong/divider)
-	total_health = 225
+	total_health = 240
 	biomass = 150
 	require_total_biomass	=	BIOMASS_REQ_T2
 	mass = 120
-	limb_health_factor = 1.0
+	limb_health_factor = 1.15
 
 	evasion = -10	//Slow and predictable
 
@@ -286,7 +286,7 @@ Reanimate can be used to take control of any already-headless corpse on the grou
 	angle = 130,
 	range = 3,
 	duration = 0.85 SECOND,
-	windup = 0.4 SECONDS,
+	windup = 0.3 SECONDS,
 	cooldown = 3.5 SECONDS,
 	damage = 20,
 	damage_flags = DAM_EDGE,

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/head.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/head.dm
@@ -11,13 +11,13 @@
 	icon_state = "head"
 	icon_living = "head"
 	icon_dead = list("head_dead_1", "head_dead_2")
-	melee_damage_lower = 4
-	melee_damage_upper = 6
+	melee_damage_lower = 3
+	melee_damage_upper = 5
 	attacktext = "whipped"
 	attack_sound = 'sound/weapons/bite.ogg'
 	speed = 1.75
 	leap_range = 4
-	max_health = 50
+	max_health = 60
 
 	pain_sounds = list('sound/effects/creatures/necromorph/divider/component/head_pain_1.ogg',
 	'sound/effects/creatures/necromorph/divider/component/head_pain_2.ogg')

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/leg.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/leg.dm
@@ -17,8 +17,8 @@
 	icon_living = "leg"
 	icon_dead = list("leg_dead_1", "leg_dead_2")
 	speed = 3
-	melee_damage_lower = 3
-	melee_damage_upper = 6
+	melee_damage_lower = 2
+	melee_damage_upper = 4
 	attacktext = "kicked"
 	attack_sound = 'sound/weapons/bite.ogg'
 	leap_cooldown = 4 SECONDS
@@ -45,7 +45,7 @@
 		var/mob/living/L = charge.last_obstacle
 		L.shake_animation(15)
 		shake_camera(L,10,6) //Smack
-		launch_strike(L, damage = 18, used_weapon = src, damage_flags = 0, armor_penetration = 10, damage_type = BRUTE, armor_type = "melee", target_zone = get_zone_sel(src), difficulty = 50)
+		launch_strike(L, damage = 22, used_weapon = src, damage_flags = 0, armor_penetration = 10, damage_type = BRUTE, armor_type = "melee", target_zone = get_zone_sel(src), difficulty = 50)
 		//We are briefly stunned
 		Stun(1)
 
@@ -57,7 +57,7 @@
 	var/turf/epicentre = get_turf(charge.last_obstacle)
 	if (istype(charge.last_obstacle, /atom/movable))
 		var/atom/movable/AM = charge.last_obstacle
-		AM.apply_push_impulse_from(src, 20)
+		AM.apply_push_impulse_from(src, 40)
 
 	//After getting kicked you stagger a bit
 	spawn(0.75 SECONDS)

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/tongue.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/tongue.dm
@@ -6,7 +6,7 @@
 
 	If it hits a mob, wraps around their neck and begins an execution move. At this point, the tongue becomes a targetable object
 */
-#define TONGUE_PROJECTILE_SPEED	4.5
+#define TONGUE_PROJECTILE_SPEED	5.5
 #define	TONGUE_OFFSET	-8,40
 #define TONGUE_RANGE	5
 /*
@@ -148,6 +148,9 @@
 	layer = BELOW_HUMAN_LAYER
 	atom_flags = 0
 	obj_flags = 0
+	max_health = 60
+	health = 60
+	mouse_opacity = TRUE
 
 //Tongue takes double damage from edged weapons
 /obj/effect/projectile/tether/tongue/take_damage(var/amount, var/damtype = BRUTE, var/user, var/used_weapon, var/bypass_resist = FALSE)
@@ -157,6 +160,9 @@
 
 	.=..()
 
+
+/obj/effect/projectile/tether/tongue/zero_health()
+	retract()
 
 /obj/effect/projectile/tether/tongue/retract(var/time = 1 SECOND, var/delete_on_finish = TRUE, var/steps = 3)
 	if (origin_atom)

--- a/code/modules/mob/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/observer/freelook/marker/signal.dm
@@ -46,7 +46,12 @@ GLOBAL_LIST_INIT(signal_sprites, list("markersignal-1",
 	return TRUE
 
 /mob/observer/eye/signal/apply_customisation(var/datum/preferences/prefs)
-	var/list/custom = prefs.get_necro_custom_list()
+	var/list/custom
+	if (prefs)
+		custom = prefs.get_necro_custom_list()
+	else
+		//With blank prefs, we use the global default
+		custom = get_default_necro_custom()
 	var/list/things = custom[SIGNAL][SIGNAL_DEFAULT]
 	if (length(things))
 		variations = things.Copy()
@@ -202,7 +207,7 @@ GLOBAL_LIST_INIT(signal_sprites, list("markersignal-1",
 	//Lets load preferences if possible
 	//This will set our icon to one of the players' chosen ones
 
-	if (client && client.prefs && client.prefs.necro_custom && client.prefs.necro_custom.len)
+	if (client)
 		apply_customisation(client.prefs)
 
 	spawn(1)	//Prevents issues when downgrading from master

--- a/code/modules/projectiles/effects/tether.dm
+++ b/code/modules/projectiles/effects/tether.dm
@@ -9,6 +9,8 @@
 	icon = 'icons/effects/tethers.dmi'
 	icon_state = "gravity_tether"
 
+	var/retracting = FALSE
+
 	//Start and endpoints are in world pixel coordinates
 	var/vector2/start = new /vector2(0,0)
 	var/vector2/end = new /vector2(0,0)
@@ -130,6 +132,10 @@
 
 /obj/effect/projectile/tether/proc/retract(var/time = 1 SECOND, var/delete_on_finish = TRUE, var/steps = 3)
 	set waitfor = FALSE
+	if (retracting)
+		return
+	retracting = TRUE
+
 	//We'll retract the tongue to 1 pixel away from its origin
 	//This is done in several steps to prevent visual glitches
 	var/vector2/tether_direction = end - start

--- a/html/changelogs/divider.yml
+++ b/html/changelogs/divider.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "The divider's tongue can now be attacked and cut with melee weapons, to free its victim. This was always intended, it was just bugged until now."
+  - tweak: "Divider components now deal less damage with their basic melee attacks, generally about 25% less."
+  - tweak: "Divider components now deal more damage with their special leap attacks."
+  - tweak: "Divider health and limb health increased."
+  - tweak: "Divider arm swing now has a faster windup animation."
+  - tweak: "Divider Tongue projectile now flies faster."
+  - bugfix: "Fixed signals not having sprites"


### PR DESCRIPTION
a bugfix for signal, and some rebalancing for divider. reorienting it towards its goal a bit more, and nerfing some of the really annoying parts

changes: 
  - bugfix: "The divider's tongue can now be attacked and cut with melee weapons, to free its victim. This was always intended, it was just bugged until now."
  - tweak: "Divider components now deal less damage with their basic melee attacks, generally about 25% less."
  - tweak: "Divider components now deal more damage with their special leap attacks."
  - tweak: "Divider health and limb health increased."
  - tweak: "Divider arm swing now has a faster windup animation."
  - tweak: "Divider Tongue projectile now flies faster."