### PR TITLE
Speed and Health

### DIFF
--- a/code/__defines/movement.dm
+++ b/code/__defines/movement.dm
@@ -25,10 +25,10 @@
 
 
 
-#define RUN_DELAY 1.5
-#define WALK_DELAY 3
+#define RUN_DELAY 1.6
+#define WALK_DELAY 2.95
 #define STALK_DELAY 6
-#define MINIMUM_SPRINT_COST 0.8
-#define SKILL_SPRINT_COST_RANGE 0.8
-#define MINIMUM_STAMINA_RECOVERY 2
-#define MAXIMUM_STAMINA_RECOVERY 6
+#define MINIMUM_SPRINT_COST 0.85	//The part of sprint cost that everyone gets
+#define SKILL_SPRINT_COST_RANGE 0.775	//The part of sprint cost that is affected by athletics
+#define MINIMUM_STAMINA_RECOVERY 1.75
+#define MAXIMUM_STAMINA_RECOVERY 5

--- a/code/__defines/skills_stats.dm
+++ b/code/__defines/skills_stats.dm
@@ -14,6 +14,7 @@
 
 #define SKILL_EVA           /decl/hierarchy/skill/general/EVA
 #define SKILL_HAULING       /decl/hierarchy/skill/general/hauling
+#define SKILL_ATHLETICS     /decl/hierarchy/skill/general/athletics
 #define SKILL_PILOT         /decl/hierarchy/skill/general/pilot
 #define SKILL_COMPUTER      /decl/hierarchy/skill/general/computer
 #define SKILL_COOKING       /decl/hierarchy/skill/service/cooking

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -622,7 +622,7 @@ If this is needed in future, add new datum procs for adding allowed movers, and 
 	return 1
 
 /mob/living/carbon/human/get_stamina_used_per_step()
-	var/mod = (1-((get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)))
+	var/mod = (1-((get_skill_value(SKILL_ATHLETICS) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)))
 	if(species && (species.species_flags & SPECIES_FLAG_LOW_GRAV_ADAPTED))
 		if(has_gravity(src))
 			mod *= 1.2

--- a/code/modules/clothing/spacesuits/rig/modules/extension/speedboost.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/extension/speedboost.dm
@@ -5,10 +5,11 @@
 	active_power_cost = 500
 
 	module_tags = list(LOADOUT_TAG_RIG_MOVESPEED = 1)
+	require_suit = TRUE	//No superspeed in civilian rigs
 
 /obj/item/rig_module/extension/speedboost/advanced
 	name = "Advanced Femoral Exoskeleton"
-	desc = "An internal frame which supports leg motions, allowing the user to run approximately 25% faster than normal"
+	desc = "An internal frame which supports leg motions, allowing the user to run approximately 22.5% faster than normal"
 	extension_type = /datum/extension/rig_speedboost/advanced
 	active_power_cost = 750
 
@@ -20,4 +21,4 @@
 	statmods = list(STATMOD_MOVESPEED_ADDITIVE = 0.15)
 
 /datum/extension/rig_speedboost/advanced
-	statmods = list(STATMOD_MOVESPEED_ADDITIVE = 0.25)
+	statmods = list(STATMOD_MOVESPEED_ADDITIVE = 0.225)

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -101,6 +101,10 @@
 	*/
 	var/module_tags
 
+
+	//If true, this module requires the rig to have a chest piece, IE a suit. Meaning it can't be installed in back-only rigs, like the civilian RIG
+	var/require_suit = FALSE
+
 /obj/item/rig_module/Initialize()
 	.=..()
 	if (!interface_name)
@@ -209,6 +213,10 @@
 	if (!redundant && check_conflict)
 		if (get_conflicting(rig))
 			return FALSE
+
+	if (require_suit && !rig.chest_type)
+		to_chat(user, "This module requires a RIG that has a suit component")
+		return FALSE
 	return TRUE
 
 //Returns any existing module which blocks the installation of this one

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -223,7 +223,7 @@
 
 		//If force is enabled, we check again with conflict detection turned off
 		if (!RM.can_install(src, user, FALSE))
-			to_chat(user, "The RIG already has a module of that class installed.")
+			to_chat(user, "The RIG either already has a module of that class installed, or this is not valid for some other reason.")
 			return FALSE
 
 	if (user)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -18,7 +18,8 @@
 		tally += chem_effects[CE_SLOWDOWN]
 
 	if(can_feel_pain())
