### PR TITLE
Movement Optimisation: Movement Handlers Part 1

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -27,7 +27,7 @@
 
 //Update this whenever the byond version is stable so people stop updating to hilariously broken versions
 #define MAX_COMPILER_VERSION 514
-#define MAX_COMPILER_BUILD 1562
+#define MAX_COMPILER_BUILD 1566
 #if DM_VERSION > MAX_COMPILER_VERSION || DM_BUILD > MAX_COMPILER_BUILD
 #warn WARNING! your byond version is over the recommended version(MAX_COMPILER_VERSION:MAX_COMPILER_BUILD)! There may be unexpected byond bugs!
 #endif

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -359,7 +359,10 @@
 /mob/proc/get_stamina()
 	return 100
 
-// Movement relayed to self handling
+/* Movement relayed to self handling
+Note: Removed from mobs because it is not currently used, nothing in the codebase ever adds an allowed mover
+If this is needed in future, add new datum procs for adding allowed movers, and add/remove the handler only when it actually has an allowed mover to relay to
+*/
 /datum/movement_handler/mob/relayed_movement
 	var/prevent_host_move = FALSE
 	var/list/allowed_movers

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -397,7 +397,7 @@
 // Death handling
 /datum/movement_handler/mob/death/DoMove()
 	if(mob.stat != DEAD)
-		return
+		return MOVEMENT_REMOVE
 	. = MOVEMENT_HANDLED
 	if(!mob.client)
 		return

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -458,7 +458,7 @@ If this is needed in future, add new datum procs for adding allowed movers, and 
 	if(is_external)
 		return MOVEMENT_PROCEED
 	if(!mob.eyeobj)
-		return MOVEMENT_PROCEED
+		return MOVEMENT_REMOVE
 	return (MOVEMENT_PROCEED|MOVEMENT_HANDLED)
 
 // Space movement
@@ -554,7 +554,10 @@ If this is needed in future, add new datum procs for adding allowed movers, and 
 /datum/movement_handler/mob/transformation/MayMove()
 	return MOVEMENT_STOP
 
-// Consciousness - Is the entity trying to conduct the move conscious?
+/* Consciousness - Is the entity trying to conduct the move conscious?
+	Disabled as it is currently not useful, we have no entities which can remotely control a mob and themselves fall unconscious
+	If this is re-enabled in future, add it only when such an entity is controlling
+*/
 /datum/movement_handler/mob/conscious/MayMove(var/mob/mover)
 	return (mover ? mover.stat == CONSCIOUS : mob.stat == CONSCIOUS) ? MOVEMENT_PROCEED : MOVEMENT_STOP
 

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -480,6 +480,9 @@
 
 // Buckle movement
 /datum/movement_handler/mob/buckle_relay/DoMove(var/direction, var/mover)
+	if (!mob.buckled)
+		return MOVEMENT_REMOVE
+
 	// TODO: Datumlize buckle-handling
 	if(istype(mob.buckled, /obj/vehicle))
 		//drunk driving
@@ -542,16 +545,7 @@
 /datum/movement_handler/mob/delay/proc/ResetDelay()
 	next_move = world.time - 1
 
-// Stop effect
-/datum/movement_handler/mob/stop_effect/DoMove()
-	if(MayMove() == MOVEMENT_STOP)
-		return MOVEMENT_HANDLED
 
-/datum/movement_handler/mob/stop_effect/MayMove()
-	for(var/obj/effect/stop/S in mob.loc)
-		if(S.victim == mob)
-			return MOVEMENT_STOP
-	return MOVEMENT_PROCEED
 
 // Transformation
 /datum/movement_handler/mob/transformation/MayMove()

--- a/code/datums/movement/movement.dm
+++ b/code/datums/movement/movement.dm
@@ -21,13 +21,11 @@ var/const/MOVEMENT_STOP    = 0x0008
 		var/datum/movement_handler/movement_handler = mh
 		if(movement_handler.MayMove(mover, is_external) & MOVEMENT_STOP)
 			return MOVEMENT_HANDLED
-
 		. = movement_handler.DoMove(direction, mover, is_external)
 		if(. & MOVEMENT_REMOVE)
-
 			REMOVE_AND_QDEL(movement_handler)
-		if(. & MOVEMENT_HANDLED)
 
