### PR TITLE
Salvage Technician

### DIFF
--- a/code/controllers/subsystems/characters/database_persistence.dm
+++ b/code/controllers/subsystems/characters/database_persistence.dm
@@ -19,9 +19,13 @@ SUBSYSTEM_DEF(database)
 	init_order = SS_INIT_DATABASE	//Initializes before atoms
 
 
+
 	//Design caches
 	var/list/known_designs
 	var/list/unknown_designs
+
+
+	var/list/pending_schematics = list()
 
 	//A list of mind datums whose credit amounts have changed recently, and are queued for updates
 	//These are batched into one per mind per minute, as needed, to reduce database load.
@@ -37,8 +41,8 @@ SUBSYSTEM_DEF(database)
 /datum/controller/subsystem/database/Initialize()
 
 
-
-	update_store_designs()
+	log_world("Database initializing")
+	//update_store_designs()	//No point doing this here, its called from the asset system after designs are initialised
 
 
 
@@ -204,6 +208,12 @@ SUBSYSTEM_DEF(database)
 
 	//And now reload the database for individual stores
 	load_store_database()
+
+
+	//Now all thats done, if there were any schematics waiting on this moment, lets allow them to do their thing now
+	for (var/obj/item/store_schematic/SS in pending_schematics)
+		SS.get_design()
+	pending_schematics.Cut()
 
 
 

--- a/code/datums/outfits/jobs/cargo.dm
+++ b/code/datums/outfits/jobs/cargo.dm
@@ -16,3 +16,8 @@
 	name = OUTFIT_JOB_NAME("Cargo Serviceman")
 	id_type = /obj/item/weapon/card/id/holo/cargo
 	pda_type = /obj/item/modular_computer/pda/cargo
+
+/decl/hierarchy/outfit/job/cargo/salvage
+	name = OUTFIT_JOB_NAME("Salvage Technician")
+	id_type = /obj/item/weapon/card/id/holo/cargo
+	pda_type = /obj/item/modular_computer/pda/cargo

--- a/code/game/gamemodes/marker/gamemodes.dm
+++ b/code/game/gamemodes/marker/gamemodes.dm
@@ -46,7 +46,7 @@ GLOBAL_DATUM_INIT(shipsystem, /datum/ship_subsystems, new)
 	antag_templates = list(/datum/antagonist/unitologist, /datum/antagonist/earthgov_agent)
 	require_all_templates = FALSE
 	votable = FALSE
-	var/marker_setup_time = 45 MINUTES
+	var/marker_setup_time = 60 MINUTES
 	var/marker_active = FALSE
 	antag_scaling_coeff = 8
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -89,8 +89,8 @@ datum/job/so/get_description_blurb()
 	department = "Supply"
 	abbreviation = "CS"
 	department_flag = SUP
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 4
+	spawn_positions = 4
 	supervisors = "the Supply Officer"
 	selection_color = "#3b3b3b"
 	minimal_player_age = 18
@@ -112,6 +112,39 @@ datum/job/so/get_description_blurb()
 
 datum/job/serviceman/get_description_blurb()
 	return "You are a Cargo Serviceman. Your job is to haul around cargo according to the Supply Officer's whim and deliver cargo shipments to departments, if needed. You are subordinate to the Supply Officer."
+
+
+/datum/job/salvage
+	title = "Salvage Technician"
+	department = "Supply"
+	abbreviation = "ST"
+	department_flag = SUP
+	total_positions = 3
+	spawn_positions = 3
+	supervisors = "the Supply Officer"
+	selection_color = "#3b3b3b"
+	minimal_player_age = 18
+	salary	= 0	//Paid on commission only
+
+	access = list(access_cargo, access_maint_tunnels, access_external_airlocks)
+	outfit_type = /decl/hierarchy/outfit/job/cargo/serviceman
+
+	min_skill = list(   SKILL_CONSTRUCTION     = SKILL_BASIC,
+	                    SKILL_ELECTRICAL    = SKILL_BASIC,
+	                    SKILL_EVA = SKILL_BASIC)
+
+	max_skill = list(	SKILL_BOTANY      = SKILL_EXPERT,
+	                    SKILL_COOKING     = SKILL_EXPERT,
+	                    SKILL_MEDICAL     = SKILL_EXPERT,
+	                    SKILL_ANATOMY     = SKILL_ADEPT,
+	                    SKILL_FORENSICS   = SKILL_ADEPT)
+	skill_points = 15
+
+datum/job/salvage/get_description_blurb()
+	return "You are a Salvage Technician, part of CEC's reclamation project. Your job is to comb dark and abandoned areas, recovering valueable equipment. You recieve no salary, but may keep some of the things you recover\n\
+	You may enlist other cargo servicemen to help you when short staffed.\n\
+	The Ishimura is decades old and a terrible rusty mess, tread carefully."
+
 
 /datum/job/botanist
 	title = "Botanist"

