### PR TITLE
Resultados de traducción Monkey cubes can no longer be ordered from cargo

### DIFF
--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -1,14 +1,14 @@
 /decl/hierarchy/supply_pack/hydroponics
 	name = "Hydroponics"
 	containertype = /obj/structure/closet/crate/hydroponics
-
+/*
 /decl/hierarchy/supply_pack/hydroponics/monkey
 	name = "Monkey crate"
 	contains = list (/obj/item/weapon/storage/box/monkeycubes)
 	cost = 20
 	containertype = /obj/structure/closet/crate/freezer
 	containername = "\improper Monkey crate"
-
+*/
 //farm animals - useless and annoying, but potentially a good source of food. expensive because they're live animals and their produce is available cheaper
 /decl/hierarchy/supply_pack/hydroponics/cow
 	name = "Cow crate"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
:cl:
tweak: Monkey cubes can no longer be ordered from cargo
/:cl: