### PR TITLE
Balance update V3

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -61,7 +61,6 @@
 /datum/uplink_item/item/ammo/c45uzi/special
 	item_cost = 2
 	is_special = TRUE
-	antag_roles = list(MODE_UNITOLOGIST, MODE_UNITOLOGIST_SHARD)
 
 /datum/uplink_item/item/ammo/a10mm
 	name = "10mm SMG Magazine"
@@ -70,6 +69,11 @@
 
 /datum/uplink_item/item/ammo/a10mm/special
 	item_cost = 2
+	is_special = TRUE
+
+/datum/uplink_item/item/ammo/bullpup/special
+	item_cost = 8
+	path = /obj/item/ammo_magazine/bullpup
 	is_special = TRUE
 	antag_roles = list(MODE_UNITOLOGIST, MODE_UNITOLOGIST_SHARD)
 

--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -26,7 +26,7 @@
 	path = /obj/item/weapon/plastique
 
 /datum/uplink_item/item/tools/plastique/special
-	item_cost = 4
+	item_cost = 6
 	is_special = TRUE
 	antag_roles = list(MODE_EARTHGOV_AGENT, MODE_UNITOLOGIST, MODE_UNITOLOGIST_SHARD)
 

--- a/code/datums/uplink/hardsuit_modules.dm
+++ b/code/datums/uplink/hardsuit_modules.dm
@@ -27,9 +27,16 @@
 /datum/uplink_item/item/hardsuit_modules/zealot
 	name = "Zealot RIG"
 	path = /obj/item/weapon/rig/zealot
-	item_cost = 15
+	item_cost = 23
 	is_special = TRUE
 	antag_roles = list(MODE_UNITOLOGIST, MODE_UNITOLOGIST_SHARD)
+
+/datum/uplink_item/item/hardsuit_modules/earthgov
+	name = "Earthgov RIG"
+	path = /obj/item/weapon/rig/marine/earthgov
+	item_cost = 19
+	is_special = TRUE
+	antag_roles = list(MODE_EARTHGOV_AGENT)
 
 /datum/uplink_item/item/hardsuit_modules/maneuvering_jets
 	name = "\improper Maneuvering Jets"

--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -68,6 +68,11 @@
 /datum/uplink_item/item/visible_weapons/submachinegun/special
 	item_cost = 9
 	is_special = TRUE
+
+/datum/uplink_item/item/visible_weapons/bullpup/special
+	item_cost = 15
+	path = /obj/item/weapon/gun/projectile/automatic/bullpup
+	is_special = TRUE
 	antag_roles = list(MODE_UNITOLOGIST, MODE_UNITOLOGIST_SHARD)
 
 /datum/uplink_item/item/visible_weapons/assaultrifle
@@ -146,4 +151,4 @@
 	item_cost = 7
 	path = /obj/item/weapon/gun/projectile/divet
 	is_special = TRUE
-	antag_roles = list(MODE_EARTHGOV_AGENT)
+	antag_roles = list(MODE_EARTHGOV_AGENT, MODE_UNITOLOGIST, MODE_UNITOLOGIST_SHARD)

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -10,7 +10,7 @@
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
 
 /datum/uplink_item/item/implants/imp_freedom/special
-	item_cost = 12
+	item_cost = 20
 	is_special = TRUE
 	antag_roles = list(MODE_EARTHGOV_AGENT)
 
@@ -40,14 +40,14 @@
 	path = /obj/item/weapon/storage/box/syndie_kit/imp_imprinting
 
 /datum/uplink_item/item/implants/imp_imprinting/special
-	item_cost = 13
+	item_cost = 20
 	is_special = TRUE
 	antag_roles = list(MODE_UNITOLOGIST, MODE_UNITOLOGIST_SHARD)
 
 /datum/uplink_item/item/implants/explosive
