### PR TITLE
Resolve #1817

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ds13/kinesis/kinesis.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ds13/kinesis/kinesis.dm
@@ -404,7 +404,7 @@
 */
 //Main release proc, drops the item but does nothing with it
 /obj/item/rig_module/kinesis/proc/release()
-	.=subject
+	. = subject
 	if (!QDELETED(subject))
 		GLOB.destroyed_event.unregister(subject, src, /obj/item/rig_module/kinesis/proc/release_grip)
 		GLOB.bump_event.unregister(subject, src, /obj/item/rig_module/kinesis/proc/subject_collision)
@@ -433,7 +433,8 @@
 //The default entrypoint, a wrapper for release
 //If the item is not in control range, it will be thrown based upon its velocity
 /obj/item/rig_module/kinesis/proc/release_grip()
-	var/speed = velocity.Magnitude()
+	//Precondition: Velocity must exist.
+	var/speed = (velocity != null) ? velocity.Magnitude() : 0
 	if (speed > 1 && release_type == RELEASE_DROP)
 		release_type = RELEASE_THROW
 
@@ -489,6 +490,9 @@
 
 	target_direction.SelfNormalize()
 	target_direction.SelfMultiply(acceleration)
+	//Precondition: Velocity must exist.
+	if(velocity == null)
+		velocity = get_new_vector(0,0)
 	velocity.SelfAdd(target_direction)
 
 	var/speed = velocity.Magnitude()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

-Velocity could be null at the time that a kinesis module tried to release the grab
-This fix will assume a velocity of 0 (IE: in case the vector was deleted normally) in this case, and apply it as such.
-Pending testing. I was unable to figure out how RIGs worked to fully test this fix.
