### PR TITLE
Necromorphs spawning in hurt intent

### DIFF
--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -25,9 +25,6 @@
 /mob/living/blocks_airlock()
 	return 1
 
-/obj/structure/closet/blocks_airlock()
-	return TRUE
-
 /obj/structure/closet/body_bag/blocks_airlock()
 	if (locate(/mob) in src)
 		return 1

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -25,6 +25,9 @@
 /mob/living/blocks_airlock()
 	return 1
 
+/obj/structure/closet/blocks_airlock()
+	return TRUE
+
 /obj/structure/closet/body_bag/blocks_airlock()
 	if (locate(/mob) in src)
 		return 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1490,9 +1490,9 @@
 
 /mob/living/carbon/human/InitializeHud()
 	..()
-	set_intenet(a_intent)
+	set_intent(a_intent)
 
-/mob/living/carbon/human/proc/set_intenet(new_intent = I_HELP)
+/mob/living/carbon/human/proc/set_intent(new_intent = I_HELP)
 	a_intent = new_intent
 	if(istype(hud_used.action_intent, /obj/screen/intent))
 		var/obj/screen/intent/I = hud_used.action_intent


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
actually the problem is that the hud was not updated. but, well.
fix: #913
:cl:
fix: the hud of the necromorph corresponds to its hurt intent.
/:cl: