### PR TITLE
Vitals Monitor: Heart stop sound

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -467,6 +467,7 @@
 #include "code\datums\observation\equipped.dm"
 #include "code\datums\observation\exited.dm"
 #include "code\datums\observation\global_listener.dm"
+#include "code\datums\observation\heart_stop.dm"
 #include "code\datums\observation\helpers.dm"
 #include "code\datums\observation\life.dm"
 #include "code\datums\observation\logged_in.dm"

--- a/code/datums/observation/heart_stop.dm
+++ b/code/datums/observation/heart_stop.dm
@@ -1,0 +1,13 @@
+//	Observer Pattern Implementation: Heart Stop
+//		Registration type: /mob/living/carbon/human
+//
+//		Raised when: Human heart stops
+//
+//		Arguments that the called proc should expect:
+//			/mob/dead: The mob that was added to the dead_mob_list
+
+GLOBAL_DATUM_INIT(heart_stop_event, /decl/observ/heart_stop, new)
+
+/decl/observ/heart_stop
+	name = "Heart Stop"
+	expected_type = /mob/living/carbon/human

--- a/code/modules/clothing/spacesuits/rig/modules/ds13/healthbar.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ds13/healthbar.dm
@@ -59,12 +59,14 @@
 	user = newuser
 	GLOB.updatehealth_event.register(user, src, /obj/item/rig_module/healthbar/proc/update)
 	GLOB.death_event.register(user, src, /obj/item/rig_module/healthbar/proc/death)
+	GLOB.heart_stop_event.register(user, src, /obj/item/rig_module/healthbar/proc/heart_stop)
 	holder.healthbar = src
 
 /obj/item/rig_module/healthbar/proc/unregister_user()
 	if(user)
 		GLOB.updatehealth_event.unregister(user, src, /obj/item/rig_module/healthbar/proc/update)
 		GLOB.death_event.unregister(user, src, /obj/item/rig_module/healthbar/proc/death)
+		GLOB.heart_stop_event.unregister(user, src, /obj/item/rig_module/healthbar/proc/heart_stop)
 		user = null
 		holder.healthbar = null
 
@@ -97,6 +99,10 @@
 
 /obj/item/rig_module/healthbar/proc/death()
 	playsound(src, 'sound/effects/rig/modules/flatline.ogg', VOLUME_MAX, 0, 4)
+	update()
+
+/obj/item/rig_module/healthbar/proc/heart_stop()
+	playsound(src, 'sound/effects/caution.ogg', VOLUME_MAX, 0, 4)
 	update()
 
 // Automatically updates tracking level depending on current station alert

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -32,7 +32,7 @@
 
 	switch(M.a_intent)
 		if(I_HELP)
-			if (!can_grasp_with_selected())
+			if (!H.can_grasp_with_selected())
 				to_chat(H, "<span class='warning'>You can't use your hand.</span>")
 				return
 			if(istype(H) && (is_asystole() || (status_flags & FAKEDEATH)))
@@ -40,13 +40,14 @@
 					return 0
 
 				cpr_time = 0
-				spawn(30)
-					cpr_time = 1
 
 				H.visible_message("<span class='notice'>\The [H] is trying to perform CPR on \the [src].</span>")
 
 				if(!do_after(H, 30, src))
+					cpr_time = 1
 					return
+
+				cpr_time = 1
 
 				H.visible_message("<span class='notice'>\The [H] performs CPR on \the [src]!</span>")
 				if(prob(5))

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -103,6 +103,7 @@
 		if(should_stop) // The heart has stopped due to going into traumatic or cardiovascular shock.
 			to_chat(owner, "<span class='danger'>Your heart has stopped!</span>")
 			pulse = PULSE_NONE
+			GLOB.heart_stop_event.raise_event(src)
 			return
 	if(pulse && oxy <= BLOOD_VOLUME_SURVIVE && !owner.chem_effects[CE_STABLE])	//I SAID MOAR OXYGEN
 		pulse = PULSE_THREADY

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -103,7 +103,7 @@
 		if(should_stop) // The heart has stopped due to going into traumatic or cardiovascular shock.
 			to_chat(owner, "<span class='danger'>Your heart has stopped!</span>")
 			pulse = PULSE_NONE
-			GLOB.heart_stop_event.raise_event(src)
+			GLOB.heart_stop_event.raise_event(owner)
 			return
 	if(pulse && oxy <= BLOOD_VOLUME_SURVIVE && !owner.chem_effects[CE_STABLE])	//I SAID MOAR OXYGEN
 		pulse = PULSE_THREADY

--- a/html/changelogs/DTraitor-PR-vitals-heart-stop.yml
+++ b/html/changelogs/DTraitor-PR-vitals-heart-stop.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "DTraitor"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Vitals Monitor plays sound on heart stop now."
+  - bugfix: "Fixed 'You can't use your hand' bug."


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
### Purpose
Fixes: https://github.com/DS-13-Dev-Team/DS13/issues/626
Vitals monitor plays sound when the heart stops.