### PR TITLE
Exploder fixes

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -265,59 +265,60 @@
 /obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
 	add_fingerprint(user, 0, I)
 
-	if(istype(I, /obj/item/stack/material) && I.get_material_name() == get_material_name())
-		if(stat & BROKEN)
-			to_chat(user, "<span class='notice'>It looks like \the [src] is pretty busted. It's going to need more than just patching up now.</span>")
-			return
-		if(health >= max_health)
-			to_chat(user, "<span class='notice'>Nothing to fix!</span>")
-			return
-		if(!density)
-			to_chat(user, "<span class='warning'>\The [src] must be closed before you can repair it.</span>")
-			return
+	if (istype(I, /obj/item))
+		if(istype(I, /obj/item/stack/material) && I.get_material_name() == get_material_name())
+			if(stat & BROKEN)
+				to_chat(user, "<span class='notice'>It looks like \the [src] is pretty busted. It's going to need more than just patching up now.</span>")
+				return
+			if(health >= max_health)
+				to_chat(user, "<span class='notice'>Nothing to fix!</span>")
+				return
+			if(!density)
+				to_chat(user, "<span class='warning'>\The [src] must be closed before you can repair it.</span>")
+				return
 
-		//figure out how much metal we need
-		var/amount_needed = (max_health - health) / DOOR_REPAIR_AMOUNT
-		amount_needed = ceil(amount_needed)
+			//figure out how much metal we need
+			var/amount_needed = (max_health - health) / DOOR_REPAIR_AMOUNT
+			amount_needed = ceil(amount_needed)
 
-		var/obj/item/stack/stack = I
-		var/transfer
-		if (repairing)
-			transfer = stack.transfer_to(repairing, amount_needed - repairing.amount)
-			if (!transfer)
-				to_chat(user, "<span class='warning'>You must weld or remove \the [repairing] from \the [src] before you can add anything else.</span>")
-		else
-			repairing = stack.split(amount_needed, force=TRUE)
+			var/obj/item/stack/stack = I
+			var/transfer
 			if (repairing)
-				repairing.loc = src
-				transfer = repairing.amount
-				repairing.uses_charge = FALSE //for clean robot door repair - stacks hint immortal if true
+				transfer = stack.transfer_to(repairing, amount_needed - repairing.amount)
+				if (!transfer)
+					to_chat(user, "<span class='warning'>You must weld or remove \the [repairing] from \the [src] before you can add anything else.</span>")
+			else
+				repairing = stack.split(amount_needed, force=TRUE)
+				if (repairing)
+					repairing.loc = src
+					transfer = repairing.amount
+					repairing.uses_charge = FALSE //for clean robot door repair - stacks hint immortal if true
 
-		if (transfer)
-			to_chat(user, "<span class='notice'>You fit [transfer] [stack.singular_name]\s to damaged and broken parts on \the [src].</span>")
+			if (transfer)
+				to_chat(user, "<span class='notice'>You fit [transfer] [stack.singular_name]\s to damaged and broken parts on \the [src].</span>")
 
-		return
-
-	if(repairing && isWelder(I))
-		if(!density)
-			to_chat(user, "<span class='warning'>\The [src] must be closed before you can repair it.</span>")
 			return
 
-		to_chat(user, "<span class='notice'>You start to fix dents and weld \the [repairing] into place.</span>")
-		if(I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_WELDING, FAILCHANCE_NORMAL))
-			to_chat(user, "<span class='notice'>You finish repairing the damage to \the [src].</span>")
-			health = between(health, health + repairing.amount*DOOR_REPAIR_AMOUNT, max_health)
-			update_icon()
-			qdel(repairing)
-			repairing = null
-		return
+		if(repairing && isWelder(I))
+			if(!density)
+				to_chat(user, "<span class='warning'>\The [src] must be closed before you can repair it.</span>")
+				return
 
