### PR TITLE
MountedE-GunRemoval

### DIFF
--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -87,7 +87,6 @@ var/list/uplink_random_selections_
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/energy_net, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/ewar_voice, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/maneuvering_jets, reselect_propbability = 15)
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/egun, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/power_sink, reselect_propbability = 15)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/hardsuit_modules/laser_canon, reselect_propbability = 5)
 

--- a/code/modules/admin/bluespacetech.dm
+++ b/code/modules/admin/bluespacetech.dm
@@ -156,8 +156,7 @@
 		/obj/item/rig_module/vision/meson,
 		/obj/item/rig_module/kinesis,
 		/obj/item/rig_module/hotswap,
-		/obj/item/rig_module/power_sink,
-		/obj/item/rig_module/mounted/egun
+		/obj/item/rig_module/power_sink
 		)
 
 /client/proc/bst_post_spawn(mob/living/carbon/human/bst/bst)

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -4,7 +4,6 @@
  * /obj/item/rig_module/device/flash/advanced
  * /obj/item/rig_module/grenade_launcher (cleaner, smoke, mfoam)
  * /obj/item/rig_module/mounted (laser cannon)
- * /obj/item/rig_module/mounted/egun
  * /obj/item/rig_module/mounted/taser
  * /obj/item/rig_module/mounted/energy_blade
  * /obj/item/rig_module/fabricator

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -32,7 +32,6 @@
 
 /obj/item/weapon/rig/combat/equipped
 	initial_modules = list(
-		/obj/item/rig_module/mounted/egun,
 		/obj/item/rig_module/vision/thermal,
 		/obj/item/rig_module/grenade_launcher,
 		/obj/item/rig_module/ai_container,
@@ -79,7 +78,6 @@
 
 /obj/item/weapon/rig/military/equipped
 	initial_modules = list(
-		/obj/item/rig_module/mounted/egun,
 		/obj/item/rig_module/vision/multi,
 		/obj/item/rig_module/grenade_launcher,
 		/obj/item/rig_module/ai_container,

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -85,7 +85,6 @@
 		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/grenade_launcher,
-		/obj/item/rig_module/mounted/egun,
 		/obj/item/rig_module/cooling_unit,
 		/obj/item/rig_module/healthbar
 		)
@@ -104,7 +103,6 @@
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/grenade_launcher,
 		/obj/item/rig_module/vision/multi,
-		/obj/item/rig_module/mounted/egun,
 		/obj/item/rig_module/chem_dispenser/combat,
 		/obj/item/rig_module/device/rcd,
 		/obj/item/rig_module/datajack,

--- a/code/modules/item_worth/worths_list.dm
+++ b/code/modules/item_worth/worths_list.dm
@@ -479,7 +479,6 @@ var/list/worths = list(
 					/obj/item/inflatable = 30,
 					/obj/item/roller = 80,
 					/obj/item/rig_module/grenade_launcher = 1500,
-					/obj/item/rig_module/mounted/egun = 2100,
 					/obj/item/rig_module/mounted/energy_blade = 2200,
 					/obj/item/rig_module/mounted = 4100,
 					/obj/item/rig_module/stealth_field = 2500,

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1267,15 +1267,6 @@
 	build_path = /obj/item/rig_module/mounted/taser
 	sort_string = "WCKAA"
 
-/datum/design/item/rig/egun
-	name = "Energy Gun"
-	desc = "An energy gun, mountable on a RIG."
-	id = "rig_egun"
-	req_tech = list(TECH_POWER = 6, TECH_COMBAT = 6, TECH_ENGINEERING = 6)
-	materials = list(MATERIAL_STEEL = 6000, MATERIAL_GLASS = 3000, "plastic" = 2500, MATERIAL_GOLD = 2000, MATERIAL_SILVER = 1000)
-	build_path = /obj/item/rig_module/mounted/egun
-	sort_string = "WCKAB"
-
 /datum/design/item/rig/enet
 	name = "Energy Net"
 	desc = "An advanced energy-patterning projector used to capture targets, mountable on a RIG."
@@ -1283,7 +1274,7 @@
 	req_tech = list(TECH_MATERIAL = 5, TECH_POWER = 6, TECH_MAGNET = 5, TECH_ILLEGAL = 4, TECH_ENGINEERING = 6)
 	materials = list(MATERIAL_STEEL = 6000, MATERIAL_GLASS = 3000, MATERIAL_DIAMOND = 2000, "plastic" = 2000)
 	build_path = /obj/item/rig_module/fabricator/energy_net
-	sort_string = "WCKAC"
+	sort_string = "WCKAB"
 
 /datum/design/item/rig/cooling_unit
 	name = "Cooling Unit"

--- a/html/changelogs/Snypehunter007-PR-1447.yml
+++ b/html/changelogs/Snypehunter007-PR-1447.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Snypehunter007
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removed the ability to make the RIG Mounted Energy Gun."
+


### PR DESCRIPTION
- Removed the mounted energy gun from the design lists.
- Removed the mounted energy gun from the few RIGs that had it in-built (this is mostly Bay legacy RIGS).