### PR TITLE
MaxSkillCaps

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -7,7 +7,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the CEC"
-	selection_color = "#1d1d4f"
+	selection_color = "#2f2f7f"
 	req_admin_notify = 1
 	minimal_player_age = 18
 	ideal_character_age = 50
@@ -23,9 +23,11 @@
 						SKILL_WEAPONS     = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_HAULING     = SKILL_MAX,
-						SKILL_WEAPONS     = SKILL_MAX,
-	                    SKILL_COMPUTER    = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/cap/get_description_blurb()
@@ -39,7 +41,7 @@ datum/job/cap/get_description_blurb()
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Captain"
-	selection_color = "#2f2f7f"
+	selection_color = "#1d1d4f"
 	req_admin_notify = 1
 	minimal_player_age = 18
 	ideal_character_age = 35
@@ -53,9 +55,11 @@ datum/job/cap/get_description_blurb()
 						SKILL_WEAPONS     = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_HAULING     = SKILL_MAX,
-						SKILL_WEAPONS     = SKILL_MAX,
-	                    SKILL_COMPUTER    = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/fl/get_description_blurb()
@@ -68,7 +72,7 @@ datum/job/fl/get_description_blurb()
 	total_positions = 4
 	spawn_positions = 4
 	supervisors = "the Captain and First Lieutenant"
-	selection_color = "#2f2f7f"
+	selection_color = "#1d1d4f"
 	minimal_player_age = 18
 	ideal_character_age = 27
 	starting_credits = 3400
@@ -79,8 +83,11 @@ datum/job/fl/get_description_blurb()
 	min_skill = list(   SKILL_HAULING     = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_EXPERT)
 
