### PR TITLE
Nerfs javelin's fire-rate

### DIFF
--- a/code/modules/projectiles/guns/projectile/javelin.dm
+++ b/code/modules/projectiles/guns/projectile/javelin.dm
@@ -23,7 +23,7 @@
 
 
 	firemodes = list(
-		list(mode_name = "launch", fire_delay = 1.5, fire_sound = 'sound/weapons/guns/fire/jav_fire.ogg'),
+		list(mode_name = "launch", fire_delay = 2.5, fire_sound = 'sound/weapons/guns/fire/jav_fire.ogg'),
 		list(mode_name = "shock mode", mode_type = /datum/firemode/automatic/shock, projectile_type = /obj/item/projectile/null_projectile, fire_delay = 3)
 		)
 

--- a/html/changelogs/KetraiJavlgun.yml
+++ b/html/changelogs/KetraiJavlgun.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Nerfs javelin fire delay from 1.5 to 2.5 seconds."


### PR DESCRIPTION

Lowers the jav's firerate from 1.5 seconds to 2.5 seconds. It felt semi-automatic, this should be a better balance between its knockback buying space, and a little leeway to miss.