### PR TITLE
fixes weapon cells

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -10,6 +10,8 @@
 	power_channel = EQUIP
 	var/obj/item/weapon/cell/charging = null
 	var/chargelevel = -1
+	var/charge_comp = 1 // Used when trying to charge special weapon cells. So they don't charge too fast.
+	var/list/compensated_devices = list (/obj/item/weapon/cell/contact, /obj/item/weapon/cell/force)
 
 /obj/machinery/cell_charger/update_icon()
 	icon_state = "ccharger[charging ? 1 : 0]"
@@ -40,6 +42,10 @@
 /obj/machinery/cell_charger/attackby(obj/item/weapon/W, mob/user)
 	if(stat & BROKEN)
 		return
+
+	for (var/compensated_type in compensated_devices)
+		if (istype(W, compensated_type)) charge_comp = 0.2
+		else charge_comp = 1
 
 	if(istype(W, /obj/item/weapon/cell) && anchored)
 		if(charging)
@@ -104,7 +110,7 @@
 		return
 
 	if (charging && !charging.fully_charged())
-		charging.give(active_power_usage*CELLRATE)
+		charging.give(active_power_usage*charge_comp*CELLRATE)
 		update_use_power(2)
 
 		update_icon()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -12,7 +12,9 @@ obj/machinery/recharger
 	circuit = /obj/item/weapon/circuitboard/recharger
 	var/obj/item/charging = null
 	var/recharge_coeff = 1
+	var/charge_comp = 1 // Used when trying to charge special weapon cells. So they don't charge too fast.
 	var/list/allowed_devices = list(/obj/item/weapon/gun/energy, /obj/item/weapon/gun/magnetic/railgun, /obj/item/weapon/melee/baton, /obj/item/weapon/cell, /obj/item/modular_computer/, /obj/item/device/suit_sensor_jammer, /obj/item/weapon/computer_hardware/battery_module, /obj/item/weapon/shield_diffuser, /obj/item/clothing/mask/smokable/ecig, /obj/item/device/radio)
+	var/list/compensated_devices = list (/obj/item/weapon/cell/contact, /obj/item/weapon/cell/force)
 	var/icon_state_charged = "recharger2"
 	var/icon_state_charging = "recharger1"
 	var/icon_state_idle = "recharger0" //also when unpowered
@@ -36,6 +38,10 @@ obj/machinery/recharger/attackby(obj/item/weapon/G as obj, mob/user as mob)
 	var/allowed = 0
 	for (var/allowed_type in allowed_devices)
 		if (istype(G, allowed_type)) allowed = 1
+
+	for (var/compensated_type in compensated_devices)
+		if (istype(G, compensated_type)) charge_comp = 0.2
+		else charge_comp = 1
 
 	if(allowed)
 		if(charging)
@@ -92,7 +98,7 @@ obj/machinery/recharger/Process()
 		if(istype(C))
 			if(!C.fully_charged())
 				icon_state = icon_state_charging
-				C.give(active_power_usage*recharge_coeff*CELLRATE)
+				C.give(active_power_usage*recharge_coeff*charge_comp*CELLRATE)
 				update_use_power(2)
 			else
 				icon_state = icon_state_charged

--- a/code/modules/projectiles/guns/ds13/contactbeam.dm
+++ b/code/modules/projectiles/guns/ds13/contactbeam.dm
@@ -19,7 +19,7 @@
 	wielded_item_state = "contact-wielded"
 	w_class = ITEM_SIZE_HUGE
 
-	charge_cost = 1000 //Five shots per battery
+	charge_cost = 250 //Five shots per battery
 	cell_type = /obj/item/weapon/cell/contact
 	projectile_type = null
 	slot_flags = SLOT_BACK
@@ -259,7 +259,7 @@
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "contact_energy"
 	w_class = ITEM_SIZE_LARGE
-	maxcharge = 4000
+	maxcharge = 1000
 	matter = list(MATERIAL_STEEL = 700, MATERIAL_SILVER = 80)
 
 /obj/item/weapon/cell/contact/update_icon()

--- a/code/modules/projectiles/guns/ds13/forcegun.dm
+++ b/code/modules/projectiles/guns/ds13/forcegun.dm
@@ -15,7 +15,7 @@
 	item_state = "forcegun"
 	w_class = ITEM_SIZE_BULKY
 
-	charge_cost = 1000 //Five shots per battery
+	charge_cost = 200 //Five shots per battery
 	cell_type = /obj/item/weapon/cell/force
 	projectile_type = null
 	slot_flags = SLOT_BACK
@@ -182,7 +182,7 @@
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "forcebattery"
 	w_class = ITEM_SIZE_NORMAL
-	maxcharge = 5000
+	maxcharge = 1000
 	matter = list(MATERIAL_STEEL = 700, MATERIAL_SILVER = 80)
 
 /obj/item/weapon/cell/force/update_icon()


### PR DESCRIPTION
Turns all weapon cells into having only 1000 charge max.
Lowers the cost of firing contact beam/forcegun by a magnitude of 5.
Makes these weapon cells charge 5 times as slow. (To preserve the same charge rate as before)

The only purpose this serves is to stop people from using weapon cells as rig power except as a last resort. 1000 is still a decent amount of power. Currently people powergame by buying these energy cells not to use the weapon, but as a source of long lasting rig power.
