### PR TITLE
Corruption Tweaks

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -64,6 +64,7 @@ Basics, the most important.
 /datum/config_entry/flag/allow_vote_mode    //allow votes to change mode
 
 /datum/config_entry/flag/allow_admin_jump   //allows admin jumping
+	config_entry_value = TRUE
 
 /datum/config_entry/flag/disable_admin_spawn   //allows admin item spawning
 

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -81,10 +81,17 @@
 
 
 /obj/effect/vine/proc/can_spread_to(var/turf/floor, var/bounds)
+	to_chat(world, "---------------------------------------")
+	to_chat(world, "Trying to spread to [jumplink(floor)]")
 	if (isfloor(floor))
 		var/turf/simulated/floor/F = floor
 		if (F.incorruptible)
 			return -1
+
+	else
+		to_chat(world, "Can't spread to [jumplink(floor)]")
+		if (floor.is_hole)
+			return FALSE
 
 	if(bounds && !can_reach(floor))
 		return FALSE

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -81,16 +81,15 @@
 
 
 /obj/effect/vine/proc/can_spread_to(var/turf/floor, var/bounds)
-	to_chat(world, "---------------------------------------")
-	to_chat(world, "Trying to spread to [jumplink(floor)]")
+
 	if (isfloor(floor))
 		var/turf/simulated/floor/F = floor
 		if (F.incorruptible)
 			return -1
 
 	else
-		to_chat(world, "Can't spread to [jumplink(floor)]")
-		if (floor.is_hole)
+		//Cant spread to openspaces unless theres a catwalk to cover
+		if (floor.is_hole && !length(floor.zstructures))
 			return FALSE
 
 	if(bounds && !can_reach(floor))

--- a/code/modules/mob/dead/observer/freelook/marker/signal_abilities/audio.dm
+++ b/code/modules/mob/dead/observer/freelook/marker/signal_abilities/audio.dm
@@ -3,8 +3,8 @@
 	id = "sound_premarker"
 	desc = "Plays a fake sound of a chosen type, from a necromorph species of your choice. This spell becomes a lot cheaper once the marker is active"
 	target_string = "any turf to play the sound from"
-	energy_cost = 150
-	cooldown = 3 MINUTES
+	energy_cost = 100
+	cooldown = 2 MINUTES
 	require_corruption = FALSE
 	require_necrovision = TRUE
 	target_types = list(/turf)
@@ -20,8 +20,8 @@
 	id = "sound_postmarker"
 	desc = "Plays a fake sound of a chosen type, from a necromorph species of your choice."
 
-	energy_cost = 50
-	cooldown = 10 SECONDS
+	energy_cost = 25
+	cooldown = 5 SECONDS
 	marker_active_required = TRUE
 
 

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -48,7 +48,7 @@
 	icon_state = ""
 	density = FALSE
 	pathweight = INFINITY //Seriously, don't try and path over this one numbnuts
-
+	is_hole = TRUE
 	z_flags = ZM_MIMIC_DEFAULTS | ZM_MIMIC_OVERWRITE | ZM_MIMIC_NO_AO | ZM_ALLOW_ATMOS
 
 /turf/simulated/open/update_dirt()

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -6,6 +6,8 @@
 GLOBAL_LIST_EMPTY(corruption_sources)
 GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 
+#define CORRUPTION_SPREAD_HEALTH_THRESHOLD	0.3
+
 //We'll be using a subtype in addition to a seed, becuase there's a lot of special case behaviour here
 /obj/effect/vine/corruption
 	name = "corruption"
@@ -191,9 +193,13 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	return FALSE
 
 /obj/effect/vine/corruption/can_spread()
-	if(neighbors && neighbors.len)
-		return TRUE
-	return FALSE
+	if(!neighbors || !neighbors.len)
+		return FALSE
+
+	if (healthpercent() <= CORRUPTION_SPREAD_HEALTH_THRESHOLD)
+		return FALSE
+
+	return TRUE
 
 /obj/effect/vine/corruption/wake_up(var/wake_adjacent = TRUE)
 	if (QDELETED(source))

--- a/code/modules/necromorph/corruption/growth.dm
+++ b/code/modules/necromorph/corruption/growth.dm
@@ -18,6 +18,10 @@
 	falloff = 0
 	marker_spawnable = FALSE
 
+//A short range debug object
+/obj/structure/corruption_node/growth/debug/smol
+	range = 2
+
 
 /obj/structure/corruption_node/growth/Initialize()
 	.=..()

--- a/code/modules/necromorph/corruption/harvester.dm
+++ b/code/modules/necromorph/corruption/harvester.dm
@@ -20,8 +20,8 @@
 /obj/structure/corruption_node/harvester
 	name = "harvester"
 	desc = "It will take its due"
-	max_health = 500
-	resistance = 10	//Extremely tough, basically immune to small arms fire
+	max_health = 475
+	resistance = 9	//Extremely tough, basically immune to small arms fire
 	icon = 'icons/effects/corruption96x96.dmi'
 	icon_state = "harvester"
 	density = TRUE

--- a/code/modules/necromorph/corruption/snare.dm
+++ b/code/modules/necromorph/corruption/snare.dm
@@ -8,7 +8,7 @@
 
 	It's main design goal is to act as a chilling effect. To force crew players to slow down and pay attention to their environment
 */
-#define SNARE_PLACEMENT_BUFFER	3
+#define SNARE_PLACEMENT_BUFFER	2
 /obj/structure/corruption_node/snare
 	name = "snare"
 	desc = "<span class='notice'>That looks dangerous, good thing you noticed before tripping over it! Should be safe to step over it now</span>"
@@ -239,7 +239,7 @@
 	name = "Snare"
 	id = "snare"
 	desc = ""
-	energy_cost = 50
+	energy_cost = 40
 	LOS_block = FALSE
 	placement_atom = /obj/structure/corruption_node/snare
 	click_handler_type = /datum/click_handler/placement/ability/snare

--- a/html/changelogs/corruptiontweaks.yml
+++ b/html/changelogs/corruptiontweaks.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Nanako"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Reduced the energy cost of snare and audio abilities for signals."
+  - balance: "Slightly reduced the health and armor of the Harvester node."
+  - balance: "Corruption now spreads more slowly."
+  - balance: "Reduced the minimum placement buffer of snare to 2 tiles."
+  - bugfix: "Corruption will no longer grow over openspace tiles"


### PR DESCRIPTION
changes:
  - balance: "Reduced the energy cost of snare and audio abilities for signals."
  - balance: "Slightly reduced the health and armor of the Harvester node."
  - balance: "Corruption now spreads more slowly."
  - balance: "Reduced the minimum placement buffer of snare to 2 tiles."
  - bugfix: "Corruption will no longer grow over openspace tiles"