+		if(. & MOVEMENT_HANDLED)
 			return
 
 // is_external means that something else (not inside us) is asking if we may move

--- a/code/game/machinery/asteroid_cannon/ads_cannon.dm
+++ b/code/game/machinery/asteroid_cannon/ads_cannon.dm
@@ -28,7 +28,7 @@ You'll need two people to do this, one to man the gun while it goes down, one to
 	light_color="#ff0000" //Glows red when it's out of commission...
 	health = 200
 	max_health = 200 //Takes a lot of effort to take out.
-	layer = ABOVE_OBJ_LAYER
+	layer = ABOVE_WINDOW_LAYER
 	atom_flags = ATOM_FLAG_INDESTRUCTIBLE
 	var/lead_distance = 0 //How aggressively to lead each shot. If set to 0 the bullets become hitscan.
 	var/bullet_origin_offset = 3 //+/-x. Offsets the bullet so it can shoot "through the wall" to more closely mirror the source material's gun.

--- a/code/game/machinery/asteroid_cannon/ads_extension.dm
+++ b/code/game/machinery/asteroid_cannon/ads_extension.dm
@@ -87,9 +87,9 @@
 	//gunner.vis_flags |= VIS_INHERIT_ID
 	//gun.vis_contents += gunner
 	gun.lead_distance = 1 //Gunners don't get hitscan...
-	eyeobj = new /mob/dead/observer/eye/turret(get_turf(gun))
-	eyeobj.acceleration = FALSE
-	eyeobj.possess(gunner, gun)	//Pass in the gun with possess
+	gunner.set_eyeobj(new /mob/dead/observer/eye/turret(get_turf(gun)))
+	gunner.eyeobj.acceleration = FALSE
+	gunner.eyeobj.possess(gunner, gun)	//Pass in the gun with possess
 
 	wake_up()
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -37,6 +37,7 @@
 		if(M != src && C.incapacitated())
 			return 0
 
+	M.AddMovementHandler(/datum/movement_handler/mob/buckle_relay, /datum/movement_handler/mob/delay)
 	M.buckled = src
 	M.facing_dir = null
 	M.set_dir(buckle_dir ? buckle_dir : dir)

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -7,11 +7,6 @@
 	density = 1
 	anchored = 0
 
-/obj/effect/stop
-	var/victim = null
-	icon_state = "empty"
-	name = "Geas"
-	desc = "You can't resist."
 
 //Paints the wall it spawns on, then dies
 /obj/effect/paint

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1459,11 +1459,7 @@
 		log_admin("[key_name(M)] has been hit by Bluespace Artillery fired by [src.owner]")
 		message_admins("[key_name(M)] has been hit by Bluespace Artillery fired by [src.owner]")
 
-		var/obj/effect/stop/S
-		S = new /obj/effect/stop(M.loc)
-		S.victim = M
-		spawn(20)
-			qdel(S)
+
 
 		var/turf/simulated/floor/T = get_turf(M)
 		if(istype(T))

--- a/code/modules/mob/dead/observer/freelook/ai/eye.dm
+++ b/code/modules/mob/dead/observer/freelook/ai/eye.dm
@@ -61,7 +61,7 @@
 /mob/living/silicon/ai/proc/create_eyeobj(var/newloc)
 	if(eyeobj) destroy_eyeobj()
 	if(!newloc) newloc = get_turf(src)
-	eyeobj = new /mob/dead/observer/eye/aiEye(newloc)
+	set_eyeobj(new /mob/dead/observer/eye/aiEye(newloc))
 	eyeobj.possess(src)
 
 // Intiliaze the eye by assigning it's "ai" variable to us. Then set it's loc to us.

--- a/code/modules/mob/dead/observer/freelook/eye.dm
+++ b/code/modules/mob/dead/observer/freelook/eye.dm
@@ -54,7 +54,7 @@
 	if(owner && owner.eyeobj != src)
 		return
 	owner = user
-	owner.eyeobj = src
+	owner.set_eyeobj(src)
 	SetName("[owner.name] ([name_sufix])") // Update its name
 	if(owner.client)
 		owner.client.eye = src

