### PR TITLE
Small balance update. - Seeker - Mining

### DIFF
--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -1,4 +1,4 @@
-#define ORE_VALUE_FACTOR	5 //Change this number to modify mining bonus outputs globally
+#define ORE_VALUE_FACTOR	4 //Change this number to modify mining bonus outputs globally
 GLOBAL_LIST_EMPTY(ore_data)
 GLOBAL_LIST_EMPTY(ores_by_type)
 

--- a/code/modules/projectiles/guns/ds13/seeker.dm
+++ b/code/modules/projectiles/guns/ds13/seeker.dm
@@ -51,8 +51,6 @@
 	step_delay = 0.75	//Real fast
 	expiry_method = EXPIRY_FADEOUT
 	fire_sound = 'sound/weapons/gunshot/sniper.ogg'
-	stun = 1.5
-	weaken = 3
 	penetrating = 5
 	armor_penetration = 20
 

--- a/code/modules/projectiles/guns/ds13/seeker.dm
+++ b/code/modules/projectiles/guns/ds13/seeker.dm
@@ -22,7 +22,7 @@
 
 
 	firemodes = list(
-		list(mode_name="semi-automatic",  fire_delay=10),
+		list(mode_name="semi-automatic",  fire_delay=12),
 		)
 
 /obj/item/weapon/gun/projectile/seeker/empty
@@ -43,7 +43,7 @@
 
 /obj/item/projectile/bullet/seeker
 	icon_state = "seeker"
-	damage = 60
+	damage = 50
 	embed = 1
 	structure_damage_factor = 3
 	penetration_modifier = 1.25
@@ -63,7 +63,7 @@
 	caliber = "seeker"
 	ammo_type = /obj/item/ammo_casing/seeker
 	matter = list(MATERIAL_STEEL = 1260)
-	max_ammo = 5
+	max_ammo = 6
 	multiple_sprites = TRUE
 	mag_type = MAGAZINE
 

--- a/html/changelogs/seekerstuff.yml
+++ b/html/changelogs/seekerstuff.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Removes seeker stun altogether."
+  - balance: "Lowers mining performance bonuses by 20%."

--- a/html/changelogs/seekerstuff.yml
+++ b/html/changelogs/seekerstuff.yml
@@ -56,4 +56,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - balance: "Removes seeker stun altogether."
+  - balance: "Seeker firerate reduced."
+  - balance: "Moved some damage from the seeker to the magazine instead."
   - balance: "Lowers mining performance bonuses by 20%."


### PR DESCRIPTION
Reduces the mining performance bonuses. People are still raking in 80-180k, sometimes as a single miner. Being able to just buy anything you want completely defeats the point of the store.

Removes the seeker rifle stun. The stun is overbearing in general for a gun that already does massive damage. It's also not very fun to be hit by, and we already have two other weapons that deal crowd-control type damage. Javelin & forcegun. And they're far weaker damage wise to make up for it.

Also lowers the fire-rate and moves some of the damage from the bullet to the clip. Same damage per clip, but now it's much slower at dealing said damage. This should give all necros slightly more of a chance to try and wrestle past it. This also means you now need 5 bullets to kill some of the higher tier necros rather than 4. 3 for enhanced instead of 2, etc. Aka, reducing the breakpoint efficiency to make it more costly to fire at necros. Pick important targets, like enhanced exploders, brutes, hunters, rather than fire indiscriminately. (Not to mention a tiny attempt at making it less effective against humans... )