-	name = "temp name1"
-	desc = "temp desc1"
-	item_cost = 13
+	name = "Explosive Implant"
+	desc = "Used to  give someone an explosive surprise"
+	item_cost = 20
 	is_special = TRUE
 	path = /obj/item/weapon/implantcase/explosive
 	antag_roles = list(MODE_UNITOLOGIST, MODE_UNITOLOGIST_SHARD)

--- a/code/modules/clothing/spacesuits/rig/suits/marine.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/marine.dm
@@ -60,3 +60,24 @@
 		/obj/item/rig_module/vision/nvgsec,
 		/obj/item/rig_module/maneuvering_jets
 		)
+
+/obj/item/weapon/rig/marine/earthgov //PLACEHOLDER RIG for earthgovs. Will be replaced by a special earthgov rig later.
+	name = "advanced specialist RIG"
+	desc = "A powerful yet flexible suit, designed for use by military and naval specialists or command staff."
+	icon_state = "adv_soldier_dark"
+	armor = list(melee = 50, bullet = 65, laser = 30, energy = 20, bomb = 30, bio = 100, rad = 75)
+	offline_slowdown = 3
+	online_slowdown = RIG_MEDIUM
+	acid_resistance = 1	//Contains a fair bit of plastic
+
+	chest_type = /obj/item/clothing/suit/space/rig/marine
+	helm_type =  /obj/item/clothing/head/helmet/space/rig/marine
+	boot_type =  /obj/item/clothing/shoes/magboots/rig/marine
+	glove_type = /obj/item/clothing/gloves/rig/marine
+
+	initial_modules = list(
+		/obj/item/rig_module/healthbar,
+		/obj/item/rig_module/storage,
+		/obj/item/rig_module/grenade_launcher/light,	//These grenades are harmless illumination
+		/obj/item/rig_module/vision/nvgsec
+		)

--- a/code/modules/necromorph/corruption/growth.dm
+++ b/code/modules/necromorph/corruption/growth.dm
@@ -7,7 +7,7 @@
 	density = FALSE
 
 	var/range = 14
-	var/speed = 1.25
+	var/speed = 1.5
 	var/falloff = 0.1
 	var/limit = null	//Maximum number of tiles it can support
 
@@ -66,7 +66,7 @@
 	name = "branch"
 	id = "branch"
 	desc = ""
-	energy_cost = 150
+	energy_cost = 135
 	placement_atom = /obj/structure/corruption_node/growth/branch
 
 
@@ -82,8 +82,8 @@
 	density = FALSE
 	marker_spawnable = FALSE
 
-	range = 40
-	speed = 3
+	range = 12
+	speed = 2
 	falloff = 0.025
 	limit = 60
 	randpixel = 4

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -61,7 +61,7 @@
 	organ_tag = BP_L_ARM
 	name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 50
+	max_damage = 60
 	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 	body_part = ARM_LEFT
@@ -152,7 +152,7 @@
 	organ_tag = BP_L_HAND
 	name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 50
+	max_damage = 60
 	min_broken_damage = 30
 	w_class = ITEM_SIZE_SMALL
 	body_part = HAND_LEFT

--- a/html/changelogs/balance.yml
+++ b/html/changelogs/balance.yml
@@ -1,0 +1,77 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Rebalanced antag equipment."
+  - balance: "Uni zealot rig cost increased."
+  - balance: "Earthgov agents can now get a rig as well."
+  - balance: "Zealot smg replaced by bullpup, cost increased."
+  - balance: "Implant cost increased."
+  - balance: "c4 cost increased."
+  - balance: "zealots now have access to the divet."
+  - balance: "Arm/hand health increased further."
+  - balance: "Marker can now spawn in the undertram."
+  - balance: "Branch cost decreased."
+  - balance: "Root distance and spread speed nerfed significantly."
+  - balance: "Propagator spread speed increased modestly."
+
+
+
+
+
+
+
+

--- a/maps/DeadSpace/M.01 Ishimura (UT).dmm
+++ b/maps/DeadSpace/M.01 Ishimura (UT).dmm
@@ -5394,6 +5394,9 @@
 	},
 /turf/simulated/floor,
 /area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