-		if(get_shock() >= 10) tally += (get_shock() / 10) //pain shouldn't slow you down if you can't even feel it
+		if(get_shock() >= 10)
+			tally += (get_shock() / 10) //pain shouldn't slow you down if you can't even feel it
 
 
 	if(istype(buckled, /obj/structure/bed/chair/wheelchair))
@@ -31,9 +32,6 @@
 			else if(E.status & ORGAN_BROKEN)
 				tally += 1.5
 
-	if(shock_stage >= 10 || src.stamina <= 0)
-		tally += 3
-
 	if(is_asystole()) tally += 10  //heart attacks are kinda distracting
 
 	if(aiming && aiming.aiming_at) tally += 5 // Iron sights make you slower, it's a well-known fact.
@@ -44,11 +42,6 @@
 		tally += (283.222 - bodytemperature) / 10 * 1.75
 
 
-	tally += max(2 * stance_damage, 0) //damaged/missing feet or legs is slow
-
-
-	if(mRun in mutations)
-		tally = 0
 
 	tally += CONFIG_GET(number/human_delay)
 
@@ -132,7 +125,7 @@
 		handle_embedded_and_stomach_objects() //Moving with objects stuck in you can cause bad times.
 
 	var/lac_chance =  10 * encumbrance()
-	if(lac_chance && prob(skill_fail_chance(SKILL_HAULING, lac_chance)))
+	if(lac_chance && prob(skill_fail_chance(SKILL_ATHLETICS, lac_chance)))
 		make_reagent(1, /datum/reagent/lactate)
 		switch(rand(1,20))
 			if(1)

--- a/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/brute.dm
@@ -7,7 +7,7 @@
 	name_plural =  "Brutes"
 	blurb = "A powerful linebreaker and assault specialist, the brute can smash through almost any obstacle, and its tough frontal armor makes it perfect for assaulting entrenched positions. \n\
 	Very vulnerable to flanking attacks"
-	total_health = 450
+	total_health = 500
 	torso_damage_mult = 1 //Hitting centre mass is fine for brute
 
 	//Normal necromorph flags plus no slip

--- a/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/divider/divider.dm
@@ -4,7 +4,7 @@
 	mob_type = /mob/living/carbon/human/necromorph/divider
 	blurb = "A bizarre walking horrorshow, slow but extremely durable. On death, it splits into five smaller creatures, in an attempt to find a new body to control. The divider is hard to kill, and has several abilities which excel at pinning down a lone target."
 	unarmed_types = list(/datum/unarmed_attack/claws/strong/divider)
-	total_health = 240
+	total_health = 264
 	biomass = 150
 	require_total_biomass	=	BIOMASS_REQ_T2
 	mass = 120

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder/enhanced.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder/enhanced.dm
@@ -4,7 +4,7 @@
 	mob_type = /mob/living/carbon/human/necromorph/exploder/enhanced
 	blurb = "An expendable suicide bomber, the exploder's sole purpose is to go out in a blaze of glory, and hopefully take a few people with it."
 	unarmed_types = list(/datum/unarmed_attack/bite/weak/exploder) //Bite attack is a backup if blades are severed
-	total_health = 215	//It has high health for the sake of making it a bit harder to destroy without targeting the pustule. Exploding the pustule is always an instakill
+	total_health = 235	//It has high health for the sake of making it a bit harder to destroy without targeting the pustule. Exploding the pustule is always an instakill
 	limb_health_factor = 1.5
 	require_total_biomass	=	BIOMASS_REQ_T2
 	biomass = 165

--- a/code/modules/mob/living/carbon/human/species/necromorph/exploder/exploder.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/exploder/exploder.dm
@@ -9,7 +9,7 @@
 	mob_type = /mob/living/carbon/human/necromorph/exploder
 	blurb = "An expendable suicide bomber, the exploder's sole purpose is to go out in a blaze of glory, and hopefully take a few people with it."
 	unarmed_types = list(/datum/unarmed_attack/bite/weak/exploder) //Bite attack is a backup if blades are severed
-	total_health = 85	//It has high health for the sake of making it a bit harder to destroy without targeting the pustule. Exploding the pustule is always an instakill
+	total_health = 94	//It has high health for the sake of making it a bit harder to destroy without targeting the pustule. Exploding the pustule is always an instakill
 	biomass = 65
 	mass = 50
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/hunter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/hunter.dm
@@ -25,7 +25,7 @@
 	Avoid fire though."
 
 	//Health and Defense
