### PR TITLE
Nerfs leaper stun duration

### DIFF
--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -273,7 +273,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	//To be considered a success, we must leap onto a mob, and they must be the one we intended to hit
 	if (isliving(charge.last_obstacle))
 		var/mob/living/L = charge.last_obstacle
-		L.Weaken(5) //Down they go!
+		L.Weaken(3) //Down they go!
 		L.apply_damage(3*(charge.distance_travelled+1), used_weapon = charge.user) //We apply damage based on the distance. We add 1 to the distance because we're moving into their tile too
 		shake_camera(L,5,3)
 		//And lets also land ontop of them

--- a/html/changelogs/leapnertnt.yml
+++ b/html/changelogs/leapnertnt.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Lowers the stun duration inflicted by leapers by about 40%."


### PR DESCRIPTION
Lowers leaper stun duration from 5 seconds to 3. This is a decrease of 40%.

I considered doing a smaller nerf to the stun at first, but I'd rather not lower leap cooldown any further for mobility reasons, and this makes it harder to spam stuns together with another leaper.