### PR TITLE
Necromorph Skill Change

### DIFF
--- a/code/__defines/skills_stats.dm
+++ b/code/__defines/skills_stats.dm
@@ -6,7 +6,7 @@
 
 #define SKILL_MIN      1 // Min skill value selectable
 #define SKILL_MAX      5 // Max skill value selectable
-#define SKILL_DEFAULT  4 //most mobs will default to this
+#define SKILL_DEFAULT  1 //most mobs will default to this
 
 #define SKILL_EASY     1
 #define SKILL_AVERAGE  2


### PR DESCRIPTION
This changes the default skill level from 4 (Expert) to 1 (None). This means necromorphs will no longer have expert level skill in all skills. This should fix the balance issue with necromorphs being able to spam disarm survivors, guaranteeing a kill.