### PR TITLE
Infector Fixes I

### DIFF
--- a/code/modules/mob/living/abilities/execution/execution.dm
+++ b/code/modules/mob/living/abilities/execution/execution.dm
@@ -37,6 +37,8 @@ if (result == EXECUTION_CANCEL && can_interrupt){\
 	interrupt();\
 	return}
 
+#define EXECUTION_DAMAGE_VULNERABILITY	1.5
+
 //Execution status vars
 #define STATUS_NOT_STARTED	0
 #define STATUS_STARTING		1
@@ -77,8 +79,8 @@ if (result == EXECUTION_CANCEL && can_interrupt){\
 
 	//Stat modifiers
 	//---------------
-	//While performing an execution, the user has lower vision range and cannot evade attacks
-	statmods = list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -4)
+	//While performing an execution, the user has lower vision range, cannot evade attacks, and takes more damage from all sources
+	statmods = list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -4, STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE	=	EXECUTION_DAMAGE_VULNERABILITY)
 
 	//Aquisition vars
 	//-----------------------
@@ -172,7 +174,7 @@ if (result == EXECUTION_CANCEL && can_interrupt){\
 	Starting
 */
 /datum/extension/execution/proc/start()
-	if (!can_start())
+	if (can_start() != EXECUTION_CONTINUE)
 		stop()
 		return
 

--- a/code/modules/mob/living/abilities/shoot.dm
+++ b/code/modules/mob/living/abilities/shoot.dm
@@ -200,6 +200,7 @@
 			return FALSE
 
 	var/datum/extension/shoot/E = get_extension(src, subtype)
+
 	if(istype(E))
 		if (error_messages)
 			if (E.stopped_at)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -7,7 +7,7 @@
 
 	var/list/hud_list[10]
 	var/list/implants	//Things that are embedded in any of our organs. Nulled out when empty
-	var/obj/item/weapon/rig/wearing_rig // This is very not good, but it's much much better than calling get_rig() every update_canmove() call.
+	var/obj/item/weapon/rig/wearing_rig // This is perfectly fine
 
 	var/list/stance_limbs
 	var/list/grasp_limbs

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -35,6 +35,9 @@
 /mob/living/carbon/human/proc/get_active_grasping_limb()
 	var/numtocheck = 1 + hand //This feels hacky
 
+	if (!length(species.grasping_limbs))
+		return null
+
 	var/obj/item/organ/external/E = get_organ(species.grasping_limbs[min(species.grasping_limbs.len, numtocheck)])
 	if(!E || E.retracted || E.is_stump())
 		return null

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/head.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/head.dm
@@ -332,7 +332,7 @@
 
 
 
-	statmods = list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -4)
+	statmods = list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -4, STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE	=	EXECUTION_DAMAGE_VULNERABILITY)
 
 
 /datum/extension/execution/divider_head/safety_check()

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/conversion.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/conversion.dm
@@ -120,15 +120,15 @@
 
 /mob/living/carbon/human/get_necromorph_conversion_possibilities(var/compatibility = 1)
 	//These options are always available