-	total_health = 250
+	total_health = 275
 	torso_damage_mult = 0.5 //Hitting centre mass more fine for hunter
 	can_obliterate = FALSE
 	healing_factor = 4	//Minor constant healing

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/infector.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/infector.dm
@@ -13,7 +13,7 @@
 	mob_type	=	/mob/living/carbon/human/necromorph/infector
 	name_plural =  "Infectors"
 	blurb = "A high value, fragile support, the Infector works as a builder and healer"
-	total_health = 140
+	total_health = 155
 
 	//Normal necromorph flags plus no slip
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_POISON  | SPECIES_FLAG_NO_BLOCK | SPECIES_FLAG_NO_SLIP

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -16,7 +16,7 @@
 	mob_type	=	/mob/living/carbon/human/necromorph/leaper
 	blurb = "A long range ambusher, the leaper can leap on unsuspecting victims from afar, knock them down, and tear them apart with its bladed tail. Not good for prolonged combat though."
 	unarmed_types = list(/datum/unarmed_attack/claws) //Bite attack is a backup if blades are severed
-	total_health = 110
+	total_health = 121
 	biomass = 75
 
 	//Normal necromorph flags plus no slip

--- a/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/puker.dm
@@ -3,7 +3,7 @@
 	name = SPECIES_NECROMORPH_PUKER
 	bodytype = SPECIES_NECROMORPH_PUKER
 	name_plural = "pukers"
-	total_health = 160
+	total_health = 176
 	biomass = 130
 	require_total_biomass	=	BIOMASS_REQ_T2
 	mass = 120

--- a/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/slasher.dm
@@ -12,7 +12,7 @@
 	mob_type = /mob/living/carbon/human/necromorph/slasher
 	blurb = "The frontline soldier of the necromorph horde. Slow when not charging, but its blade arms make for powerful melee attacks"
 	unarmed_types = list(/datum/unarmed_attack/blades, /datum/unarmed_attack/bite/weak) //Bite attack is a backup if blades are severed
-	total_health = 90
+	total_health = 100
 	biomass = 50
 	mass = 70
 
@@ -138,7 +138,7 @@
 	marker_spawnable = TRUE 	//Enable this once we have sprites for it
 	mob_type = /mob/living/carbon/human/necromorph/slasher_enhanced
 	unarmed_types = list(/datum/unarmed_attack/blades/strong, /datum/unarmed_attack/bite/strong)
-	total_health = 225
+	total_health = 250
 	slowdown = 2.8
 	biomass = 125
 	require_total_biomass	=	BIOMASS_REQ_T2

--- a/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/spitter.dm
@@ -2,7 +2,7 @@
 /datum/species/necromorph/slasher/spitter
 	name = SPECIES_NECROMORPH_SPITTER
 	name_plural = "Spitters"
-	total_health = 65
+	total_health = 72
 	biomass = 55
 	mass = 45
 	view_range = 8

--- a/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/tripod.dm
@@ -15,7 +15,7 @@
 	mob_type	=	/mob/living/carbon/human/necromorph/tripod
 	name_plural =  "Tripods"
 	blurb = "A heavy skirmisher, the tripod is adept at leaping around open spaces and fighting against multiple distant targets."
-	total_health = 450
+	total_health = 475
 	torso_damage_mult = 0.65 //Hitting centre mass is fine for tripod
 
 	//Normal necromorph flags plus no slip

--- a/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/twitcher.dm
@@ -28,7 +28,7 @@
 	biomass	=	120
 	require_total_biomass	=	BIOMASS_REQ_T2
 	lying_rotation = 90
-	total_health = 100
+	total_health = 110
 
 	slowdown = 1.5
 	view_offset = 3 * WORLD_ICON_SIZE //Forward view offset allows longer-ranged charges

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -11,6 +11,10 @@
 	name_language = LANGUAGE_GALCOM
 	min_age = 16
 	max_age = 65
+
+	limb_health_factor = 1.1
+	pain_shock_threshold = 55
+
 	gluttonous = GLUT_TINY
 
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_NO_LACE

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -82,8 +82,20 @@ GLOBAL_LIST_EMPTY(skills)
 
 /decl/hierarchy/skill/general/hauling
 	ID = "hauling"