-	if(repairing && isCrowbar(I))
-		to_chat(user, "<span class='notice'>You remove \the [repairing].</span>")
-		playsound(loc, 'sound/items/Crowbar.ogg', 100, 1)
-		repairing.loc = user.loc
-		repairing = null
-		return
+			to_chat(user, "<span class='notice'>You start to fix dents and weld \the [repairing] into place.</span>")
+			if(I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_WELDING, FAILCHANCE_NORMAL))
+				to_chat(user, "<span class='notice'>You finish repairing the damage to \the [src].</span>")
+				health = between(health, health + repairing.amount*DOOR_REPAIR_AMOUNT, max_health)
+				update_icon()
+				qdel(repairing)
+				repairing = null
+			return
+
+		if(repairing && isCrowbar(I))
+			to_chat(user, "<span class='notice'>You remove \the [repairing].</span>")
+			playsound(loc, 'sound/items/Crowbar.ogg', 100, 1)
+			repairing.loc = user.loc
+			repairing = null
+			return
 
 	if(check_force(I, user))
 		return

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -27,7 +27,8 @@
 
 	//If not null, this piece of clothing belongs to a rig frame
 	var/obj/item/weapon/rig/rig
-
+	acid_resistance = 1.2
+	max_health = 150
 
 // Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/clothing/proc/update_clothing_icon()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -474,8 +474,8 @@ This function restores all organs.
 				//user.throw_at(target, 200, 4)
 
 		if (2.0)
-			b_loss = 60
-			f_loss = 60
+			b_loss = 70
+			f_loss = 70
 
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				adjust_ear_damage(30, 20)
@@ -483,7 +483,8 @@ This function restores all organs.
 				Paralyse(3)
 
 		if(3.0)
-			b_loss = 30
+			b_loss = 35
+			f_loss = 35
 			if (!istype(l_ear, /obj/item/clothing/ears/earmuffs) && !istype(r_ear, /obj/item/clothing/ears/earmuffs))
 				adjust_ear_damage(15, 15)
 			if (prob(50))
@@ -494,13 +495,13 @@ This function restores all organs.
 	b_loss *= protection
 	f_loss *= protection
 
-	// focus most of the blast on one organ
+	// focus the largest part of the blast on one organ
 	var/obj/item/organ/external/take_blast = pick(organs)
-	take_blast.take_external_damage(b_loss * 0.7, f_loss * 0.7, used_weapon = "Explosive blast")
+	take_blast.take_external_damage(b_loss * 0.6, f_loss * 0.6, used_weapon = "Explosive blast")
 
-	// distribute the remaining 30% on all limbs equally (including the one already dealt damage)
-	b_loss *= 0.3
-	f_loss *= 0.3
+	// distribute the remaining 40% on all limbs equally (including the one already dealt damage)
+	b_loss *= 0.4
+	f_loss *= 0.4
 
 	for(var/obj/item/organ/external/temp in organs)
 		var/loss_val

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder/enhanced.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder/enhanced.dm
@@ -6,6 +6,7 @@
 	unarmed_types = list(/datum/unarmed_attack/bite/weak/exploder) //Bite attack is a backup if blades are severed
 	total_health = 215	//It has high health for the sake of making it a bit harder to destroy without targeting the pustule. Exploding the pustule is always an instakill
 	limb_health_factor = 1.5
+	require_total_biomass	=	BIOMASS_REQ_T2
 	biomass = 165
 	mass = 80
 	view_range = 8
@@ -80,7 +81,7 @@ A successful charge is the most effective and reliable way to detonate. It shoul
 The last resort. The exploder screams and shakes violently for 3 seconds, before detonating the pustule.<br>\
  This is quite telegraphed and it can give your victims time to back away before the explosion. Not the most ideal way to detonate, but it can be a viable backup if you fail to hit something with charge."
 
-/datum/species/necromorph/exploder/get_ability_descriptions()
+/datum/species/necromorph/exploder/enhanced/get_ability_descriptions()
 	.= ""
 	. += EXPLODER_ENHANCED_PASSIVE
 	. += "<hr>"
@@ -124,23 +125,23 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 	The actual explosion!
 */
 //A multi-level explosion using a broad variety of cool mechanics
-/obj/item/organ/external/exploder_pustule/enhanced/explode()
+/obj/item/organ/external/exploder_pustule/enhanced/do_explode()
 	var/turf/T = get_turf(src)
 	var/target = pick(view(1, src))	//Pick literally anything as target, it doesnt matter. We just need something to avoid runtimes
+
+	fragmentate(T, fragment_number = 50, spreading_range = 5, fragtypes=list(/obj/item/projectile/bullet/pellet/fragment/rivet))
 	.=..()
-	if (.)
+	//True return means an explosion is happening
+	spawn(1)
 
-		//True return means an explosion is happening
-		spawn(1)
+		T.spray_ability(subtype = /datum/extension/spray/flame/radial,  target = target, angle = 360, length = 4, duration = 2 SECONDS, extra_data = list("temperature" = (T0C + 2800)), affect_origin = TRUE)
 
