### PR TITLE
Increases contact beam damage by 15%, increases construction costs by 30% at request of Westhybrid

### DIFF
--- a/code/modules/projectiles/guns/ds13/contactbeam.dm
+++ b/code/modules/projectiles/guns/ds13/contactbeam.dm
@@ -268,7 +268,7 @@
 	Projectile
 */
 /obj/item/projectile/beam/contact
-	damage = 80
+	damage = 92
 	armor_penetration = 15
 	accuracy	=	100
 	fire_sound = list('sound/weapons/guns/fire/contact_fire_1.ogg', 'sound/weapons/guns/fire/contact_fire_2.ogg')

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -537,7 +537,7 @@
 	name = "C99 Supercollider Contact Beam"
 	id = "contactbeam"
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 5, TECH_POWER = 3)
-	materials = list(MATERIAL_STEEL = 2500, MATERIAL_GOLD = 1500, "uranium" = 1450)
+	materials = list(MATERIAL_STEEL = 3250, MATERIAL_GOLD = 1950, "uranium" = 1885)
 	build_path = /obj/item/weapon/gun/energy/contact
 	sort_string = "TAEAA"
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
Damage up to 92 from 80, AP value untouched.
material costs increased to 3,250 steel, 1,950 gold, and 1,885 uranium.