-	max_skill = list(   SKILL_HAULING     = SKILL_MAX,
-	                    SKILL_COMPUTER    = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/bo/get_description_blurb()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -5,7 +5,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the First Lieutenant"
-	selection_color = "#5e4215"
+	selection_color = "#006200"
 	minimal_player_age = 18
 	ideal_character_age = 30
 	starting_credits = 943
@@ -14,7 +14,10 @@
 	outfit_type = /decl/hierarchy/outfit/job/service/bar
 
 	min_skill = list(   SKILL_COOKING     = SKILL_ADEPT)
-	max_skill = list(   SKILL_COOKING     = SKILL_MAX)
+	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/bar/get_description_blurb()
@@ -27,7 +30,7 @@ datum/job/bar/get_description_blurb()
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the First Lieutenant"
-	selection_color = "#5e4215"
+	selection_color = "#006200"
 	minimal_player_age = 18
 	ideal_character_age = 21
 	starting_credits = 1240
@@ -38,7 +41,10 @@ datum/job/bar/get_description_blurb()
 	min_skill = list(   SKILL_COOKING     = SKILL_EXPERT,
 						SKILL_HAULING     = SKILL_BASIC)
 
-	max_skill = list(   SKILL_COOKING     = SKILL_MAX)
+	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/line_cook/get_description_blurb()
@@ -52,20 +58,23 @@ datum/job/line_cook/get_description_blurb()
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the First Lieutenant"
-	selection_color = "#3b3b3b"
+	selection_color = "#515151"
 	minimal_player_age = 18
 	ideal_character_age = 40
 	starting_credits = 2380
 
-	access = list(access_so, access_bridge, access_cargo, access_maint_tunnels)
+	access = list(access_so, access_bridge, access_cargo, access_maint_tunnels, access_keycard_auth)
 	outfit_type = /decl/hierarchy/outfit/job/cargo/so
 
 	min_skill = list(   SKILL_HAULING     = SKILL_ADEPT,
 	                    SKILL_COMPUTER    = SKILL_ADEPT,
 	                    SKILL_COMBAT	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_HAULING     = SKILL_MAX,
-	                    SKILL_COMPUTER    = SKILL_MAX)
+	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/so/get_description_blurb()
@@ -79,7 +88,7 @@ datum/job/so/get_description_blurb()
 	total_positions = 5
 	spawn_positions = 5
 	supervisors = "the Supply Officer"
-	selection_color = "#515151"
+	selection_color = "#3b3b3b"
 	minimal_player_age = 18
 	starting_credits = 1970
 
@@ -89,8 +98,11 @@ datum/job/so/get_description_blurb()
 	min_skill = list(   SKILL_HAULING     = SKILL_EXPERT,
 	                    SKILL_COMPUTER    = SKILL_BASIC)
 
-	max_skill = list(   SKILL_HAULING     = SKILL_MAX,
-	                    SKILL_COMPUTER    = SKILL_MAX)
+	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/serviceman/get_description_blurb()
@@ -103,7 +115,7 @@ datum/job/serviceman/get_description_blurb()
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the First Lieutenant"
-	selection_color = "#5e4215"
+	selection_color = "#006200"
 	minimal_player_age = 18
 	ideal_character_age = 30
 	starting_credits = 943
@@ -111,8 +123,11 @@ datum/job/serviceman/get_description_blurb()
 	access = list(access_service)
 	outfit_type = /decl/hierarchy/outfit/job/service/botanist
 
-	min_skill = list(   SKILL_BOTANY = SKILL_EXPERT)
-	max_skill = list(   SKILL_BOTANY     = SKILL_MAX)
+	min_skill = list(   SKILL_BOTANY 	  = SKILL_EXPERT)
+	max_skill = list(   SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/bar/get_description_blurb()

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -23,10 +23,11 @@
 	                    SKILL_ELECTRICAL  = SKILL_EXPERT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_EVA	      = SKILL_MAX,
-	                    SKILL_COMPUTER    = SKILL_MAX,
-	                    SKILL_CONSTRUCTION= SKILL_MAX,
-	                    SKILL_ELECTRICAL  = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/ce/get_description_blurb()
@@ -54,10 +55,11 @@ datum/job/ce/get_description_blurb()
 	                    SKILL_CONSTRUCTION= SKILL_ADEPT,
 	                    SKILL_ELECTRICAL  = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_EVA	      = SKILL_MAX,
-						SKILL_COMPUTER    = SKILL_MAX,
-	                    SKILL_CONSTRUCTION= SKILL_MAX,
-	                    SKILL_ELECTRICAL  = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 14
 
 datum/job/tech_engineer/get_description_blurb()

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -74,7 +74,7 @@ datum/job/md/get_description_blurb()
 	outfit_type = /decl/hierarchy/outfit/job/medical/surg
 
 	min_skill = list(	SKILL_ANATOMY     = SKILL_EXPERT,
-						SKILL_MEDICAL	  = SKILL_ADEPT,
+						SKILL_MEDICAL	  = SKILL_EXPERT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
 	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -17,12 +17,14 @@
 					access_keycard_auth)
 	outfit_type = /decl/hierarchy/outfit/job/medical/smo
 
-	min_skill = list(   SKILL_ANATOMY     = SKILL_EXPERT,
-						SKILL_MEDICAL	  = SKILL_EXPERT,
+	min_skill = list(   SKILL_ANATOMY     = SKILL_MAX,
+						SKILL_MEDICAL	  = SKILL_MAX,
+						SKILL_HAULING     = SKILL_BASIC,
 	                    SKILL_DEVICES	  = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_ANATOMY	  = SKILL_MAX,
-	                    SKILL_MEDICAL     = SKILL_MAX)
+	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_FORENSICS   = SKILL_EXPERT)
 	skill_points = 25
 
 datum/job/smo/get_description_blurb()
@@ -44,11 +46,13 @@ datum/job/smo/get_description_blurb()
 	outfit_type = /decl/hierarchy/outfit/job/medical/md
 
 	min_skill = list(   SKILL_ANATOMY     = SKILL_BASIC,
-						SKILL_MEDICAL	  = SKILL_ADEPT,
+						SKILL_MEDICAL	  = SKILL_EXPERT,
+						SKILL_HAULING     = SKILL_BASIC,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_ANATOMY	  = SKILL_EXPERT,
-	                    SKILL_MEDICAL     = SKILL_MAX)
+	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_FORENSICS   = SKILL_EXPERT)
 	skill_points = 20
 
 datum/job/md/get_description_blurb()
@@ -69,12 +73,13 @@ datum/job/md/get_description_blurb()
 	access = list(access_medical, access_surgery, access_research)
 	outfit_type = /decl/hierarchy/outfit/job/medical/surg
 
-	min_skill = list(   SKILL_ANATOMY     = SKILL_PROF,
+	min_skill = list(	SKILL_ANATOMY     = SKILL_EXPERT,
 						SKILL_MEDICAL	  = SKILL_ADEPT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_ANATOMY	  = SKILL_MAX,
-	                    SKILL_MEDICAL     = SKILL_MAX)
+	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_FORENSICS   = SKILL_EXPERT)
 	skill_points = 24
 
 datum/job/surg/get_description_blurb()

--- a/code/game/jobs/job/mining.dm
+++ b/code/game/jobs/job/mining.dm
@@ -7,7 +7,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the CEC"
-	selection_color = "#515151"
+	selection_color = "#7e591c"
 	req_admin_notify = 1
 	minimal_player_age = 18
 	ideal_character_age = 30
@@ -19,8 +19,11 @@
 	min_skill = list(   SKILL_COMPUTER	  = SKILL_BASIC,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_COMPUTER	  = SKILL_MAX,
-	                    SKILL_DEVICES     = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 30
 
 /datum/job/dom/get_description_blurb()
@@ -34,7 +37,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the Director of Mining"
-	selection_color = "#515151"
+	selection_color = "#5e4215"
 	minimal_player_age = 18
 	starting_credits = 2400
 
@@ -45,8 +48,11 @@
 						SKILL_HAULING	  = SKILL_ADEPT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_EVA		  = SKILL_MAX,
-	                    SKILL_HAULING     = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 /datum/job/foreman/get_description_blurb()
@@ -60,7 +66,7 @@
 	total_positions = 25
 	spawn_positions = 25
 	supervisors = "the Mining Foreman"
-	selection_color = "#515151"
+	selection_color = "#5e4215"
 	minimal_player_age = 18
 	starting_credits = 670
 
@@ -71,8 +77,11 @@
 						SKILL_HAULING	  = SKILL_ADEPT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_EVA		  = SKILL_MAX,
-	                    SKILL_HAULING     = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 /datum/job/planet_cracker/get_description_blurb()

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -21,8 +21,11 @@
 						SKILL_COMPUTER	  = SKILL_ADEPT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_COMPUTER	  = SKILL_MAX,
-	                    SKILL_DEVICES	  = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/cscio/get_description_blurb()
@@ -49,8 +52,11 @@ datum/job/cscio/get_description_blurb()
 						SKILL_COMPUTER	  = SKILL_ADEPT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_COMPUTER	  = SKILL_MAX,
-	                    SKILL_DEVICES	  = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/ra/get_description_blurb()

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -21,8 +21,10 @@
 						SKILL_COMBAT	  = SKILL_ADEPT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_WEAPONS     = SKILL_MAX,
-						SKILL_COMBAT	  = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY	  = SKILL_ADEPT)
 	skill_points = 20
 
 datum/job/cseco/get_description_blurb()
@@ -48,8 +50,10 @@ datum/job/cseco/get_description_blurb()
 						SKILL_FORENSICS   = SKILL_EXPERT,
 	                    SKILL_DEVICES	  = SKILL_ADEPT)
 