-	var/list/options = list(SPECIES_NECROMORPH_SLASHER = (10 / compatibility),
+	var/list/options = list(SPECIES_NECROMORPH_SLASHER = (9.5 / compatibility),
 	SPECIES_NECROMORPH_SLASHER_ENHANCED = (1 * compatibility))
 
 	//Gender based options
 	if (gender == FEMALE)
 		options[SPECIES_NECROMORPH_SPITTER]	=	3 * compatibility
 	else
-		options[SPECIES_NECROMORPH_EXPLODER]	=	3 * compatibility
-
+		options[SPECIES_NECROMORPH_EXPLODER]	=	2.5 * compatibility
+		options[SPECIES_NECROMORPH_EXPLODER_ENHANCED]	=	0.5 * compatibility
 
 	//Future TODO: Twitcher if they had stasis
 
@@ -161,7 +161,7 @@
 			light_armor = FALSE
 
 	if (light_armor && has_organ(BP_L_LEG) && has_organ(BP_R_LEG))
-		options[SPECIES_NECROMORPH_LEAPER]	=	1 * compatibility	//Its still a pretty rare option
+		options[SPECIES_NECROMORPH_LEAPER]	=	2 * compatibility	//Its still a pretty rare option
 
 	return options
 
@@ -176,7 +176,10 @@
 		return FALSE
 
 
-
+/mob/living/carbon/human/is_necromorph_conversion_valid()
+	.=..()
+	if (!has_organ(BP_HEAD))
+		return FALSE
 
 
 //Compatibility

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/infector.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/infector.dm
@@ -6,18 +6,19 @@
 #define FLAP_COOLDOWN	(3 SECONDS)
 #define FLAP_SINGLE_WING_IMPAIRMENT	(0.4)
 
-#define INFECTOR_STING_DAMAGE	10
+#define INFECTOR_STING_DAMAGE	9
 
 /datum/species/necromorph/infector
 	name = SPECIES_NECROMORPH_INFECTOR
 	mob_type	=	/mob/living/carbon/human/necromorph/infector
 	name_plural =  "Infectors"
 	blurb = "A high value, fragile support, the Infector works as a builder and healer"
-	total_health = 150
+	total_health = 140
 
 	//Normal necromorph flags plus no slip
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_POISON  | SPECIES_FLAG_NO_BLOCK | SPECIES_FLAG_NO_SLIP
 	stability = 2
+
 
 	icon_template = 'icons/mob/necromorph/infector.dmi'
 	icon_lying = "_lying"
@@ -39,6 +40,8 @@
 	bump_flag 	= SIMPLE_ANIMAL	// Quadrupedal and physically weak
 	push_flags 	= ALLMOBS	// What can we push?
 	swap_flags 	= ALLMOBS	// What can we swap place with?
+	can_pull_mobs = MOB_PULL_SMALLER
+	can_pull_size = ITEM_SIZE_NORMAL
 	evasion = 10
 	reach = 2
 
@@ -60,7 +63,7 @@
 
 	unarmed_types = list(/datum/unarmed_attack/proboscis)
 
-	slowdown = 5 //Note, this is a terribly awful way to do speed, bay's entire speed code needs redesigned
+	slowdown = 5.5 //Note, this is a terribly awful way to do speed, bay's entire speed code needs redesigned
 
 	//Vision
 	view_range = 10
@@ -74,7 +77,7 @@
 
 	locomotion_limbs = list(BP_R_ARM, BP_L_ARM)
 
-	grasping_limbs = list(BP_R_ARM, BP_L_ARM)
+	grasping_limbs = list()	//It has no grasping limbs, it cannot grab or pull anything
 
 	has_organ = list(    // which required-organ checks are conducted.
 	BP_HEART =    /obj/item/organ/internal/heart/undead,
@@ -236,7 +239,7 @@ All of them except New Growth require corruption to build upon\
 	attack_sound = list('sound/effects/attacks/whip_1.ogg', 'sound/effects/attacks/whip_2.ogg','sound/effects/attacks/whip_3.ogg','sound/effects/attacks/whip_4.ogg',)
 
 	damage = INFECTOR_STING_DAMAGE
-	armor_penetration = 10
+	armor_penetration = 5
 	delay = 4 SECONDS	//Long delay makes for low DPS, this is a hit and run thing
 
 	required_limb = list(BP_HEAD)
@@ -278,11 +281,6 @@ All of them except New Growth require corruption to build upon\
 
 	face_atom(A)
 
-	//Shared cooldown
-	var/datum/extension/shoot/longshot/LS = get_extension(src, /datum/extension/shoot/longshot)
-	if (LS && (world.time - LS.started_at) < SHARED_COOLDOWN_SHOT)
-		return
-
 	.= shoot_ability(/datum/extension/shoot/longshot/spine, A , /obj/item/projectile/bullet/spine/venomous, accuracy = 50, dispersion = 0, num = 1, windup_time = 0 SECONDS, fire_sound = null, cooldown = 10 SECONDS)
 	if (.)
 		play_species_audio(src, SOUND_ATTACK, VOLUME_MID, 1, 3)
@@ -295,7 +293,7 @@ All of them except New Growth require corruption to build upon\
 
 /datum/extension/shoot/longshot/spine
 	name = "Sting"
-	base_type = /datum/extension/shoot/longshot
+	base_type = /datum/extension/shoot/longshot/spine
 
 /*--------------------------------
 	Flap

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/parasite_leap.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/parasite_leap.dm
@@ -103,8 +103,8 @@
 	cooldown = 60 SECONDS
 	base_type	=	/datum/extension/execution/infector
 	require_grab = FALSE
-	reward_biomass = 10
-	reward_energy = 100
+	reward_biomass = 0
+	reward_energy = 80
 	reward_heal = 0
 	range = 0
 	all_stages = list(/datum/execution_stage/wingwrap,
@@ -114,7 +114,6 @@
 
 	weapon_check = /datum/extension/execution/proc/weapon_check_organ
 
-	statmods = list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -4)
 
 /datum/extension/execution/infector/can_start()
 	.=..()
@@ -124,6 +123,13 @@
 
 	//Now in addition
 
+	//Can't target necros
+	if (victim.is_necromorph())
+		world << "Victim is necromorph"
+		return EXECUTION_CANCEL
+	else
+		world << "Victim is not necromorph"
+
 	//The target must have a head for us to penetrate
 	if (!victim.get_organ(BP_HEAD))
 		return EXECUTION_CANCEL
@@ -132,6 +138,14 @@
 	if (victim.lying)
 		return EXECUTION_CANCEL
 
+
+	//To prevent stacking, there must be no other infectors in the victim's turf
+	for (var/mob/living/carbon/human/H in get_turf(victim))
+		if (H == victim || H == user)
+			continue
+
+		if (istype(H.species, /datum/species/necromorph/infector))
+			return EXECUTION_CANCEL
 
 
 /datum/extension/execution/infector/safety_check()

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/parasite_leap.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/parasite_leap.dm
@@ -125,10 +125,7 @@
 
 	//Can't target necros
 	if (victim.is_necromorph())
-		world << "Victim is necromorph"
 		return EXECUTION_CANCEL
-	else
-		world << "Victim is not necromorph"
 
 	//The target must have a head for us to penetrate
 	if (!victim.get_organ(BP_HEAD))

--- a/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
@@ -639,7 +639,7 @@ If performed successfully on a live crewman, it yields a bonus of 10kg biomass f
 	/datum/execution_stage/tripod_bisect)
 
 
-	statmods = 	list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -6)
+	statmods = 	list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -6, STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE	=	EXECUTION_DAMAGE_VULNERABILITY)
 
 
 /datum/extension/execution/tripod_kiss/interrupt()

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -67,6 +67,8 @@
 
 	var/mob_size	= MOB_MEDIUM
 	var/strength    = STR_MEDIUM
+	var/can_pull_mobs = MOB_PULL_SAME
+	var/can_pull_size = ITEM_SIZE_NO_CONTAINER
 	var/show_ssd = "fast asleep"
 	var/virus_immune
 	var/biomass	=	80	//How much biomass does it cost to spawn this (for necros) and how much does it yield when absorbed by a marker
@@ -456,6 +458,8 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 
 	H.mob_size = mob_size
+	H.can_pull_mobs = src.can_pull_mobs
+	H.can_pull_size = src.can_pull_size
 	H.mass = src.mass
 	H.biomass = src.biomass
 	for(var/obj/item/organ/organ in H.contents)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -113,9 +113,10 @@
 	src.updatehealth()
 
 //Heals a total number of points of all types of damage. Not divided equally, but done in order
-/mob/living/proc/heal_quantified_damage(var/total, var/brute = TRUE, var/fire = TRUE, var/tox = FALSE)
+//Returns the unused number of points, if any
+/mob/living/proc/heal_quantified_damage(var/total, var/brute = TRUE, var/fire = TRUE, var/tox = FALSE, var/lasting = FALSE)
 	if (total <= 0)
-		return
+		return 0
 
 	if (brute)
 		var/heal_amount = min(total, getBruteLoss())
@@ -123,7 +124,7 @@
 		total -= heal_amount
 
 	if (total <= 0)
-		return
+		return 0
 
 	if (fire)
 		var/heal_amount = min(total, getFireLoss())
@@ -131,13 +132,22 @@
 		total -= heal_amount
 
 	if (total <= 0)
-		return
+		return 0
 
 	if (tox)
 		var/heal_amount = min(total, getToxLoss())
 		adjustToxLoss(-heal_amount)
 		total -= heal_amount
+		
+	if (total <= 0)
+		return 0
 
+	if (lasting)
+		var/heal_amount = min(total, getLastingDamage())
+		adjustLastingDamage(-heal_amount)
+		total -= heal_amount
+
+	return total
 
 /mob/living/proc/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/unitology/blade.dm
+++ b/code/modules/unitology/blade.dm
@@ -78,7 +78,7 @@
 	reward_heal = 0
 	start_range = 7
 
-	statmods = list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -2)
+	statmods = list(STATMOD_EVASION = -100, STATMOD_VIEW_RANGE = -2, STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE	=	EXECUTION_DAMAGE_VULNERABILITY)
 
 	all_stages = list(/datum/execution_stage/approach,
 	/datum/execution_stage/cover_mouth,

--- a/html/changelogs/infector.yml
+++ b/html/changelogs/infector.yml
@@ -33,6 +33,11 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - experiment: "Added the Infector, a complex new support necromorph with abilities to convert humans, construct corruption nodes, heal and buff other necromorphs."
-  - rscadd: "Added necrotoxin, a poison that converts its victims into necromorphs if it kills them. Necrotoxin is applied by all infector attacks."
-  - tweak: "Reworked chemical metabolism rates. The base rate is a bit slower, but now chemicals metabolize faster, the larger the quantity is in a patient's system."
+  - experiment: "All mobs now take 50% more damage from all sources while they are performing an execution. Its a vulnerable time for others to get you while your back is turned!"
+  - tweak: "Reduced the infector's movespeed, max health, and melee damage+armorpen."
+  - tweak: "Infector can no longer grapple or pull humans. It has no limbs to do so!"
+  - tweak: "Mend can now heal Lasting Damage."
+  - bugfix: "Fixed infector spine shot having no cooldown."
+  - bugfix: "Parasite Leap can no longer hit other necromorphs."
+  - bugfix: "Fixed being able to reanimate headless corpses."
+  - bugfix: "Engorge can no longer be used again on already enlarged targets."

--- a/html/changelogs/infectorfixes.yml
+++ b/html/changelogs/infectorfixes.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "All mobs now take 50% more damage from all sources while they are performing an execution. Its a vulnerable time for others to get you while your back is turned!"
+  - tweak: "Reduced the infector's movespeed, max health, and melee damage+armorpen."
+  - tweak: "Infector can no longer grapple or pull humans. It has no limbs to do so!"
+  - tweak: "Mend can now heal Lasting Damage."
+  - bugfix: "Fixed infector spine shot having no cooldown."
+  - bugfix: "Parasite Leap can no longer hit other necromorphs."
+  - bugfix: "Fixed being able to reanimate headless corpses."
+  - bugfix: "Engorge can no longer be used again on already enlarged targets."


### PR DESCRIPTION
changes: 
  - experiment: "All mobs now take 50% more damage from all sources while they are performing an execution. Its a vulnerable time for others to get you while your back is turned!"
  - tweak: "Reduced the infector's movespeed, max health, and melee damage+armorpen."
  - tweak: "Infector can no longer grapple or pull humans. It has no limbs to do so!"
  - tweak: "Mend can now heal Lasting Damage."
  - bugfix: "Fixed infector spine shot having no cooldown."
  - bugfix: "Parasite Leap can no longer hit other necromorphs."
  - bugfix: "Fixed being able to reanimate headless corpses."
  - bugfix: "Engorge can no longer be used again on already enlarged targets."