### PR TITLE
Scorched earth

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2420,6 +2420,7 @@
 #include "code\modules\necromorph\bioblast.dm"
 #include "code\modules\necromorph\corruption.dm"
 #include "code\modules\necromorph\corruption_nodes.dm"
+#include "code\modules\necromorph\corruption_scorch.dm"
 #include "code\modules\necromorph\corruption_source.dm"
 #include "code\modules\necromorph\corruption\bioluminescence.dm"
 #include "code\modules\necromorph\corruption\cyst.dm"

--- a/code/__defines/necromorph.dm
+++ b/code/__defines/necromorph.dm
@@ -26,6 +26,10 @@
 
 
 #define CORRUPTION_SPREAD_RANGE	12	//How far from the source corruption spreads
+#define CORRUPTION_FIRE_DAMAGE_FACTOR	3	//Damage dealt to corruption from high heat is multiplied by this value
+#define CORRUPTION_SCORCH_DURATION	(5 MINUTES)	//Corruption hit by fire cannot regrow in that tile for this quantity of time
+
+
 #define MAW_EAT_RANGE	2	//Nom distance of a maw node
 
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -69,7 +69,9 @@ for reference:
 	anchored = 0.0
 	density = 1
 	icon_state = "barrier0"
-	max_health = 200.0
+	max_health = 100
+	health = 100
+	resistance = 5
 	var/locked = 0.0
 //	req_access = list(access_maint_tunnels)
 
@@ -220,6 +222,12 @@ for reference:
 /obj/machinery/deployable/repair_needed()
 	return max_health - health
 
+
+/obj/machinery/deployable/attack_hand(mob/user)
+	if(user.a_intent == I_HURT)
+		user.strike_structure(src)
+		return 1
+	return ..()
 
 //Future TODO: Make this generic atom behaviour
 /obj/machinery/deployable/fire_act(var/datum/gas_mixture/air, var/exposed_temperature, var/exposed_volume, var/multiplier = 1)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -339,7 +339,7 @@
 	if(user)
 		user.visible_message(SPAN_NOTICE("[user] knock down [src]."), SPAN_NOTICE("You tear down [src]."))
 	shot_down = TRUE
-	density = FALSE
+	set_density(FALSE)
 	src.set_dir(turn(src.dir, 90))
 	return TRUE
 

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -223,7 +223,7 @@
 
 //Future TODO: Make this generic atom behaviour
 /obj/structure/fire_act(var/datum/gas_mixture/air, var/exposed_temperature, var/exposed_volume, var/multiplier = 1)
-	var/damage = get_fire_damage(exposed_temperature, multiplier) //Plants and corruption take 2.5x damage from fire
+	var/damage = get_fire_damage(exposed_temperature, multiplier)
 	if (damage > 0)
 		take_damage(damage, BURN,bypass_resist = TRUE)
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -25,6 +25,9 @@
 	var/list/step_structures = list()
 	var/step_priority = 1
 
+	//If true, corruption cannot spread to this turf
+	var/incorruptible = FALSE
+
 
 /turf/simulated/floor/Entered(var/atom/movable/AM, var/atom/old_loc)
 	..(AM, old_loc)

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -310,7 +310,7 @@ var/list/flooring_cache = list()
 	return round(p, 0.1)
 
 
-/turf/simulated/floor/proc/get_damage_overlay(var/cache_key, var/icon_base)
+/turf/simulated/floor/proc/get_damage_overlay(var/cache_key, var/icon_base, var/forced_alpha)
 	if(!flooring_cache[cache_key])
 		var/image/I = image(icon =  'icons/turf/flooring/damage.dmi', icon_state = icon_base)
 		I.alpha = 255 * get_damagepercent()

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -59,6 +59,7 @@
 	var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/plant
 	var/list/neighbors
 	var/can_cut = TRUE
+	layer = PLANT_LAYER
 
 /obj/effect/vine/single
 	spread_chance = 0

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -81,6 +81,11 @@
 
 
 /obj/effect/vine/proc/can_spread_to(var/turf/floor, var/bounds)
+	if (isfloor(floor))
+		var/turf/simulated/floor/F = floor
+		if (F.incorruptible)
+			return -1
+
 	if(bounds && !can_reach(floor))
 		return FALSE
 
@@ -91,6 +96,8 @@
 			break
 	if(blocked)
 		return FALSE
+
+
 
 	if(!floor.Enter(src))
 		watch_tile(floor)

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -91,7 +91,12 @@
 
 //Future TODO: Make this generic atom behaviour
 /obj/effect/vine/fire_act(var/datum/gas_mixture/air, var/exposed_temperature, var/exposed_volume, var/multiplier = 1)
-	var/damage = get_fire_damage(exposed_temperature, 3*multiplier) //Plants and corruption take 3x damage from fire
+	var/damage = get_fire_damage(exposed_temperature, CORRUPTION_FIRE_DAMAGE_FACTOR*multiplier)
+
+	var/datum/extension/scorched_earth/SE = get_extension(loc, /datum/extension/scorched_earth)
+	if (!SE)
+		set_extension(loc, /datum/extension/scorched_earth)
+
 	if (damage > 0)
 		adjust_health(-damage)
 