-	max_skill = list(   SKILL_WEAPONS     = SKILL_MAX,
-						SKILL_COMBAT	  = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT)
 	skill_points = 16
 
 datum/job/sso/get_description_blurb()
@@ -75,8 +79,10 @@ datum/job/sso/get_description_blurb()
 						SKILL_FORENSICS   = SKILL_ADEPT,
 	                    SKILL_DEVICES	  = SKILL_BASIC)
 
-	max_skill = list(   SKILL_WEAPONS     = SKILL_MAX,
-						SKILL_COMBAT	  = SKILL_MAX)
+	max_skill = list(   SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT)
 	skill_points = 10
 
 datum/job/security_officer/get_description_blurb()

--- a/html/changelogs/Snypehunter007-PR-1379.yml
+++ b/html/changelogs/Snypehunter007-PR-1379.yml
@@ -40,6 +40,7 @@ changes:
   - tweak: "The SMO and MD's starting Athletics skill has been bumped up to Basic."
   - tweak: "The SMO's starting Medical and Anatomy skill has been bumped up to Master."
   - tweak: "Surgeon's starting Anatomy skill has been downgraded to Experienced."
+  - tweak: "Surgeon's starting Medical skill has been bumped up to Experienced."
   - tweak: "The Forensics skill has been capped at Trained for most of the crew except for Medical personnel, who have it capped as Experienced, and Security personnel."
   - tweak: "The Cooking, Botany, and Medical skills have been capped at Experienced for roles who don't use those skills for their job."
   - tweak: "The Anatomy skill has been capped at Trained for roles who don't use that skill for their job."

--- a/html/changelogs/Snypehunter007-PR-1379.yml
+++ b/html/changelogs/Snypehunter007-PR-1379.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Snypehunter007
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed the SO not having keycard authorization access."
+  - tweak: "MDs starting Medical skill has been bumped up to Experienced."
+  - tweak: "The SMO and MD's starting Athletics skill has been bumped up to Basic."
+  - tweak: "The SMO's starting Medical and Anatomy skill have been bumped up to Master."
+  - tweak: "Surgeon's starting Anatomy skill has been downgraded to Experienced."
+  - tweak: "The Forensics skill has been capped at Trained for most of the crew except for Medical personnel, who have it capped as Experienced, and Security personnel."
+  - tweak: "The Cooking, Botany, and Medical skills have been capped at Experienced for roles who don't use those skills for their job."
+  - tweak: "The Anatomy skill has been capped at Trained for roles who don't use that skill for their job."

