### PR TITLE
Puker and Spitter projectiles are now slower

### DIFF
--- a/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
@@ -270,7 +270,7 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 /obj/item/projectile/bullet/acid/puker_snap
 	icon_state = "acid_small"
 	damage = 15
-	step_delay = 1.25
+	step_delay = 2
 	kill_count = PUKER_SNAPSHOT_RANGE
 	impact_type = /obj/effect/projectile/acid/impact/small
 
@@ -279,7 +279,7 @@ Be warned that friendly fire is fully active, it can harm other necromorphs as m
 /obj/item/projectile/bullet/acid/puker_long
 	name = "acid blast"
 	icon_state = "acid_large"
-	step_delay = 1.75
+	step_delay = 3
 	damage = 30
 	grippable = TRUE
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
@@ -215,7 +215,7 @@ Best used for harassment, skirmishing and initiating fights from afar against un
 /obj/item/projectile/bullet/acid/spitter_snap
 	icon_state = "acid_small"
 	damage = 10
-	step_delay = 1.5
+	step_delay = 2.5
 	kill_count = SPITTER_SNAPSHOT_RANGE
 	impact_type = /obj/effect/projectile/acid/impact/small
 
@@ -224,7 +224,7 @@ Best used for harassment, skirmishing and initiating fights from afar against un
 /obj/item/projectile/bullet/acid/spitter_long
 	name = "acid blast"
 	icon_state = "acid_large"
-	step_delay = 2
+	step_delay = 3.5
 	damage = 20
 	grippable = TRUE
 

--- a/html/changelogs/DTraitor-PR-balance-acid-bolts.yml
+++ b/html/changelogs/DTraitor-PR-balance-acid-bolts.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "DTraitor"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Puker and spitter projectiles are now slower which means catching them with kinesis is easier."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
### Purpose
After we got a new server it became really hard to catch spitter projectiles due to ping and their high speed. This PR makes them slower