--- a/code/modules/mob/living/carbon/human/strike.dm
+++ b/code/modules/mob/living/carbon/human/strike.dm
@@ -551,7 +551,7 @@
 	else if (istype(target, /obj/machinery/door))
 		impact_door()
 
-	else if (istype(target, /obj/structure))
+	else if (istype(target, /obj/structure) || istype(target, /obj/machinery/deployable))
 		impact_structure()
 
 	else if(istype(target, /obj/machinery/vending) && ishuman(huser) && huser.is_necromorph())
@@ -575,7 +575,7 @@
 /datum/strike/proc/impact_structure()
 	var/obj/structure/S = target
 	damage_done = get_final_damage()
-	damage_done = S.take_damage(damage_done, BRUTE, user, used_weapon)
+	damage_done = S:take_damage(damage_done, BRUTE, user, used_weapon)
 
 /datum/strike/proc/impact_vending()
 	var/obj/machinery/vending/S = target

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -282,7 +282,8 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	return trange(1, src)
 
 /obj/effect/vine/corruption/watched_tile_updated(var/turf/T)
-	source.needs_update = TRUE
+	if (source)
+		source.needs_update = TRUE
 	.=..()
 
 //Finds all visualnet chunks that this vine could possibly infringe on.

--- a/code/modules/necromorph/corruption_nodes.dm
+++ b/code/modules/necromorph/corruption_nodes.dm
@@ -12,7 +12,6 @@
 	var/placement_type = /datum/click_handler/placement/necromorph
 	var/placement_location = PLACEMENT_FLOOR
 
-	var/fire_damage_multiplier = 3
 
 
 	default_rotation = 0
@@ -150,7 +149,7 @@
 
 //Future TODO: Make this generic atom behaviour
 /obj/structure/corruption_node/fire_act(var/datum/gas_mixture/air, var/exposed_temperature, var/exposed_volume, var/multiplier = 1)
-	.=..(air, exposed_temperature, exposed_volume, multiplier*fire_damage_multiplier)
+	.=..(air, exposed_temperature, exposed_volume, multiplier*CORRUPTION_FIRE_DAMAGE_FACTOR)
 
 
 //Nodes are organic

--- a/code/modules/necromorph/corruption_scorch.dm
+++ b/code/modules/necromorph/corruption_scorch.dm
@@ -1,0 +1,52 @@
+/*
+	This simple extension prevents corruption from regrowing here until it fades away
+*/
+/datum/extension/scorched_earth
+	flags = EXTENSION_FLAG_IMMEDIATE
+	var/scorched_until
+	var/turf/simulated/floor/earth
+
+
+/datum/extension/scorched_earth/New(var/turf/simulated/floor/earth)
+
+	//No scorching tiles which contain nodes
+	if (locate(/obj/structure/corruption_node) in earth)
+		qdel(src)
+
+	.=..()
+	src.earth = earth
+	src.scorched_until = scorched_until
+	addtimer(CALLBACK(src, /datum/extension/proc/remove_self), wait = CORRUPTION_SCORCH_DURATION)
+
+	var/obj/effect/decal/scorch/scorch = new (earth)
+	QDEL_IN(scorch, CORRUPTION_SCORCH_DURATION)
+	animate(scorch, alpha = 0, time = CORRUPTION_SCORCH_DURATION)
+
+	earth.incorruptible = TRUE
+
+/datum/extension/scorched_earth/Destroy()
+	if (earth)
+		earth.incorruptible = FALSE
+		GLOB.clarity_set_event.raise_event(earth)
+	.=..()
+
+
+/obj/effect/decal/scorch
+
+	color = "#808080"
+	anchored = TRUE
+	icon = 'icons/turf/flooring/damage.dmi'
+	icon_state = "burned1"
+
+/obj/effect/decal/scorch/Initialize()
+	.=..()
+	layer = DECAL_LAYER
+	icon_state = pick("burned1", "burned2")
+	var/matrix/M = matrix()
+	var/rotation = rand_between(0, 360)	//Randomly rotate it
+	transform = turn(M, rotation)
+
+//When deleted, let nearby vines know this turf is safe to spread into
+/obj/effect/decal/scorch/Destroy()
+
+	.=..()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -386,3 +386,6 @@ RADIATION_LOWER_LIMIT 0.15
 
 ## Uncomment this to allow patron players to bypass the player limit, and connect even if server is full. Only works if a player limit is set
 #ALWAYS_ADMIT_PATRONS
+
+## Admins can use jumping
+ALLOW_ADMIN_JUMP

--- a/html/changelogs/scorched_earth.yml
+++ b/html/changelogs/scorched_earth.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "When corruption is destroyed via heat effects (fire, lasers, explosions, etc) the scorched floor will block corruption regrowth for a few minutes afterwards"
+  - bugfix: "Made sure corruption can now go through deployable barricades and knocked-down-vendors"
+  - bugfix: "Deployable barriers can now be attacked by necromorphs"


### PR DESCRIPTION
changes: 
  - rscadd: "When corruption is destroyed via heat effects (fire, lasers, explosions, etc) the scorched floor will block corruption regrowth for a few minutes afterwards"
  - bugfix: "Made sure corruption can now go through deployable barricades and knocked-down-vendors"
  - bugfix: "Deployable barriers can now be attacked by necromorphs"

Also a little additional fix, edits default config to allow admin jumping again. that got caught up accidentally in the recent config rework