-			T.spray_ability(subtype = /datum/extension/spray/flame/radial,  target = target, angle = 360, length = 4, duration = 2 SECONDS, extra_data = list("temperature" = (T0C + 2600)))
+	spawn(2)
 
-		spawn(2)
-
-			T.spray_ability(subtype = /datum/extension/spray/reagent,  target = target, angle = 360, length = 4, duration = 2 SECONDS, extra_data = list("reagent" = /datum/reagent/acid/necromorph, "volume" = 30))
+		T.spray_ability(subtype = /datum/extension/spray/reagent,  target = target, angle = 360, length = 4, duration = 2 SECONDS, extra_data = list("reagent" = /datum/reagent/acid/necromorph, "volume" = 30), affect_origin = TRUE)
 
 
-		fragmentate(T, fragment_number = 50, spreading_range = 5, fragtypes=list(/obj/item/projectile/bullet/pellet/fragment/rivet))
+
 
 
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder/exploder.dm
@@ -21,7 +21,7 @@
 	icon_lying = "_lying"
 	pixel_offset_x = -8
 	single_icon = FALSE
-	evasion = 10	//Awkward movemetn makes it a tricky target
+	evasion = 5	//Awkward movemetn makes it a tricky target
 	spawner_spawnable = TRUE
 	virus_immune = 1
 
@@ -232,6 +232,7 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 	defensive_group = null
 	light_color = COLOR_NECRO_YELLOW
 	var/exploded = FALSE
+	base_miss_chance = -10
 
 /obj/item/organ/external/exploder_pustule/hand
 	organ_tag = BP_L_HAND
@@ -265,11 +266,16 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 /obj/item/organ/external/exploder_pustule/proc/explode()
 	if (exploded)
 		return
-
 	exploded = TRUE
+	do_explode()
 
+
+/obj/item/organ/external/exploder_pustule/proc/do_explode()
 
 	var/turf/T = get_turf(src)
