### PR TITLE
Exploder charge, clumsy shooting and sizes fixes

### DIFF
--- a/code/__defines/inventory_sizes.dm
+++ b/code/__defines/inventory_sizes.dm
@@ -9,7 +9,7 @@
 #define ITEM_SIZE_BULKY          4
 #define ITEM_SIZE_HUGE           5
 #define ITEM_SIZE_GARGANTUAN     6
-#define ITEM_SIZE_NO_CONTAINER INFINITY // Use this to forbid item from being placed in a container.
+#define ITEM_SIZE_NO_CONTAINER 		7// Use this to forbid item from being placed in a container.
 
 
 /*

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "pscrubber:0"
 	density = 1
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_HUGE
 
 	var/on = 0
 	var/volume_rate = 800

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -12,7 +12,7 @@
 	//Used to store information about the contents of the object.
 	var/list/matter
 	var/list/matter_reagents
-	var/w_class // Size of the object.
+	var/w_class  = ITEM_SIZE_LARGE// Size of the object.
 	var/unacidable = 0 //universal "unacidabliness" var, here so you can use it in any obj.
 	animate_movement = 2
 	var/throwforce = 1
@@ -26,7 +26,7 @@
 	var/list/tool_qualities = null// List of item qualities for tools system. See tools_and_qualities.dm.
 	var/heat = 0 //Temperature of this object, mostly used to see if it can set other things on fire
 	var/worksound = null	//Sound played when this object is used as a tool in tool operations
-	
+
 
 /obj/Destroy()
 	if (is_processing)

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder.dm
@@ -361,20 +361,25 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 /*
 	Exploders have a special charge impact. They detonate on impact
 */
-/datum/species/necromorph/exploder/charge_impact(var/mob/living/charger, var/atom/obstacle, var/power, var/target_type, var/distance_travelled)
-	if (target_type == CHARGE_TARGET_PRIMARY && isliving(obstacle))
+/datum/species/necromorph/exploder/charge_impact(var/datum/extension/charge/charge)
+	var/mob/living/carbon/human/charger = charge.user
+
+	if (isliving(charge.last_obstacle))
 		//Make sure its still there
+		var/mob/living/L = charge.last_obstacle
 		if (!can_explode(charger))
 			return
 
+		//Bonus behaviour if we hit our originally intended target
+		if (charge.last_target_type == CHARGE_TARGET_PRIMARY)
+			L.Weaken(3)	//Knock them down
+			charger.forceMove(get_turf(charge.last_obstacle))	//Move ontop of them for maximum damage
 
-
-		var/mob/living/L = obstacle
-		L.Weaken(3)	//Knock them down
-		charger.forceMove(get_turf(obstacle))	//Move ontop of them for maximum damage
 
 		var/obj/item/organ/external/hand/exploder_pustule/E = charger.get_organ(BP_L_HAND)
-		E.explode()	//Kaboom!
+		if (istype(E))
+
+			E.explode()	//Kaboom!
 
 		return FALSE
 	else

--- a/html/changelogs/exploder_charge.yml
+++ b/html/changelogs/exploder_charge.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Exploder's detonate-on-charge now works again"
+  - tweak: "Lowered the chance for clumsy mobs using guns to shoot themselves."
+  - bugfix: "Portable scrubbers can now be dragged, and many other large objects too."


### PR DESCRIPTION
changes: 
  - bugfix: "Exploder's detonate-on-charge now works again"
  - tweak: "Lowered the chance for clumsy mobs using guns to shoot themselves."
  - bugfix: "Portable scrubbers can now be dragged, and many other large objects too."