### PR TITLE
SStimer runtimes fix

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -11,7 +11,7 @@
 	cache_lifespan = 7
 	hub = "Exadv1.spacestation13"
 	icon_size = WORLD_ICON_SIZE
-	fps = 20
+	fps = 50
 #ifdef GC_FAILURE_HARD_LOOKUP
 	loop_checks = FALSE
 #endif


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
### Purpose
Fixes a lot of SStimer runtimes. Most likely they were caused by changing FPS during world initialization instead of setting it in the code. This shouldn't affect anything, I haven't seen any timer runtimes playing this branch but it's possible that they will exist after this PR since runtimes are randomly triggered and I was just unlucky in reproducing any of them.