### PR TITLE
Simply adds necro toxin syringes to adminspawn

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -386,3 +386,18 @@
 	reagents.add_reagent(/datum/reagent/adrenaline, 5)
 	reagents.add_reagent(/datum/reagent/hyperzine, 10)
 
+/obj/item/weapon/reagent_containers/syringe/necrotoxin
+	name = "Syringe (mysterious fluid)"
+	desc = "Smells like rotten flesh."
+
+/obj/item/weapon/reagent_containers/syringe/necrotoxin/New()
+	..()
+	reagents.add_reagent(/datum/reagent/toxin/necro, 15)
+
+/obj/item/weapon/reagent_containers/syringe/necrotoxin/low
+
+/obj/item/weapon/reagent_containers/syringe/necrotoxin/low/New()
+	..()
+	reagents.add_reagent(/datum/reagent/toxin/necro, 5)
+
+


### PR DESCRIPTION
Adminspawn only.

Two variants

Use low if you only want there to be one victim. Normal syringe can probably kill three if used wisely.