### PR TITLE
Frantic Growth Nerf

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -246,6 +246,30 @@
 		return H
 
 
+/*
+	Very specific use case. This proc returns true if the turf is currently visible to any conscious, living, human crewmember
+	It does not return true if seen by:
+		Animals
+		Necromorphs
+		Ghosts/signals
+
+	Optionally (enabled by default), tiles in sight of the marker, or a marker shard, are designated safe zone, crew visibility is ignored there
+*/
+/turf/proc/crew_nearby(var/distance = 7)
+	.=FALSE
+	for (var/mob/living/carbon/human/H in range(distance, src))
+		if (H.is_necromorph())
+			//Necromorphs don't count
+			continue
+		if (H.stat == UNCONSCIOUS)
+			continue
+
+		return H
+
+	return FALSE
+
+
+
 /turf/proc/is_in_sight_of_marker()
 	var/list/safe_types = list(/obj/item/marker_shard, /obj/machinery/marker)
 	for (var/obj/O in dview(7, src))

--- a/code/modules/mob/dead/observer/freelook/marker/signal_abilities/signal_ability.dm
+++ b/code/modules/mob/dead/observer/freelook/marker/signal_abilities/signal_ability.dm
@@ -55,7 +55,7 @@
 	var/LOS_block	=	FALSE
 
 	//When set to a number, the spell must be cast at least this distance away from a conscious crewmember
-	//var/distance_blocked = 0
+	var/distance_blocked = null
 
 	//If true, this spell can only be cast after the marker has activated
 	//If false, it can be cast anytime from roundstart
@@ -385,6 +385,12 @@
 		var/mob/M = T.is_seen_by_crew()
 		if (M)
 			to_chat(user, SPAN_WARNING("Casting here is blocked because the tile is seen by [M]"))
+			return FALSE
+
+	if (distance_blocked)
+		var/mob/M = T.crew_nearby(distance_blocked)
+		if (M)
+			to_chat(user, SPAN_WARNING("Casting here is blocked because the tile is too close to [M]. It must be cast at least [distance_blocked] tiles away from crewmembers"))
 			return FALSE
 
 	if (!isnull(allied_check))

--- a/code/modules/mob/dead/observer/freelook/marker/signal_abilities/wall.dm
+++ b/code/modules/mob/dead/observer/freelook/marker/signal_abilities/wall.dm
@@ -12,6 +12,8 @@
 	energy_cost = 100
 	LOS_block = FALSE
 	placement_atom = /obj/structure/corruption_node/wall/visible
+	distance_blocked = 1	//Small minimum distance
+
 
 /*
 	The actual atom

--- a/html/changelogs/frantic.yml
+++ b/html/changelogs/frantic.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Nanako"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Frantic Growth can now only be cast at least two tiles away from conscious crewmembers"


### PR DESCRIPTION
changes:
  - tweak: "Frantic Growth can now only be cast at least two tiles away from conscious crewmembers"