### PR TITLE
Reworks enhanced leaper

### DIFF
--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -34,7 +34,7 @@
 
 	evasion = 20	//Harder to hit than usual
 	var/stun = 2 //stun duration
-	var/leap_damage = 3
+	var/leap_damage = 2.8
 
 	view_range = 9
 	// view_offset = (WORLD_ICON_SIZE*3)	//Just no.
@@ -160,7 +160,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	total_health = 225
 	limb_health_factor = 1.6
 	evasion = 30
-	leap_damage = 3.3
+	leap_damage = 1.4
 	stun = 1
 
 	biomass = 180
@@ -299,7 +299,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	else
 		H.play_species_audio(H, SOUND_SHOUT, 100, 1, 3)
 
-	return leap_attack(A, _cooldown = 4 SECONDS, _delay = 1 SECONDS, _speed = 8, _maxrange = 11, _lifespan = 8 SECONDS, _maxrange = 20)
+	return leap_attack(A, _cooldown = 4 SECONDS, _delay = 0.9 SECONDS, _speed = 8, _maxrange = 11, _lifespan = 8 SECONDS, _maxrange = 20)
 
 
 /atom/movable/proc/leaper_leap_monkey(var/mob/living/A)
@@ -387,7 +387,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 		A = get_step(src, dir)
 
 	//The sound has a randomised delay
-	if(tailstrike_attack(A, _damage = 28, _windup_time = 0.6 SECONDS, _winddown_time = 1 SECONDS, _cooldown = 0))
+	if(tailstrike_attack(A, _damage = 10, _windup_time = 0.55 SECONDS, _winddown_time = 0.9 SECONDS, _cooldown = 0))
 		spawn(rand_between(0, 1.8 SECONDS))
 			play_species_audio(src, SOUND_ATTACK, 30, 1)
 
@@ -415,7 +415,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 		return
 
 
-	if (gallop_ability(_duration = 4 SECONDS, _cooldown = 10 SECONDS, _power = 3))
+	if (gallop_ability(_duration = 4 SECONDS, _cooldown = 15 SECONDS, _power = 3))
 		H.play_species_audio(H, SOUND_SHOUT, VOLUME_MID, 1, 3)
 
 /mob/living/proc/leaper_gallop_enhanced()

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -372,7 +372,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 		A = get_step(src, dir)
 
 
-	.=tailstrike_attack(A, _damage = 20, _windup_time = 0.75 SECONDS, _winddown_time = 1.2 SECONDS, _cooldown = 2)
+	.=tailstrike_attack(A, _damage = 20, _windup_time = 0.75 SECONDS, _winddown_time = 1.2 SECONDS, _cooldown = 2.5)
 	if (.)
 		//The sound has a randomised delay
 		spawn(rand_between(0, 2 SECONDS))

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -387,7 +387,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 		A = get_step(src, dir)
 
 	//The sound has a randomised delay
-	if(tailstrike_attack(A, _damage = 10, _windup_time = 0.55 SECONDS, _winddown_time = 0.9 SECONDS, _cooldown = 0))
+	if(tailstrike_attack(A, _damage = 10, _windup_time = 0.55 SECONDS, _winddown_time = 0.9 SECONDS, _cooldown = 0.5))
 		spawn(rand_between(0, 1.8 SECONDS))
 			play_species_audio(src, SOUND_ATTACK, 30, 1)
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -161,7 +161,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 	limb_health_factor = 1.6
 	evasion = 30
 	leap_damage = 1.4
-	stun = 1
+	stun = 0.5
 
 	biomass = 180
 	spawner_spawnable = FALSE

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -372,7 +372,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 		A = get_step(src, dir)
 
 
-	.=tailstrike_attack(A, _damage = 20, _windup_time = 0.75 SECONDS, _winddown_time = 1.2 SECONDS, _cooldown = 0.5)
+	.=tailstrike_attack(A, _damage = 20, _windup_time = 0.75 SECONDS, _winddown_time = 1.2 SECONDS, _cooldown = 2)
 	if (.)
 		//The sound has a randomised delay
 		spawn(rand_between(0, 2 SECONDS))

--- a/html/changelogs/Ketraiehnerf.yml
+++ b/html/changelogs/Ketraiehnerf.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Made enhanced leaper more agile."
+  - balance: "More than halves enhanced leaper damage."
+  - balance: "Lowered leaper damage slightly."
+  - balance: "Leaper is now unable to gallop continuously, there's downtime."


### PR DESCRIPTION
  - balance: "Made enhanced leaper more agile."
  - balance: "More than halves enhanced leaper damage."
  - balance: "Lowered leaper damage slightly."
  - balance: "Leaper is now unable to gallop continuously, there's downtime."
  
  Enhanced leapers are now quick, but their damage is far less than that of a regular leaper. This should make them rely more on cooperation with other necros, especially regular leapers.
  
  Regular leapers now can't gallop basically without cooldown. They've got an actual cooldown to their tail strike as well so it's unable to be spammed anymore. This should make them meme doors less quickly, and give survivors more of a chance to recover from being leapt on at close range.