### PR TITLE
Infinite plasma pickaxe and plasma saw fix

### DIFF
--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -311,6 +311,8 @@
 //Cell reload
 /obj/item/weapon/tool/MouseDrop(over_object)
 	if((src.loc == usr) && istype(over_object, /obj/screen) && eject_item(cell, usr)) ///Formerly checked for /obj/screeninventory/hand. Not sure how that fits with bay's UI system
+		if (switched_on)
+			turn_off()
 		cell = null
 		update_icon()
 	else

--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -706,6 +706,8 @@
 
 	if(use_power_cost)
 		if (!consume_power(use_power_cost*timespent))
+			if (switched_on)
+				turn_off()
 			user << SPAN_WARNING("[src] battery is dead or missing.")
 			return FALSE
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
### Purpose

Fixes infinite plasma pickaxe and plasma saw. 
Right now you can turn on plasma pickaxe, remove it's battery and have infinite plasma pickaxe. This PR fixes it.