### PR TITLE
Mining Tweaks and Credit Fixes

### DIFF
--- a/code/controllers/subsystems/characters/database_persistence.dm
+++ b/code/controllers/subsystems/characters/database_persistence.dm
@@ -64,16 +64,18 @@ SUBSYSTEM_DEF(database)
 /*
 	Credit Handling
 */
-/datum/controller/subsystem/database/proc/credits_changed(var/datum/mind/M)
+/datum/controller/subsystem/database/credits_changed(var/datum/mind/M)
 	credits_to_update |= M
 
+/datum/proc/credits_changed()
+
 //Mob level helper
-/mob/proc/credits_changed()
+/mob/credits_changed()
 	if (mind)
 		SSdatabase.credits_changed(mind)
 
 //Item helper
-/obj/item/proc/credits_changed()
+/obj/item/credits_changed()
 	var/mob/M = get_holding_mob()
 	if(M)
 		M.credits_changed()

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -92,6 +92,7 @@
 
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null)
 	if(H.mind)
+
 		var/remembered_info = ""
 		remembered_info += "<b>Your account number is:</b> #[M.account_number]<br>"
 		remembered_info += "<b>Your account pin is:</b> [M.remote_access_pin]<br>"
@@ -103,6 +104,7 @@
 		H.mind.store_memory(remembered_info)
 
 		H.mind.initial_account = M
+		M.mind = H.mind	//Give the account a link to our mind
 		update_lastround_credits(H.mind)	//Update persistent credits to prepare for future changes
 
 	to_chat(H, "<span class='notice'><b>Your account number is: [M.account_number], your account pin is: [M.remote_access_pin]</b></span>")

--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -15,7 +15,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "satchel"
 	slot_flags = SLOT_BELT
-	max_storage_space = 20
+	max_storage_space = 30
 	max_w_class = ITEM_SIZE_NORMAL
 	w_class = ITEM_SIZE_LARGE
 	can_hold = list(/obj/item/weapon/ore)

--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -15,7 +15,7 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "satchel"
 	slot_flags = SLOT_BELT
-	max_storage_space = 200
+	max_storage_space = 20
 	max_w_class = ITEM_SIZE_NORMAL
 	w_class = ITEM_SIZE_LARGE
 	can_hold = list(/obj/item/weapon/ore)

--- a/code/modules/economy/money_account.dm
+++ b/code/modules/economy/money_account.dm
@@ -10,9 +10,17 @@
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
 
+	var/datum/mind/mind = null 	//Optional, contains a character mind this account is associated with
+
+/datum/money_account/credits_changed()
+	to_chat(world, "money account credits changed")
+	if (mind)
+		SSdatabase.credits_changed(mind)
+
 /datum/money_account/proc/do_transaction(var/datum/transaction/T)
 	money = max(0, money + T.amount)
 	transaction_log += T
+	credits_changed()
 
 /datum/money_account/proc/get_balance()
 	. = 0

--- a/code/modules/economy/money_account.dm
+++ b/code/modules/economy/money_account.dm
@@ -13,7 +13,6 @@
 	var/datum/mind/mind = null 	//Optional, contains a character mind this account is associated with
 
 /datum/money_account/credits_changed()
-	to_chat(world, "money account credits changed")
 	if (mind)
 		SSdatabase.credits_changed(mind)
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -34,6 +34,7 @@ var/list/mining_floors = list()
 	var/obj/item/weapon/last_find
 	var/datum/artifact_find/artifact_find
 
+	var/mining_done = FALSE
 
 	has_resources = 1
 
@@ -333,6 +334,10 @@ var/list/mining_floors = list()
 	finish_mining()
 
 /turf/simulated/mineral/proc/finish_mining()
+	if (mining_done)
+		return
+
+	mining_done = TRUE
 	//var/destroyed = 0 //used for breaking strange rocks
 	if (mineral && mineral.result_amount)
 

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -10,18 +10,32 @@
 	var/last_update = 0
 	var/list/stored_ore = list()
 
+	var/max_contents = 150
+
+
 /obj/structure/ore_box/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if (istype(W, /obj/item/weapon/ore))
+		if (contents.len >= max_contents)
+			to_chat(user, "<span class='danger'>The ore box is full!</span>")
+			return
 		user.unEquip(W, src)
 	else if (istype(W, /obj/item/weapon/storage))
+		if (contents.len >= max_contents)
+			to_chat(user, "<span class='danger'>The ore box is full!</span>")
+			return
 		var/obj/item/weapon/storage/S = W
 		S.hide_from(usr)
 		for(var/obj/item/weapon/ore/O in S.contents)
+			if (contents.len >= max_contents)
+				to_chat(user, "<span class='danger'>You filled the ore box, but there's still ore in the satchel.</span>")
+				return
 			S.remove_from_storage(O, src, 1) //This will move the item to this item's contents
+
 		S.finish_bulk_removal()
 		to_chat(user, "<span class='notice'>You empty the satchel into the box.</span>")
 
 	update_ore_count()
+
 
 //A debug type that contains a bunch of randomly generated ores
 /obj/structure/ore_box/random/Initialize()
@@ -76,6 +90,8 @@
 	to_chat(user, "It holds:")
 	for(var/ore in stored_ore)
 		to_chat(user, "- [stored_ore[ore]] [ore]")
+
+	to_chat(user, "It is [(contents.len / max_contents)*100]% full")
 	return
 
 

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -82,7 +82,7 @@
 			else                             // Deep metals.
 				T.resources["uranium"] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
 				T.resources[MATERIAL_DIAMOND] =  rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
-				T.resources[MATERIAL_PHORON] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
+				T.resources[MATERIAL_PHORON] =   rand(RESOURCE_MID_MIN, RESOURCE_HIGH_MAX)
 				T.resources["osmium"] =   rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
 				T.resources["hydrogen"] = rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources["iron"] =     0

--- a/html/changelogs/mining.yml
+++ b/html/changelogs/mining.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Nanako"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Mining satchels and ore boxes now have a significantly smaller capacity, so they need to be hauled back to the processor more often. This change is designed to encourage cooperation, and slow down solo-miners. Bring a friend with you to carry your stuff!"
+  - bugfix: "Fixed a major bug where rock turfs mined out with ranged toolguns (like plasma cutter and line cutter) were giving double ore yields. This was never an intended thing."
+  - bugfix: "Fixed a case where credits weren't being saved from payday and mining bonuses."


### PR DESCRIPTION
changes:
  - balance: "Mining satchels and ore boxes now have a significantly smaller capacity, so they need to be hauled back to the processor more often. This change is designed to encourage cooperation, and slow down solo-miners. Bring a friend with you to carry your stuff!"
  - bugfix: "Fixed a major bug where rock turfs mined out with ranged toolguns (like plasma cutter and line cutter) were giving double ore yields. This was never an intended thing."
  - bugfix: "Fixed a case where credits weren't being saved from payday and mining bonuses."