--- a/html/changelogs/Snypehunter007-PR-1379.yml
+++ b/html/changelogs/Snypehunter007-PR-1379.yml
@@ -35,10 +35,10 @@ delete-after: True
 changes: 
   - bugfix: "Fixed the SO not having keycard authorization access."
   - bugfix: "Fixed the Services jobs (Botanist, Line Cook, Bartender) having the wrong colors."
-  - bugfix: "Fixed the Mining Department sharing the same color on the Occupation screen in the Character Setup."
+  - bugfix: "Fixed the Mining Department sharing the same color as the Supply Department on the Occupation screen in the Character Setup."
   - tweak: "MDs starting Medical skill has been bumped up to Experienced."
   - tweak: "The SMO and MD's starting Athletics skill has been bumped up to Basic."
-  - tweak: "The SMO's starting Medical and Anatomy skill have been bumped up to Master."
+  - tweak: "The SMO's starting Medical and Anatomy skill has been bumped up to Master."
   - tweak: "Surgeon's starting Anatomy skill has been downgraded to Experienced."
   - tweak: "The Forensics skill has been capped at Trained for most of the crew except for Medical personnel, who have it capped as Experienced, and Security personnel."
   - tweak: "The Cooking, Botany, and Medical skills have been capped at Experienced for roles who don't use those skills for their job."

--- a/html/changelogs/Snypehunter007-PR-1379.yml
+++ b/html/changelogs/Snypehunter007-PR-1379.yml
@@ -34,8 +34,8 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Fixed the SO not having keycard authorization access."
-  - bugifx: "Fixed the Services jobs (Botanist, Line Cook, Bartender) having the wrong colors.
-  - bugfix: "Fixed the Mining Department sharing the same color on the Occupation screen in the Character Setup.
+  - bugfix: "Fixed the Services jobs (Botanist, Line Cook, Bartender) having the wrong colors."
+  - bugfix: "Fixed the Mining Department sharing the same color on the Occupation screen in the Character Setup."
   - tweak: "MDs starting Medical skill has been bumped up to Experienced."
   - tweak: "The SMO and MD's starting Athletics skill has been bumped up to Basic."
   - tweak: "The SMO's starting Medical and Anatomy skill have been bumped up to Master."

--- a/html/changelogs/Snypehunter007-PR-1379.yml
+++ b/html/changelogs/Snypehunter007-PR-1379.yml
@@ -34,7 +34,7 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Fixed the SO not having keycard authorization access."
-  - bugfix: "Fixed the Services jobs (Botanist, Line Cook, Bartender) having the wrong colors."
+  - bugfix: "Fixed the Services jobs (Botanist, Line Cook, Bartender) having the wrong colors on the Occupation screen in the Character Setup."
   - bugfix: "Fixed the Mining Department sharing the same color as the Supply Department on the Occupation screen in the Character Setup."
   - tweak: "MDs starting Medical skill has been bumped up to Experienced."
   - tweak: "The SMO and MD's starting Athletics skill has been bumped up to Basic."

--- a/html/changelogs/Snypehunter007-PR-1379.yml
+++ b/html/changelogs/Snypehunter007-PR-1379.yml
@@ -34,6 +34,8 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Fixed the SO not having keycard authorization access."
+  - bugifx: "Fixed the Services jobs (Botanist, Line Cook, Bartender) having the wrong colors.
+  - bugfix: "Fixed the Mining Department sharing the same color on the Occupation screen in the Character Setup.
   - tweak: "MDs starting Medical skill has been bumped up to Experienced."
   - tweak: "The SMO and MD's starting Athletics skill has been bumped up to Basic."
   - tweak: "The SMO's starting Medical and Anatomy skill have been bumped up to Master."


### PR DESCRIPTION
  - Fixed the SO not having keycard authorization access.
  - Fixed the Services jobs (Botanist, Line Cook, Bartender) having the wrong colors on the Occupation screen in the Character Setup.
  - Fixed the Mining Department sharing the same color as the Supply Department on the Occupation screen in the Character Setup.
  - MDs starting Medical skill has been bumped up to Experienced.
  - The SMO and MD's starting Athletics skill has been bumped up to Basic.
  - The SMO's starting Medical and Anatomy skill have been bumped up to Master.
  - Surgeon's starting Anatomy skill has been downgraded to Experienced.
  - The Forensics skill has been capped at Trained for most of the crew except for Medical personnel, who have it capped as Experienced, and Security personnel.
  - The Cooking, Botany, and Medical skills have been capped at Experienced for roles who don't use those skills for their job.
  - The Anatomy skill has been capped at Trained for roles who don't use that skill for their job.


Also fixed some redundancies made with max_skill for jobs.

Fixes #1365
Fixes #1283 