### PR TITLE
Items bought in store no longer use Fabricate()

### DIFF
--- a/code/modules/economy/store/store_credits.dm
+++ b/code/modules/economy/store/store_credits.dm
@@ -68,7 +68,7 @@
 
 
 	playsound(src, sound_vend, VOLUME_MID, TRUE)
-	return new current_design(src)
+	return current_design.CreatedInStore(src)
 
 /obj/machinery/store/proc/store_or_drop(var/obj/item/I)
 	if (!deposit_box.store_item(I))

--- a/code/modules/economy/store/store_credits.dm
+++ b/code/modules/economy/store/store_credits.dm
@@ -68,7 +68,7 @@
 
 
 	playsound(src, sound_vend, VOLUME_MID, TRUE)
-	return current_design.Fabricate(src, 1, src)
+	return new current_design(src)
 
 /obj/machinery/store/proc/store_or_drop(var/obj/item/I)
 	if (!deposit_box.store_item(I))

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -197,7 +197,17 @@ other types of metals and chemistry for reagents).
 
 	return A
 
+// Same as above but for store
+/datum/design/proc/CreatedInStore(store_ref)
+	if(!build_path)
+		return
 
+	if(!(build_type & STORE))
+		return
+
+	var/atom/A = new build_path(store_ref)
+
+	return A
 
 /datum/design/autolathe
 	build_type = AUTOLATHE

--- a/html/changelogs/DTraitor-PR-store-new().yml
+++ b/html/changelogs/DTraitor-PR-store-new().yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "DTraitor"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Cells bought in store no longer spawn with 0 charge."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
### Purpose
Items bought in store now use `new ()` instead of `Fabricate()`
Fixes: https://github.com/DS-13-Dev-Team/DS13/issues/1610