--- a/code/game/objects/random/loot.dm
+++ b/code/game/objects/random/loot.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_EMPTY(loot_locations)
 	icon_state = "randomloot"
 	possible_spawns = list(/obj/random/common_loot = 74,
 				/obj/random/uncommon_loot = 20,
-				/obj/random/rare_loot = 6)
+				/obj/random/rare_loot = 6.2)
 
 /obj/random/loot/Initialize()
 	GLOB.loot_locations |= get_turf(src)
@@ -126,7 +126,7 @@ GLOBAL_LIST_EMPTY(loot_locations)
 
 /obj/random/rare_loot
 	possible_spawns = list( /obj/item/stack/power_node = 3,
-	/obj/item/store_schematic = 0.75,
+	/obj/item/store_schematic = 0.8,
 	/obj/random/material/rare = 1,
 	/obj/random/tool/modded = 1,
 	/obj/random/material/rare = 1,

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -354,6 +354,7 @@ var/decl/asset_cache/asset_cache = new()
 		SSresearch.initialize_design_file(file)
 	SSresearch.design_files_to_init = list()
 
+
 	SSdatabase.update_store_designs()
 
 

--- a/code/modules/economy/store/store_schematic.dm
+++ b/code/modules/economy/store/store_schematic.dm
@@ -60,9 +60,10 @@
 
 /obj/item/store_schematic/proc/get_design()
 
-	//If the designs aren't populated, do so
+	//If the designs aren't populated, add ourself to a pending list, we'll be back!
 	if (!SSdatabase.unknown_designs)
-		SSdatabase.update_store_designs()
+		SSdatabase.pending_schematics |= src
+		return
 
 	if (!length(SSdatabase.unknown_designs))
 		//There are no unknown designs left? We'll just have to delete ourselves

--- a/html/changelogs/salvage.yml
+++ b/html/changelogs/salvage.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a new Salvage Technician role, part of the supply department. Their job is to explore the dark corners of the ship and procure interesting equipment."
+  - experiment: "The marker now activates at approximately the 1 Hour mark. Total round time is increased as well, so necromorphs arent losing any time"
+  - bugfix: "Fixed schematics never spawning."

--- a/maps/DeadSpace/ishimura.dm
+++ b/maps/DeadSpace/ishimura.dm
@@ -86,7 +86,7 @@
 						/datum/job/sso, /datum/job/security_officer, /datum/job/smo,
 						/datum/job/md, /datum/job/surg, /datum/job/cscio, /datum/job/ra,
 						/datum/job/ce, /datum/job/tech_engineer, /datum/job/so,
-						/datum/job/serviceman, /datum/job/dom, /datum/job/foreman,
+						/datum/job/serviceman, /datum/job/salvage, /datum/job/dom, /datum/job/foreman,
 						/datum/job/planet_cracker, /datum/job/line_cook, /datum/job/bar, /datum/job/botanist
 						)
 /turf/simulated/wall


### PR DESCRIPTION
changes: 
  - rscadd: "Added a new Salvage Technician role, part of the supply department. Their job is to explore the dark corners of the ship and procure interesting equipment."
  - experiment: "The marker now activates at approximately the 1 Hour mark. Total round time is increased as well, so necromorphs arent losing any time"
  - bugfix: "Fixed schematics never spawning."