+"ow" = (
+/turf/simulated/floor/plating,
+/area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
 "oL" = (
 /obj/structure/table/steel,
 /obj/random/loot/sometimes/few,
@@ -5411,6 +5414,11 @@
 	},
 /turf/simulated/floor,
 /area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
+"ro" = (
+/obj/structure/foamedmetal,
+/obj/machinery/vending/snack,
+/turf/simulated/floor/plating,
+/area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
 "rW" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor,
@@ -5426,6 +5434,16 @@
 "tQ" = (
 /turf/simulated/wall/r_wall/hull,
 /area/ishimura/tramdeck/tram/undertunnel/uttt)
+"uf" = (
+/obj/effect/landmark/marker/ishimura,
+/turf/simulated/floor/plating,
+/area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
+"vk" = (
+/obj/structure/foamedmetal,
+/obj/structure/foamedmetal,
+/obj/machinery/vending/hotfood,
+/turf/simulated/floor/plating,
+/area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
 "vK" = (
 /obj/structure/table/steel,
 /obj/random/tool/low_chance,
@@ -5440,6 +5458,11 @@
 /obj/random/loot/sometimes/few,
 /turf/simulated/floor,
 /area/ishimura/tramdeck/tram/undertunnel/undermidmaintenance)
+"Aa" = (
+/obj/structure/foamedmetal,
+/obj/machinery/vending/hotfood,
+/turf/simulated/floor/plating,
+/area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
 "Ff" = (
 /obj/machinery/light{
 	dir = 1;
@@ -5499,6 +5522,12 @@
 /obj/effect/decal/cleanable/blood/gibs/robot/down,
 /turf/simulated/floor,
 /area/ishimura/tramdeck/tram/undertunnel/undermidmaintenance)
+"Ll" = (
+/obj/structure/foamedmetal,
+/obj/structure/foamedmetal,
+/obj/machinery/vending/cola,
+/turf/simulated/floor/plating,
+/area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
 "Mk" = (
 /obj/machinery/light{
 	dir = 4
@@ -5521,6 +5550,11 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor,
+/area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
+"PN" = (
+/obj/structure/foamedmetal,
+/obj/machinery/vending/cola,
+/turf/simulated/floor/plating,
 /area/ishimura/tramdeck/tram/undertunnel/underaftmaintenance)
 "SP" = (
 /obj/effect/decal/cleanable/cobweb2{
@@ -5549,6 +5583,12 @@
 /obj/structure/table/standard,
 /obj/random/loot/sometimes/few,
 /turf/simulated/floor,
+/area/ishimura/tramdeck/tram/undertunnel/uttt)
+"Yo" = (
+/obj/machinery/door/airlock/civilian{
+	name = "Garbage Pit"
+	},
+/turf/simulated/floor/plating,
 /area/ishimura/tramdeck/tram/undertunnel/uttt)
 "YH" = (
 /obj/structure/table/rack/dark,
@@ -13292,9 +13332,9 @@ dN
 dN
 dN
 dN
+ro
 il
-il
-il
+Aa
 il
 il
 il
@@ -13903,7 +13943,7 @@ il
 il
 il
 il
-il
+PN
 il
 il
 ef
@@ -14101,7 +14141,7 @@ il
 il
 il
 il
-il
+Aa
 il
 il
 il
@@ -14299,7 +14339,7 @@ ab
 dN
 il
 il
-il
+PN
 il
 il
 il
@@ -14903,20 +14943,20 @@ aa
 aa
 ab
 dN
+ro
+il
+il
+il
+il
+ow
+ow
+ow
 il
 il
 il
 il
 il
-il
-il
-il
-il
-il
-il
-il
-il
-ef
+Yo
 dB
 ef
 dp
@@ -15110,9 +15150,9 @@ il
 il
 il
 il
-il
-il
-il
+ow
+uf
+ow
 il
 il
 il
@@ -15312,9 +15352,9 @@ il
 il
 il
 il
-il
-il
-il
+ow
+ow
+ow
 il
 il
 il
@@ -15924,7 +15964,7 @@ ae
 ae
 ae
 ae
-il
+PN
 il
 ef
 dB
@@ -16320,7 +16360,7 @@ il
 ae
 ae
 ae
-ae
+vk
 ae
 ae
 ae
@@ -16329,7 +16369,7 @@ ae
 ae
 ae
 il
-il
+ro
 ef
 dB
 ef
@@ -16517,7 +16557,7 @@ aa
 aa
 ab
 dN
-il
+ro
 il
 ae
 ae
@@ -16724,7 +16764,7 @@ il
 ae
 ae
 ae
-ae
+Ll
 ae
 ae
 ae
@@ -16931,7 +16971,7 @@ il
 il
 il
 il
-il
+Aa
 il
 il
 dN
@@ -17329,9 +17369,9 @@ il
 il
 il
 il
-il
-il
-il
+ow
+ow
+ow
 il
 il
 il
@@ -17531,9 +17571,9 @@ dN
 il
 il
 il
-il
-il
-il
+ow
+uf
+ow
 il
 il
 il
@@ -17733,9 +17773,9 @@ dN
 il
 il
 il
-il
-il
-il
+ow
+ow
+ow
 il
 il
 il
@@ -17932,7 +17972,7 @@ aa
 aa
 ab
 dN
-il
+ro
 il
 il
 il
@@ -18142,7 +18182,7 @@ il
 il
 il
 il
-il
+PN
 il
 il
 il
@@ -19761,7 +19801,7 @@ il
 il
 il
 il
-il
+ro
 dN
 dP
 dN
@@ -20162,7 +20202,7 @@ il
 il
 il
 dN
-il
+ro
 il
 il
 dN


### PR DESCRIPTION
 The primary focus of this update is to lower the overall power level of unitologists, and the chaos they tend to cause. They're a bit too disruptive to the round currently, and the ease of access to deadly equipment doesn't help.
 
 The second part is necromorph nerfs. More specifically, spread. If anything, corruption can claim medbay within 5-15 minutes, depending on how adamant necros are. And no place is safe from dedicated spread. This should slow them down a bit, and give people more time to respond to the infection.

 - Rebalanced antag equipment.
  - Uni zealot rig cost increased. (Now you can't buy a rig, a weapon, and three mags anymore. Choose either a rig and a divet, just the rig, or just a bullpup instead)
  - Earthgov agents can now get a rig as well. (Primarily for parity. I'll make a unique rig sprite for this later)
  - Zealot smg replaced by bullpup, cost increased. (Because using a classic ballistic smg is silly.)
  - Implant cost increased. (you were able to get 2. Unis could effectively enslave half the crew on some rounds)
  - c4 cost increased. (You can now buy up to a maximum of 5. Down from 7. This will lower the amount of chaos caused by mass c4 detonations)
  - zealots now have access to the divet. (Simple sidearm to use with the rig. They can't buy additional ammo, it's really just a backup.)
  - Arm/hand health increased further. (It's mostly incredibly unfun for humans to loose the means to fight effectively. Necros can still easily kill people with infector aid, or by damaging them enough.)
  - Marker can now spawn in the undertram. (2 spawns, 2/5 total spawns. Bit Experimental. They get access to some vending machines right away, but are much further from topside bio objectives. Players have been complaining about medical falling really early, making it hard to effectively treat wounds even when doctors are still alive.)
  - Branch cost decreased. (underused node. This makes it more attractive. 10% decrease)
  - Root distance and spread speed nerfed significantly. (12 tiles now. This is still a lot of absolute distance. But also makes it easier to spread a given direction. This makes propagators and branches more attractive again, instead of signals only spawning roots 33% decrease in speed)
  - Propagator spread speed increased modestly. (Makes it more attractive. 20% increase)
