### PR TITLE
spitter cooldown

### DIFF
--- a/code/modules/mob/living/carbon/human/species/necromorph/_shared.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/_shared.dm
@@ -1,3 +1,7 @@
 #define WALLRUN_DESC	"<h2>PASSIVE: Wallcrawling:</h2><br>\
 This necromorph is capable of crawling along walls, over the heads of other creature. Simply move into a wall to climb onto it.<br>\
  While crawling on a wall, the necromorph gains +15% movespeed and +10% evasion."
+
+
+
+#define SHARED_COOLDOWN_SHOT	(1.5 SECOND)

--- a/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
@@ -166,7 +166,14 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 		return FALSE
 
 	face_atom(A)
-	.= shoot_ability(/datum/extension/shoot/snapshot, A , /obj/item/projectile/bullet/acid/puker_snap, accuracy = 50, dispersion = 0, num = 1, windup_time = 0, fire_sound = null, nomove = 1 SECOND, cooldown = 3 SECONDS)
+
+	//Shared cooldown
+	var/datum/extension/shoot/longshot/LS = get_extension(src, /datum/extension/shoot/longshot)
+	if (LS && (world.time - LS.started_at) < SHARED_COOLDOWN_SHOT)
+		return
+
+
+	.= shoot_ability(/datum/extension/shoot/snapshot, A , /obj/item/projectile/bullet/acid/puker_snap, accuracy = 50, dispersion = 0, num = 1, windup_time = 0, fire_sound = null, nomove = 1 SECOND, cooldown = 3.5 SECONDS)
 	if (.)
 		play_species_audio(src, SOUND_ATTACK, VOLUME_MID, 1, 3)
 
@@ -181,7 +188,13 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 	set desc = "A powerful projectile for longrange shooting. HK: Alt+Click"
 
 	face_atom(A)
-	.= shoot_ability(/datum/extension/shoot/longshot, A , /obj/item/projectile/bullet/acid/puker_long, accuracy = 50, dispersion = 0, num = 1, windup_time = 0.5 SECONDS, fire_sound = null, nomove = 1 SECOND, cooldown = 1 SECONDS)
+
+	//Shared cooldown
+	var/datum/extension/shoot/longshot/LS = get_extension(src, /datum/extension/shoot/longshot)
+	if (LS && (world.time - LS.started_at) < SHARED_COOLDOWN_SHOT)
+		return
+
+	.= shoot_ability(/datum/extension/shoot/longshot, A , /obj/item/projectile/bullet/acid/puker_long, accuracy = 50, dispersion = 0, num = 1, windup_time = 0.5 SECONDS, fire_sound = null, nomove = 1 SECOND, cooldown = 1.25 SECONDS)
 	if (.)
 		play_species_audio(src, SOUND_ATTACK, VOLUME_MID, 1, 3)
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
@@ -129,8 +129,16 @@ Best used for harassment, skirmishing and initiating fights from afar against un
 		to_chat(src, SPAN_WARNING("No valid targets found within [SPITTER_SNAPSHOT_RANGE] range"))
 		return FALSE
 
+
+
 	face_atom(A)
-	.= shoot_ability(/datum/extension/shoot/snapshot, A , /obj/item/projectile/bullet/acid/spitter_snap, accuracy = 50, dispersion = 0, num = 1, windup_time = 0, fire_sound = null, nomove = 1 SECOND, cooldown = 3 SECONDS)
+
+	//Shared cooldown
+	var/datum/extension/shoot/longshot/LS = get_extension(src, /datum/extension/shoot/longshot)
+	if (LS && (world.time - LS.started_at) < SHARED_COOLDOWN_SHOT)
+		return
+
+	.= shoot_ability(/datum/extension/shoot/snapshot, A , /obj/item/projectile/bullet/acid/spitter_snap, accuracy = 50, dispersion = 0, num = 1, windup_time = 0, fire_sound = null, nomove = 1 SECOND, cooldown = 4 SECONDS)
 	if (.)
 		play_species_audio(src, SOUND_ATTACK, VOLUME_MID, 1, 3)
 
@@ -145,7 +153,13 @@ Best used for harassment, skirmishing and initiating fights from afar against un
 	set desc = "A moderate-strength projectile for longrange shooting. HK: Alt+Click"
 
 	face_atom(A)
-	.= shoot_ability(/datum/extension/shoot/longshot, A , /obj/item/projectile/bullet/acid/spitter_long, accuracy = 50, dispersion = 0, num = 1, windup_time = 0.5 SECONDS, fire_sound = null, nomove = 1 SECOND, cooldown = 1 SECONDS)
+
+	//Shared cooldown
+	var/datum/extension/shoot/longshot/LS = get_extension(src, /datum/extension/shoot/longshot)
+	if (LS && (world.time - LS.started_at) < SHARED_COOLDOWN_SHOT)
+		return
+
+	.= shoot_ability(/datum/extension/shoot/longshot, A , /obj/item/projectile/bullet/acid/spitter_long, accuracy = 50, dispersion = 0, num = 1, windup_time = 0.5 SECONDS, fire_sound = null, nomove = 1 SECOND, cooldown = 1.5 SECONDS)
 	if (.)
 		play_species_audio(src, SOUND_ATTACK, VOLUME_MID, 1, 3)
 

--- a/html/changelogs/spit_cooldown.yml
+++ b/html/changelogs/spit_cooldown.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Slightly increased the cooldown times on spitter and puker ranged attacks."
+  - tweak: "Spitter and puker ranged attacks now have a small shared cooldown, preventing both shots from firing simultaneously. Alternate!."
+  - bugfix: "Fixed a nice but also bad thing."

--- a/html/changelogs/spit_cooldown.yml
+++ b/html/changelogs/spit_cooldown.yml
@@ -34,5 +34,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - tweak: "Slightly increased the cooldown times on spitter and puker ranged attacks."
-  - tweak: "Spitter and puker ranged attacks now have a small shared cooldown, preventing both shots from firing simultaneously. Alternate!."
-  - bugfix: "Fixed a nice but also bad thing."
+  - tweak: "Spitter and puker ranged attacks now have a small shared cooldown, preventing both shots from firing simultaneously."


### PR DESCRIPTION
changes: 
  - tweak: "Slightly increased the cooldown times on spitter and puker ranged attacks."
  - tweak: "Spitter and puker ranged attacks now have a small shared cooldown, preventing both shots from firing simultaneously."

replaces another open PR