+	link_necromorphs_to(SPAN_NOTICE("Exploder Exploding at LINK"), T)
+
+
 	//A bioblast, dealing some burn and acid damage
 	spawn()
 		bioblast(epicentre = T,
@@ -442,7 +448,6 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 */
 /datum/species/necromorph/exploder/charge_impact(var/datum/extension/charge/charge)
 	var/mob/living/carbon/human/charger = charge.user
-
 	if (isliving(charge.last_obstacle))
 		//Make sure its still there
 		var/mob/living/L = charge.last_obstacle
@@ -455,9 +460,8 @@ The last resort. The exploder screams and shakes violently for 3 seconds, before
 			charger.forceMove(get_turf(charge.last_obstacle))	//Move ontop of them for maximum damage
 
 
-		var/obj/item/organ/external/exploder_pustule/E = charger.get_organ(BP_L_HAND)
+		var/obj/item/organ/external/exploder_pustule/E = charger.get_organ_by_type(/obj/item/organ/external/exploder_pustule)
 		if (istype(E))
-
 			E.explode()	//Kaboom!
 
 		return FALSE

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -12,6 +12,14 @@
 	anchored = TRUE
 	obj_flags = OBJ_FLAG_NOFALL
 
+	/*
+		Planned future todo: Allow stairs and ladders to be damaged and enter a broken state,  which makes them much slower and harder to climb
+		And from which they can be repaired with materials or tools to return to normalcy
+
+		For now though, just making them indestructible because deleting stairs is no fun
+	*/
+	atom_flags = ATOM_FLAG_INDESTRUCTIBLE
+
 	var/allowed_directions = DOWN
 	var/obj/structure/ladder/target_up
 	var/obj/structure/ladder/target_down
@@ -31,6 +39,8 @@
 				T.ReplaceWithLattice()
 				return
 	update_icon()
+
+
 
 /obj/structure/ladder/Destroy()
 	if(target_down)
@@ -209,6 +219,15 @@
 	opacity = FALSE
 	anchored = TRUE
 	layer = RUNE_LAYER
+
+	/*
+		Planned future todo: Allow stairs and ladders to be damaged and enter a broken state,  which makes them much slower and harder to climb
+		And from which they can be repaired with materials or tools to return to normalcy
+
+		For now though, just making them indestructible because deleting stairs is no fun
+	*/
+	atom_flags = ATOM_FLAG_INDESTRUCTIBLE
+
 
 /obj/structure/stairs/Initialize()
 	for(var/turf/turf in locs)

--- a/code/modules/projectiles/guns/ds13/divet.dm
+++ b/code/modules/projectiles/guns/ds13/divet.dm
@@ -153,5 +153,5 @@ Projectile logic
 		T = get_turf(target)
 	spawn()
 
-		T.spray_ability(subtype = /datum/extension/spray/flame/radial,  target = target, angle = 360, length = 2, duration = 1.2 SECONDS, extra_data = list("temperature" = (T0C + 2600)))
+		T.spray_ability(subtype = /datum/extension/spray/flame/radial,  target = target, angle = 360, length = 2, duration = 1.2 SECONDS, extra_data = list("temperature" = (T0C + 2600)), affect_origin = TRUE)
 	. = ..()

--- a/code/modules/projectiles/guns/ds13/flamethrower.dm
+++ b/code/modules/projectiles/guns/ds13/flamethrower.dm
@@ -604,5 +604,5 @@
 		var/turf/T = get_turf(src)
 
 		//We trigger the spray on the turf, because this object is about to be deleted
-		T.spray_ability(subtype = spraytype,  target = null, angle = 360, length = 3, duration = 3 SECONDS, extra_data = list("temperature" = temperature))
+		T.spray_ability(subtype = spraytype,  target = null, angle = 360, length = 3, duration = 3 SECONDS, extra_data = list("temperature" = temperature), affect_origin = TRUE)
 		expire()

--- a/code/modules/projectiles/guns/ds13/rivet_gun.dm
+++ b/code/modules/projectiles/guns/ds13/rivet_gun.dm
@@ -241,7 +241,7 @@
 	Fragmentation
 */
 /obj/item/projectile/bullet/pellet/fragment/rivet
-	damage = 2.5
+	damage = 3
 	range_step = 3 //controls damage falloff with distance. projectiles lose a "pellet" each time they travel this distance. Can be a non-integer.
 
 	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone

--- a/code/modules/reagents/Chemistry-Reagents/acid.dm
+++ b/code/modules/reagents/Chemistry-Reagents/acid.dm
@@ -6,7 +6,7 @@
 	color = "#db5008"
 	metabolism = REM * 2
 	touch_met = 50 // It's acid!
-	var/power = 0.7
+	var/power = 0.9
 	var/meltdose = 23 // How much is needed to melt
 
 /datum/reagent/acid/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)

--- a/html/changelogs/exploder_enhanced.yml
+++ b/html/changelogs/exploder_enhanced.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: Nanako
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Exploder now detonates when charging into people again."
+  - bugfix: "Spray explosions now affect their origin tile. This change affects divet incendiary ammo, hydrazine torch secondary fire, and effects on enhanced exploder."
+  - bugfix: "Stairs and ladders can no longer be destroyed by explosions."
+  - bugfix: "Fixed enhanced exploder having incorrect ability descriptions."
+  - bugfix: "Fixed enhanced exploder being spawnable before the T2 biomass threshold is reached."
+  - tweak: "Slightly buffed the damage of the rivet gun's shrapnel"
+  - tweak: "Reduced the miss chance on exploder pustules so they should be easier to shoot."
+  - tweak: "Biological acid is now more powerful against flesh. Clothes have been given buffs to health and acid resistance to compensate so they should get melted less often"
+  - tweak: "Increased the damage of explosions on humans, and spread that damage out more across the body"


### PR DESCRIPTION
changes: 
  - bugfix: "Exploder now detonates when charging into people again."
  - bugfix: "Spray explosions now affect their origin tile. This change affects divet incendiary ammo, hydrazine torch secondary fire, and effects on enhanced exploder."
  - bugfix: "Stairs and ladders can no longer be destroyed by explosions."
  - bugfix: "Fixed enhanced exploder having incorrect ability descriptions."
  - bugfix: "Fixed enhanced exploder being spawnable before the T2 biomass threshold is reached."
  - tweak: "Slightly buffed the damage of the rivet gun's shrapnel"
  - tweak: "Reduced the miss chance on exploder pustules so they should be easier to shoot."
  - tweak: "Biological acid is now more powerful against flesh. Clothes have been given buffs to health and acid resistance to compensate so they should get melted less often"
  - tweak: "Increased the damage of explosions on humans, and spread that damage out more across the body"


Closes #518 
Closes #1616 
Closes #1614
Closes #1604 