### PR TITLE
Added "+RUNTIMES" to admin verbs

### DIFF
--- a/code/__defines/admin.dm
+++ b/code/__defines/admin.dm
@@ -19,25 +19,27 @@
 #define ROUNDSTART_LOGOUT_REPORT_TIME 6000 // Amount of time (in deciseconds) after the rounds starts, that the player disconnect report is issued.
 
 // Admin permissions.
-#define R_BUILDMODE     0x1
-#define R_ADMIN         0x2
-#define R_BAN           0x4
-#define R_FUN           0x8
-#define R_SERVER        0x10
-#define R_DEBUG         0x20
-#define R_POSSESS       0x40
-#define R_PERMISSIONS   0x80
-#define R_STEALTH       0x100
-#define R_REJUVINATE    0x200
-#define R_VAREDIT       0x400
-#define R_SOUNDS        0x800
-#define R_SPAWN         0x1000
-#define R_MOD           0x2000
-#define R_MENTOR        0x4000
-#define R_HOST          0x8000 //higher than this will overflow
+#define R_DEFAULT		0x1
+#define R_RUNTIMES		0x2
+#define R_BUILDMODE     0x4
+#define R_ADMIN         0x8
+#define R_BAN           0x10
+#define R_FUN           0x20
+#define R_SERVER        0x40
+#define R_DEBUG         0x80
+#define R_POSSESS       0x100
+#define R_PERMISSIONS   0x200
+#define R_STEALTH       0x400
+#define R_REJUVINATE    0x800
+#define R_VAREDIT       0x1000
+#define R_SOUNDS        0x2000
+#define R_SPAWN         0x4000
+#define R_MOD           0x8000
+#define R_MENTOR        0x10000
+#define R_HOST          0x20000 //higher than this will overflow
 #define R_INVESTIGATE   (R_ADMIN|R_MOD)
 
-#define R_MAXPERMISSION 0x8000 // This holds the maximum value for a permission. It is used in iteration, so keep it updated.
+#define R_MAXPERMISSION 0x20000 // This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
 #define ADDANTAG_PLAYER 1	// Any player may call the add antagonist vote.
 #define ADDANTAG_ADMIN 2	// Any player with admin privilegies may call the add antagonist vote.

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -166,6 +166,8 @@
 
 // Converts a rights bitfield into a string
 /proc/rights2text(rights,seperator="")
+	if (rights & R_DEFAULT)		. += "[seperator]+DEFAULT"
+	if (rights & R_RUNTIMES)	. += "[seperator]+RUNTIMES"
 	if (rights & R_BUILDMODE)   . += "[seperator]+BUILDMODE"
 	if (rights & R_ADMIN)       . += "[seperator]+ADMIN"
 	if (rights & R_BAN)         . += "[seperator]+BAN"

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -26,6 +26,8 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 		for(var/i=2, i<=List.len, i++)
 			switch(ckey(List[i]))
 				if("@","prev")					rights |= previous_rights
+				if("default")					rights |= R_DEFAULT
+				if("runtimes")					rights |= R_RUNTIMES
 				if("buildmode","build")			rights |= R_BUILDMODE
 				if("admin")						rights |= R_ADMIN
 				if("ban")						rights |= R_BAN
@@ -37,7 +39,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 				if("stealth")					rights |= R_STEALTH
 				if("rejuv","rejuvinate")		rights |= R_REJUVINATE
 				if("varedit")					rights |= R_VAREDIT
