### PR TITLE
Hyperzine & floors

### DIFF
--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -15,6 +15,7 @@
 	if (flooring && flooring.attackby(I, user, src))
 		return TRUE
 
+/* disabled until further notice. This isn't intended, use tools instead.
 	//Attempting to damage floors with things
 	//This has a lot of potential to break things, so it's limited to harm intent.
 	//This supercedes all construction, deconstruction and similar actions. So change your intent out of harm if you don't want to smack the floor
@@ -36,6 +37,7 @@
 				visible_message(SPAN_DANGER("[user] ineffectually hits [src] with [I]"))
 			user.set_click_cooldown(DEFAULT_ATTACK_COOLDOWN*1.5) //This longer cooldown helps promote skill in melee combat by punishing misclicks a bit
 			return TRUE
+*/
 
 	for(var/atom/movable/A in src)
 		if(A.preventsTurfInteractions())

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -259,11 +259,13 @@
 	inhibitors = list(/datum/reagent/sugar = 1) // Messes up with inaprovaline
 	result_amount = 2
 
+/* disabled for now. You can still spawn in anabolic steroids for events, but this needs to be rebalanced.
 /datum/chemical_reaction/hyperzine
 	name = "Hyperzine"
 	result = /datum/reagent/hyperzine
 	required_reagents = list(/datum/reagent/sugar = 1, /datum/reagent/phosphorus = 1, /datum/reagent/sulfur = 1)
 	result_amount = 3
+*/
 
 /datum/chemical_reaction/cryoxadone
 	name = "Cryoxadone"


### PR DESCRIPTION
- Disables the recipe for hyperzine.
Hyperzine can still be found in maintenance as zoom pill bottles and anabolic steroids. It should just be a very rare 'treat' now, which serves it right granted how powerful it is currently.

- Removes floor digging by hand.
We already removed this from necromorphs for the very same issue as necros digging through levels or making holes to curb survivor movement. You can still remove floors by using the proper tools. Which takes longer, requires engineering skill, and the appropriate inventory space allocated to tools. 