### PR TITLE
Infector Fixes

### DIFF
--- a/code/_helpers/mob_status_effects.dm
+++ b/code/_helpers/mob_status_effects.dm
@@ -52,3 +52,16 @@
 		O.rejuvenate()
 
 	shock_stage = 0
+
+	paralysis = 0
+	stunned = 0
+	sleeping = 0
+	weakened = 0
+
+	//Remake the hud
+	if (hud_used)
+		QDEL_NULL(hud_used)
+
+		//If there isn't a client right now, the next one to login to this mob will run this anyway
+		if (client)
+			create_mob_hud()

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -71,7 +71,7 @@
 	if(!ticker) //why do we need to check this?
 		to_chat(user, "<span class='warning'>You can't buckle anyone in before the game starts.</span>")
 		return 0
-	if(!user.Adjacent(M) || user.restrained() || user.stat || istype(user, /mob/living/silicon/pai))
+	if(!user.Adjacent(M) || !user.is_advanced_tool_user() || user.restrained() || user.stat || istype(user, /mob/living/silicon/pai))
 		return 0
 	if(M == buckled_mob)
 		return 0

--- a/code/modules/mob/living/abilities/sense.dm
+++ b/code/modules/mob/living/abilities/sense.dm
@@ -69,6 +69,9 @@
 			if (H.stat == DEAD)
 				continue
 
+			if (H.is_necromorph())
+				continue
+
 			//Only detect people on our floor
 			if (H.z != user.z)
 				continue

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/conversion.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/conversion.dm
@@ -173,13 +173,18 @@
 	return options
 
 
-
+/*
+	Safety Checks
+*/
 /mob/living/proc/is_necromorph_conversion_valid()
 	.= TRUE
-	if (stat != DEAD)
+	if (stat != DEAD && stat != UNCONSCIOUS)
 		return FALSE
 
 	if (QDELETED(src))
+		return FALSE
+
+	if (is_necromorph())
 		return FALSE
 
 
@@ -187,6 +192,9 @@
 	.=..()
 	if (!has_organ(BP_HEAD))
 		return FALSE
+
+
+
 
 
 //Compatibility

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/essence_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/essence_abilities.dm
@@ -123,7 +123,7 @@
 			return
 
 		if (!L.is_necromorph_conversion_valid())
-			to_chat(potential_user, "Invalid Target: The target must be a dead non-necromorph lifeform which is not headless")
+			to_chat(potential_user, "Invalid Target: The target must be a dead or unconscious,  non-necromorph lifeform which is not headless")
 			return FALSE
 /*
 	Engorge

--- a/html/changelogs/infectorfixes.yml
+++ b/html/changelogs/infectorfixes.yml
@@ -58,3 +58,5 @@ changes:
   - bugfix: "Fixed infectors being able to affect necromorphs."
   - bugfix: "Sense no longer detects converted humans."
   - bugfix: "Fixed a few issues where newly converted humans would be stuck unconscious for a long period or have a missing HUD"
+  - tweak: "Necromorphs can no longer buckle people to chairs"
+  - tweak: "Infectors can now use Reanimate on unconscious victims."

--- a/html/changelogs/infectorfixes.yml
+++ b/html/changelogs/infectorfixes.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Nanako"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed infectors being able to affect necromorphs."
+  - bugfix: "Sense no longer detects converted humans."
+  - bugfix: "Fixed a few issues where newly converted humans would be stuck unconscious for a long period or have a missing HUD"


### PR DESCRIPTION
changes:
  - bugfix: "Fixed infectors being able to affect necromorphs."
  - bugfix: "Sense no longer detects converted humans."
  - bugfix: "Fixed a few issues where newly converted humans would be stuck unconscious for a long period or have a missing HUD"
  - tweak: "Necromorphs can no longer buckle people to chairs"
  - tweak: "Infectors can now use Reanimate on unconscious victims."

Closes #1775
Closes #1772
Closes #1682