-				if("everything","host","all")	rights |= (R_HOST | R_BUILDMODE | R_ADMIN | R_BAN | R_FUN | R_SERVER | R_DEBUG | R_PERMISSIONS | R_POSSESS | R_STEALTH | R_REJUVINATE | R_VAREDIT | R_SOUNDS | R_SPAWN | R_MOD| R_MENTOR)
+				if("everything","host","all")	rights |= (R_HOST | R_DEFAULT | R_RUNTIMES | R_BUILDMODE | R_ADMIN | R_BAN | R_FUN | R_SERVER | R_DEBUG | R_PERMISSIONS | R_POSSESS | R_STEALTH | R_REJUVINATE | R_VAREDIT | R_SOUNDS | R_SPAWN | R_MOD| R_MENTOR)
 				if("sound","sounds")			rights |= R_SOUNDS
 				if("spawn","create")			rights |= R_SPAWN
 				if("mod")						rights |= R_MOD

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -212,7 +212,6 @@ var/list/admin_verbs_debug = list(
 	/client/proc/view_chunk,
 	/client/proc/update_chunk,
 	/datum/admins/proc/capture_map,
-	/datum/admins/proc/view_runtimes,
 	/client/proc/cmd_analyse_health_context,
 	/client/proc/cmd_analyse_health_panel,
 	/client/proc/visualpower,
@@ -447,7 +446,8 @@ var/list/admin_verbs_mentor = list(
 
 /client/proc/add_admin_verbs()
 	if(holder)
-		verbs += admin_verbs_default
+		if(holder.rights & R_DEFAULT)		verbs += admin_verbs_default
+		if(holder.rights & R_RUNTIMES)		verbs += /datum/admins/proc/view_runtimes
 		if(holder.rights & R_BUILDMODE)		verbs += /client/proc/togglebuildmodeself
 		if(holder.rights & R_ADMIN)			verbs += admin_verbs_admin
 		if(holder.rights & R_BAN)			verbs += admin_verbs_ban
@@ -469,6 +469,7 @@ var/list/admin_verbs_mentor = list(
 /client/proc/remove_admin_verbs()
 	verbs.Remove(
 		admin_verbs_default,
+		/datum/admins/proc/view_runtimes,
 		/client/proc/togglebuildmodeself,
 		admin_verbs_admin,
 		admin_verbs_ban,
@@ -481,6 +482,7 @@ var/list/admin_verbs_mentor = list(
 		admin_verbs_rejuv,
 		admin_verbs_sounds,
 		admin_verbs_spawn,
+		admin_verbs_mod,
 		debug_verbs
 		)
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -502,7 +502,7 @@
 	set name = "View Runtimes"
 	set desc = "Open the Runtime Viewer"
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_RUNTIMES))
 		return
 
 	GLOB.error_cache.show_to(usr.client)

--- a/config/example/admin_ranks.txt
+++ b/config/example/admin_ranks.txt
@@ -12,6 +12,8 @@
 #            I'll be doing more moving around as feedback comes in. So be sure to check the notes after updates.
 
 # KEYWORDS:
+# +DEFAULT = gives access to default admin verbs
+# +RUNTIMES = the ability to see runtimes
 # +ADMIN = general admin tools, verbs etc
 # +FUN = events, other event-orientated actions. Access to the fun secrets in the secrets panel.
 # +BAN = the ability to ban, jobban and fullban
@@ -27,20 +29,20 @@
 # +SPAWN (or +CREATE) = mob transformations, spawning of most atoms including mobs (high-risk atoms, e.g. blackholes, will require the +FUN flag too)
 # +EVERYTHING (or +HOST or +ALL) = Simply gives you everything without having to type every flag
 
-RetiredAdmin
+RetiredAdmin +DEFAULT
 
-Moderator       +MOD
-TrialModerator  +MOD
+Moderator       +DEFAULT +MOD
+TrialModerator  +DEFAULT +MOD
 
-Mentor		+MENTOR  
+Mentor		+DEFAULT +MENTOR  
 TrialAdmin      +@ +ADMIN +STEALTH +SPAWN +REJUV +VAREDIT +BAN +SERVER
-GameAdmin       +@ +DEBUG +FUN +POSSESS +BUILDMODE +SOUND +PERMISSIONS
+GameAdmin       +@ +RUNTIMES +DEBUG +FUN +POSSESS +BUILDMODE +SOUND +PERMISSIONS
 SeniorAdmin     +@
 
 HeadDeveloper   +EVERYTHING
 HeadAdmin       +EVERYTHING
 Host            +EVERYTHING
 
-Developer       +DEBUG +VAREDIT +SERVER +SPAWN +REJUV +POSSESS +BUILDMODE +ADMIN +FUN
-TrialDevAdmin   +DEBUG +VAREDIT +SERVER +SPAWN +REJUV +POSSESS +BUILDMODE +ADMIN +STEALTH +BAN +FUN
-DevAdmin        +DEBUG +VAREDIT +SERVER +SPAWN +REJUV +POSSESS +BUILDMODE +ADMIN +STEALTH +BAN +FUN +SOUND +PERMISSIONS
+Developer       +DEFAULT +RUNTIMES +DEBUG +VAREDIT +SERVER +SPAWN +REJUV +POSSESS +BUILDMODE +ADMIN +FUN
+TrialDevAdmin  +DEFAULT +RUNTIMES +DEBUG +VAREDIT +SERVER +SPAWN +REJUV +POSSESS +BUILDMODE +ADMIN +STEALTH +BAN +FUN
+DevAdmin        +DEFAULT +RUNTIMES +DEBUG +VAREDIT +SERVER +SPAWN +REJUV +POSSESS +BUILDMODE +ADMIN +STEALTH +BAN +FUN +SOUND +PERMISSIONS


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
### Purpose
Added "+RUNTIME" and "+DEFAULT" to admin rights. First gives access to runtimes, second gives access to default admin verbs that previously were added without any rights.

### DON'T FORGET TO ADD +DEFAULT TO ALL EXISTING ADMIN RANKS AND +RUNTIMES TO ALL RANKS WITH +DEBUG AFTER MERGING!