### PR TITLE
No DB connected = all designs in the store

### DIFF
--- a/code/controllers/subsystems/characters/database_persistence.dm
+++ b/code/controllers/subsystems/characters/database_persistence.dm
@@ -224,6 +224,8 @@ SUBSYSTEM_DEF(database)
 		//Cache this
 		unknown_designs	=	designs
 
+	else
+		SSdatabase.known_designs = designs
 
 	//And now reload the database for individual stores
 	load_store_database()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
### Purpose
If there is no database connected all designs will appear in the store. I have tested it and it seems to work.
If buying something in the store does interact with db this PR will cause runtimes (I don't remember such things so it shouldn't).