### PR TITLE
Look Up fix and Look Down verb

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -890,27 +890,6 @@
 	else
 		to_chat(usr, "<span class='warning'>You failed to check the pulse. Try again.</span>")
 
-/mob/living/carbon/human/verb/lookup()
-	set name = "Look up"
-	set desc = "If you want to know what's above."
-	set category = "IC"
-
-	if(!is_physically_disabled())
-		var/turf/above = GetAbove(src)
-		if(bound_overlay)
-			if(client.eye == bound_overlay)
-				reset_view(0)
-				return
-			if(istype(above, /turf/simulated/open))
-				to_chat(src, "<span class='notice'>You look up.</span>")
-				if(client)
-					reset_view(bound_overlay)
-				return
-		to_chat(src, "<span class='notice'>You can see \the [above].</span>")
-	else
-		to_chat(src, "<span class='notice'>You can't look up right now.</span>")
-	return
-
 /mob/living/carbon/human/proc/set_species(var/new_species, var/default_colour = 1)
 	if(!dna)
 		if(!new_species)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1015,7 +1015,7 @@
 			reset_view(null)
 	else
 		var/isRemoteObserve = 0
-		if(bound_overlay && client.eye == bound_overlay && !is_physically_disabled())
+		if(z_eye)
 			isRemoteObserve = 1
 		else if((mRemote in mutations) && remoteview_target)
 			if(remoteview_target.stat == CONSCIOUS)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -192,6 +192,8 @@
 	else if(eyeobj)
 		if(eyeobj.owner != src)
 			reset_view(null)
+	else if(z_eye)
+		return
 	else if(!client.adminobs)
 		reset_view(null)
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -244,13 +244,6 @@
 			set_fullscreen(eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
 			set_fullscreen(druggy, "high", /obj/screen/fullscreen/high)
 
-		if (machine)
-			if (machine.check_eye(src) < 0)
-				reset_view(null)
-		else
-			if(client && !client.adminobs)
-				reset_view(null)
-
 	return 1
 
 /mob/living/silicon/robot/handle_vision()

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -276,6 +276,48 @@
 			visible_message("<span class='warning'>[src] gives up on trying to climb onto \the [A]!</span>", "<span class='warning'>You give up on trying to climb onto \the [A]!</span>")
 		return TRUE
 
+/mob/living/verb/lookup()
+	set name = "Look Up"
+	set desc = "If you want to know what's above."
+	set category = "IC"
+
+	if(client && !is_physically_disabled())
+		if(z_eye)
+			reset_view(null)
+			qdel(z_eye)
+			z_eye = null
+			return
+		var/turf/above = GetAbove(src)
+		if(istype(above) && above.z_flags & ZM_MIMIC_BELOW)
+			z_eye = new /atom/movable/z_observer/z_up(src, src)
+			to_chat(src, "<span class='notice'>You look up.</span>")
+			reset_view(z_eye)
+			return
+		to_chat(src, "<span class='notice'>You can see \the [above ? above : "ceiling"].</span>")
+	else
+		to_chat(src, "<span class='notice'>You can't look up right now.</span>")
+
+/mob/living/verb/lookdown()
+	set name = "Look Down"
+	set desc = "If you want to know what's below."
+	set category = "IC"
+
+	if(client && !is_physically_disabled())
+		if(z_eye)
+			reset_view(null)
+			qdel(z_eye)
+			z_eye = null
+			return
+		var/turf/T = get_turf(src)
+		if(T && (T.z_flags & ZM_MIMIC_BELOW) && HasBelow(T.z) && !istype(T, /turf/simulated/wall) && !istype(T, /turf/simulated/wall))
+			z_eye = new /atom/movable/z_observer/z_down(src, src)
+			to_chat(src, "<span class='notice'>You look down.</span>")
+			reset_view(z_eye)
+			return
+		to_chat(src, "<span class='notice'>You can see \the [T ? T : "floor"].</span>")
+	else
+		to_chat(src, "<span class='notice'>You can't look below right now.</span>")
+
 /mob/living
 	var/atom/movable/z_observer/z_eye
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -309,7 +309,7 @@
 			z_eye = null
 			return
 		var/turf/T = get_turf(src)
-		if(T && (T.z_flags & ZM_MIMIC_BELOW) && HasBelow(T.z) && !istype(T, /turf/simulated/wall) && !istype(T, /turf/simulated/wall))
+		if(T && (T.z_flags & ZM_MIMIC_BELOW) && HasBelow(T.z))
 			z_eye = new /atom/movable/z_observer/z_down(src, src)
 			to_chat(src, "<span class='notice'>You look down.</span>")
 			reset_view(z_eye)

--- a/html/changelogs/DTraitor-PR-1555.yml
+++ b/html/changelogs/DTraitor-PR-1555.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: DTraitor
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added Look Down verb."
+  - bugfix: "Fixed bug when you used move up while looking up."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
### Purpose
Camera won't go higher when looking up and using move up. If there is no open space below or above you camera position will be **IMMIDEATLY** reset. Added look down verb that will help a lot.
Thanks to Nebula for this fix and look down verb: https://github.com/NebulaSS13/Nebula/pull/163