--- a/code/modules/mob/dead/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/dead/observer/freelook/marker/signal.dm
@@ -42,6 +42,10 @@ GLOBAL_LIST_INIT(signal_sprites, list("markersignal-1",
 		/datum/movement_handler/mob/incorporeal/eye
 	)
 
+/mob/dead/observer/eye/signal/set_eyeobj(var/atom/new_eye)
+	eyeobj = new_eye
+	//No messing with movement handlers here
+
 
 /mob/dead/observer/eye/signal/is_necromorph()
 	return TRUE

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -69,6 +69,8 @@
 	drop_r_hand()
 	drop_l_hand()
 
+	AddMovementHandler(/datum/movement_handler/mob/death)
+
 	//TODO:  Change death state to health_dead for all these icon files.  This is a stop gap.
 
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -11,12 +11,10 @@
 	virtual_mob = /mob/dead/observer/virtual/mob
 
 	movement_handlers = list(
-		/datum/movement_handler/mob/conscious,
-		/datum/movement_handler/mob/eye,
 		/datum/movement_handler/move_relay,
 		/datum/movement_handler/mob/delay,
 		/datum/movement_handler/mob/physically_capable,
-		/datum/movement_handler/mob/physically_restrained,
+		/datum/movement_handler/mob/physically_restrained,	//TODO: Add this from various things it checks, should be removed otherwise
 		/datum/movement_handler/mob/space,
 		/datum/movement_handler/mob/multiz,
 		/datum/movement_handler/mob/movement

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -17,7 +17,7 @@
 		/datum/movement_handler/move_relay,
 		/datum/movement_handler/mob/buckle_relay,
 		/datum/movement_handler/mob/delay,
-		/datum/movement_handler/mob/stop_effect,
+		//Stop effect handler entirely removed, it is trash. If you want to prevent someone from moving, use root
 		/datum/movement_handler/mob/physically_capable,
 		/datum/movement_handler/mob/physically_restrained,
 		/datum/movement_handler/mob/space,

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -11,12 +11,10 @@
 	virtual_mob = /mob/dead/observer/virtual/mob
 
 	movement_handlers = list(
-		/datum/movement_handler/mob/relayed_movement,
 		/datum/movement_handler/mob/conscious,
 		/datum/movement_handler/mob/eye,
 		/datum/movement_handler/move_relay,
 		/datum/movement_handler/mob/delay,
-		//Stop effect handler entirely removed. If you want to prevent someone from moving, use root
 		/datum/movement_handler/mob/physically_capable,
 		/datum/movement_handler/mob/physically_restrained,
 		/datum/movement_handler/mob/space,

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -12,7 +12,6 @@
 
 	movement_handlers = list(
 		/datum/movement_handler/mob/relayed_movement,
-		/datum/movement_handler/mob/death,
 		/datum/movement_handler/mob/conscious,
 		/datum/movement_handler/mob/eye,
 		/datum/movement_handler/move_relay,

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -15,9 +15,8 @@
 		/datum/movement_handler/mob/conscious,
 		/datum/movement_handler/mob/eye,
 		/datum/movement_handler/move_relay,
-		/datum/movement_handler/mob/buckle_relay,
 		/datum/movement_handler/mob/delay,
-		//Stop effect handler entirely removed, it is trash. If you want to prevent someone from moving, use root
+		//Stop effect handler entirely removed. If you want to prevent someone from moving, use root
 		/datum/movement_handler/mob/physically_capable,
 		/datum/movement_handler/mob/physically_restrained,
 		/datum/movement_handler/mob/space,

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -820,3 +820,8 @@ proc/is_blind(A)
 		reach_mod -= 1
 
 	return max(min(reach, 1), reach+reach_mod)
+
+
+/mob/proc/set_eyeobj(var/atom/new_eye)
+	eyeobj = new_eye
+	AddMovementHandler(/datum/movement_handler/mob/eye)


### PR DESCRIPTION
Movement handlers are all checked in sequence whenever anyone takes a single step. There were 13 of them when i started this. Each one calls two procs

This adds up to a lot of load over time.

The purpose of this PR is to reduce the number of handlers by removing those which only exist for wierd edge cases. These are added back in, temporarily, when the case they're made for can occur. Though a few are simply unused and have been outright removed.

Six of these thirteen have been removed here
 More of these handlers can still be removed yet, this is just my work for tonight, i'm sleepy

This PR is part 1 of a broad longterm effort to improve performance of the movement system. There will be several more in coming weeks