+	name = "Hauling"
+	desc = "Your ability to perform tasks requiring great strength. Affects the penalties of wearing heavy gear"
+	levels = list( "Unskilled"			= "You are not used to manual labor, tire easily, and are likely not in great shape. Extended heavy labor may be dangerous for you.",
+						"Basic"				= "You have some familiarity with manual labor, and are in reasonable physical shape. Tasks requiring great dexterity or strength may still elude you.",
+						"Trained"			= "You have sufficient strength and dexterity for even very strenuous tasks, and can work for a long time without tiring.",
+						"Experienced"		= "You have experience with heavy work in trying physical conditions, and are in excellent shape. You visit the gym frequently.",
+						"Master"		= "In addition to your excellent strength and endurance, you have a lot of experience with the specific physical demands of your job. You may have competitive experience with some form of athletics.")
+	difficulty = SKILL_EASY
+
+
+/decl/hierarchy/skill/general/athletics
+	ID = "athletics"
 	name = "Athletics"
-	desc = "Your ability to perform tasks requiring great strength, dexterity, or endurance. Affects work speed and failure chance when mining"
+	desc = "Your ability to perform tasks requiring great endurance. Affects your stamina costs"
 	levels = list( "Unskilled"			= "You are not used to manual labor, tire easily, and are likely not in great shape. Extended heavy labor may be dangerous for you.",
 						"Basic"				= "You have some familiarity with manual labor, and are in reasonable physical shape. Tasks requiring great dexterity or strength may still elude you.",
 						"Trained"			= "You have sufficient strength and dexterity for even very strenuous tasks, and can work for a long time without tiring.",

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -374,7 +374,7 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 	var/incoming_damage_mod = 0.85	//Incoming damage reduction
 
 	//Effects on non necros
-	var/slowdown = 0.60	//Movespeed Penalty
+	var/slowdown = 0.625	//Movespeed Penalty
 
 	var/speed_factor = 0
 

--- a/html/changelogs/speedhealth.yml
+++ b/html/changelogs/speedhealth.yml
@@ -55,5 +55,13 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance: "Reduced the speed bonus of advanced femoral exoskeleton"
-  - balance: "Slightly Increased stamina costs of sprinting, and slightly reduced stamina regen
+  - experiment: "Reduced human top speed. The intent here is to nerf the most extreme examples of zoomy humans without significantly affecting the majority of people. This is broken up into several changes:"
+  - balance: "Reduced the speed bonus of advanced femoral exoskeleton, Basic femoral unaffected"
+  - balance: "Slightly Increased stamina costs of sprinting, and slightly reduced stamina regen"
+  - balance: "Athletics skill is now broken into two skills, Hauling and Athletics. The former affects speed penalties from encumbrance, throwing, and pulling, the latter affects stamina costs."
+  - balance: "Slightly increased corruption slowdown effect on humans."
+  - balance: "Slightly decreased sprint speed, and slightly increased walking speed."
+  - experiment: "Increased Time To Kill (TTK) by 10% across the board. This is broken up into several changes:"
+  - balance: "Increased human limb health by 10%"
+  - balance: "Increased human pain-shock threshold by 10%. from 50 to 55 This is the quantity of pain that can be suffered without any real bad effects."
+  - tweak: "Increased health of all necromorphs by 10%"

--- a/html/changelogs/stairfix.yml
+++ b/html/changelogs/stairfix.yml
@@ -55,5 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance: "Reduced the speed bonus of advanced femoral exoskeleton"
-  - balance: "Slightly Increased stamina costs of sprinting, and slightly reduced stamina regen
+  - bugfix: "Corruption now grows through stairs and ladders again"


### PR DESCRIPTION
Changes aimed at shifting the metagame based on discussion with staff yesterday

Two broad categories: Nerfing the speed of powergamers, and increasing TTK across the board

changes:
  - experiment: "Reduced human top speed. The intent here is to nerf the most extreme examples of zoomy humans without significantly affecting the majority of people. This is broken up into several changes:"
  - balance: "Reduced the speed bonus of advanced femoral exoskeleton, Basic femoral unaffected"
  - balance: "Slightly Increased stamina costs of sprinting, and slightly reduced stamina regen"
  - balance: "Athletics skill is now broken into two skills, Hauling and Athletics. The former affects speed penalties from encumbrance, throwing, and pulling, the latter affects stamina costs."
  - balance: "Slightly increased corruption slowdown effect on humans."
  - balance: "Slightly decreased sprint speed, and slightly increased walking speed."
  - experiment: "Increased Time To Kill (TTK) by 10% across the board. This is broken up into several changes:"
  - balance: "Increased human limb health by 10%"
  - balance: "Increased human pain-shock threshold by 10%. from 50 to 55 This is the quantity of pain that can be suffered without any real bad effects."
  - tweak: "Increased health of all necromorphs by 10%"