### PR TITLE
Bigger shotguns

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -133,6 +133,7 @@
 	icon = 'icons/obj/weapons/ds13guns48x32.dmi'
 	icon_state = "scl_shotgun"
 	item_state = "scl_shotgun"
+	wielded_item_state = "scl_shotgun-wielded"
 	var/icon_loaded = "scl_shotgun_loaded"
 	slot_flags = SLOT_BELT
 	magazine_type = /obj/item/ammo_magazine/shotgun

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -142,6 +142,7 @@
 	force = 5
 	one_hand_penalty = 0
 	fire_delay = 20
+	one_hand_penalty = 6 //It's a shotgun, brace yourself before firing.
 	firemodes = list(
 		list(mode_name = "shotgun", fire_delay = 1 SECONDS),
 		list(mode_name = "bolas", projectile_type = /obj/item/projectile/bullet/shotgun/bola, fire_sound = 'sound/weapons/bolathrow.ogg', fire_delay = 1 SECONDS))

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -136,7 +136,7 @@
 	var/icon_loaded = "scl_shotgun_loaded"
 	slot_flags = SLOT_BELT
 	magazine_type = /obj/item/ammo_magazine/shotgun
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_HUGE
 	load_method = MAGAZINE
 	caliber = "shotgun"
 	force = 5

--- a/html/changelogs/shotgun.yml
+++ b/html/changelogs/shotgun.yml
@@ -56,3 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - balance: "Shotguns no longer fit in backpacks."
+  - balance: "Shotguns need to be wielded for perfect accuracy."

--- a/html/changelogs/shotgun.yml
+++ b/html/changelogs/shotgun.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Shotguns no longer fit in backpacks."


### PR DESCRIPTION
Shotguns no longer fit in backpacks. You must put them on your suit or back now.

Because pocket shotgun bad. Disproportionally large amount of people carrying a pocket shotgun over an actual sidearm like plasmacutter, divet.

You also get an accuracy penalty for one handing a shotgun now.

On a side note, shotguns now display their wielded sprite correctly.