### PR TITLE
Infector rework.

### DIFF
--- a/code/__defines/skills_stats.dm
+++ b/code/__defines/skills_stats.dm
@@ -39,6 +39,7 @@
 #define STATMOD_SCALE "scale"
 #define STATMOD_CONVERSION_COMPATIBILITY	"conversion compatibility"
 #define STATMOD_LAYER	"layer"
+#define STATMOD_HEALTH_MULTIPLICATIVE "health percent"
 
 //Resource Defines
 #define RESOURCE_ESSENCE	/datum/extension/resource/essence

--- a/code/datums/extensions/extension_statmod.dm
+++ b/code/datums/extensions/extension_statmod.dm
@@ -16,6 +16,7 @@
 	Max Health							STATMOD_HEALTH							A flat value which is added or removed
 	Conversion Compatibility			STATMOD_CONVERSION_COMPATIBILITY			A flat value which is added or removed
 	Layer								STATMOD_LAYER							A flat value, the highest one is used and all others are ignored. Note that any specified value, even if lower, will override the base layer
+	Health Percent						STATMOD_HEALTH_PERCENT					A percentage value, 0=no change, 1 = +100%, etc. Negative allowed
 */
 
 
@@ -32,7 +33,8 @@ STATMOD_EVASION = list(/datum/proc/update_evasion),
 STATMOD_VIEW_RANGE = list(/datum/proc/update_vision_range),
 STATMOD_SCALE	=	list(/datum/proc/update_scale),
 STATMOD_HEALTH	=	list(/datum/proc/update_max_health),
-STATMOD_LAYER	=	list(/datum/proc/reset_layer)
+STATMOD_LAYER	=	list(/datum/proc/reset_layer),
+STATMOD_HEALTH_MULTIPLICATIVE	=	list(/datum/proc/update_max_health)
 //Conversion compatibility doesn't get an entry here, its only used by infector conversions
 ))
 
@@ -278,6 +280,12 @@ STATMOD_LAYER	=	list(/datum/proc/reset_layer)
 
 /mob/living/update_max_health()
 	max_health = get_base_health()
+
+	for (var/datum/extension/E as anything in LAZYACCESS(statmods, STATMOD_HEALTH_MULTIPLICATIVE))
+		var/health_increase = (max_health * E.get_statmod(STATMOD_HEALTH_MULTIPLICATIVE))
+		max_health += health_increase
+
+
 	for (var/datum/extension/E as anything in LAZYACCESS(statmods, STATMOD_HEALTH))
 		max_health += E.get_statmod(STATMOD_HEALTH)
 
@@ -290,8 +298,6 @@ STATMOD_LAYER	=	list(/datum/proc/reset_layer)
 
 /mob/living/carbon/human/get_base_health()
 	return species.total_health
-
-
 
 //Layer
 

--- a/code/modules/mob/living/abilities/ability.dm
+++ b/code/modules/mob/living/abilities/ability.dm
@@ -31,7 +31,7 @@
 	var/ongoing_timer
 	var/tick_timer
 
-	var/atom/target
+	var/atom/movable/target
 
 	var/resource_cost_type	=	null
 	var/resource_cost_quantity = 1

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/essence_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/essence_abilities.dm
@@ -6,7 +6,7 @@
 	"Forming: Maw" = /datum/extension/ability/construction/corruption/maw,
 	"Forming: Eye" = /datum/extension/ability/construction/corruption/eye,
 	"Forming: Snare" = /datum/extension/ability/construction/corruption/snare,
-	"Forming: Propagator" = /datum/extension/ability/construction/corruption/growth,
+	"Forming: Propagator" = /datum/extension/ability/construction/corruption/branch,
 	"Forming: New Growth" = /datum/extension/ability/construction/corruption/newgrowth,
 	"Forming: Harvester" = /datum/extension/ability/construction/corruption/harvester,
 	"Forming: Bioluminescence" = /datum/extension/ability/construction/corruption/light)
@@ -40,17 +40,17 @@
 /datum/extension/resource/essence
 	name = "Essence"
 	current_value = 5 //5 points free to start with
-	max_value = 15
+	max_value = 20
 	regen = (1 SECOND) / (1 MINUTE)	//One point regenerated per minute
 	meter_type = /atom/movable/screen/meter/resource/essence
 	var/list/selected_essence_ability	//Used by infector, this is a list containing the type and parameters of the essence ability we have selected
 
 
-//Regenerates faster when over half, to encourage cautious allocation
+//Regenerates faster when over 37.5%, to encourage cautious allocation
 /datum/extension/resource/essence/get_regen_amount()
 	.=..()
-	if (current_value >= max_value * 0.5)
-		.*=1.5
+	if (current_value >= max_value * 0.375)
+		.*=1.6
 
 /*
 	Entrypoints
@@ -100,7 +100,7 @@
 	duration = 13 SECONDS
 	reach = 2
 	resource_cost_type	=	RESOURCE_ESSENCE
-	resource_cost_quantity = 3
+	resource_cost_quantity = 3.5
 
 /datum/extension/ability/domob/reanimate/apply_start_effect()
 	var/mob/living/L = target
@@ -130,13 +130,14 @@
 */
 /datum/extension/ability/domob/engorge
 	name = "Engorge"
-	blurb = "Makes the targeted necromorph larger, increasing its health, movespeed and view range."
+	blurb = "Makes the targeted necromorph larger, increasing its health, movespeed and view range. Costs more to engorge expensive necromorphs"
 	resource_cost_type	=	RESOURCE_ESSENCE
 	resource_cost_quantity = 2
 
 /datum/extension/ability/domob/engorge/apply_effect()
 	if (!has_extension(target, /datum/extension/engorge))
 		set_extension(target, /datum/extension/engorge)
+		user.consume_resource(resource_cost_type, (target.biomass * 0.005))
 
 /datum/extension/ability/domob/engorge/is_valid_target(var/datum/potential_target, var/mob/potential_user)
 	.=..()
@@ -160,13 +161,12 @@
 			to_chat(potential_user, "You can't target yourself!")
 			return FALSE
 
-
-
 /datum/extension/engorge
 	flags = EXTENSION_FLAG_IMMEDIATE
 	statmods = list(STATMOD_SCALE	=	0.15,
 	STATMOD_MOVESPEED_MULTIPLICATIVE = 1.08,
-	STATMOD_HEALTH = 50,
+	STATMOD_HEALTH = 10,
+	STATMOD_HEALTH_MULTIPLICATIVE = 0.15,
 	STATMOD_VIEW_RANGE = 1)
 
 
@@ -272,24 +272,24 @@
 	blurb = "Constructs a Snare, used as a floor trap."
 	result_path = /obj/structure/corruption_node/snare
 	construction_time = 5	//Seconds
-	resource_cost_quantity = 1
+	resource_cost_quantity = 0.6
 
 
-/datum/extension/ability/construction/corruption/growth
-	name = "Forming: Propagator"
-	blurb = "Constructs a Propagator, used to spread corruption."
-	result_path = /obj/structure/corruption_node/growth
-	construction_time = 30	//Seconds
-	resource_cost_quantity = 4
+/datum/extension/ability/construction/corruption/branch
+	name = "Forming: Branch"
+	blurb = "Constructs a Branch, used to spread corruption."
+	result_path = /obj/structure/corruption_node/growth/branch
+	construction_time = 15	//Seconds
+	resource_cost_quantity = 2
 
 
 /datum/extension/ability/construction/corruption/newgrowth
 	name = "Forming: New Growth"
-	blurb = "Constructs a Propagator without requiring existing corruption, allowing an entirely new place to be corrupted. \n\
+	blurb = "Constructs a tiny node without requiring existing corruption, allowing an entirely new place to be corrupted. \n\
 	This is very slow and expensive, multiple Infectors should work together."
-	result_path = /obj/structure/corruption_node/growth
-	construction_time = 300	//Seconds
-	resource_cost_quantity = 30
+	result_path = /obj/structure/corruption_node/growth/mini
+	construction_time = 180	//Seconds
+	resource_cost_quantity = 10
 	deposit = 0.05	//1.5 base deposit
 	require_corruption = FALSE
 

--- a/code/modules/mob/living/carbon/human/species/necromorph/infector/infector.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/infector/infector.dm
@@ -13,7 +13,7 @@
 	mob_type	=	/mob/living/carbon/human/necromorph/infector
 	name_plural =  "Infectors"
 	blurb = "A high value, fragile support, the Infector works as a builder and healer"
-	total_health = 155
+	total_health = 90
 
 	//Normal necromorph flags plus no slip
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_MINOR_CUT | SPECIES_FLAG_NO_POISON  | SPECIES_FLAG_NO_BLOCK | SPECIES_FLAG_NO_SLIP
@@ -27,10 +27,9 @@
 	//health_doll_offset	= 56
 
 
-	biomass = 150
-	require_total_biomass	=	BIOMASS_REQ_T2
+	biomass = 105
 	mass = 30
-	biomass_reclamation_time	=	15 MINUTES
+	biomass_reclamation_time	=	10 MINUTES
 	marker_spawnable = TRUE
 
 
@@ -286,6 +285,9 @@ All of them except New Growth require corruption to build upon\
 	.= shoot_ability(/datum/extension/shoot/longshot/spine, A , /obj/item/projectile/bullet/spine/venomous, accuracy = 50, dispersion = 0, num = 1, windup_time = 0 SECONDS, fire_sound = null, cooldown = 10 SECONDS)
 	if (.)
 		play_species_audio(src, SOUND_ATTACK, VOLUME_MID, 1, 3)
+
+/obj/item/projectile/bullet/spine/venomous
+	damage = 9
 
 //Poisons the victim on impact but only if their armor didn't stop the hit
 /obj/item/projectile/bullet/spine/venomous/on_hit(var/atom/target, var/blocked = 0, var/def_zone = null)

--- a/code/modules/necromorph/corruption/growth.dm
+++ b/code/modules/necromorph/corruption/growth.dm
@@ -105,3 +105,18 @@
 	desc = ""
 	energy_cost = 150
 	placement_atom = /obj/structure/corruption_node/growth/root
+
+/obj/structure/corruption_node/growth/mini
+	name = "decrepit root"
+	desc = "weak"
+	max_health = 10
+	resistance = 6
+	icon_state = "minigrowth"
+	density = FALSE
+	marker_spawnable = FALSE
+
+	range = 2
+	speed = 0.5
+	falloff = 0.025
+	limit = 4
+	randpixel = 4

--- a/html/changelogs/KetraiInfector.yml
+++ b/html/changelogs/KetraiInfector.yml
@@ -1,0 +1,70 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Infector cost 150 => 105."
+  - balance: "Infector is now a T1 morph."
+  - balance: "Infector spine damage reduced by about 33%."
+  - balance: "Infector health reduced from 155 => 90."
+  - balance: "Infector essence generation when about 7.5 increased from 50 => 60%."
+  - balance: "Infector max essence increased by 33%."
+  - balance: "Infector can now make new growths far more cheaply 30 => 10. And do so quicker."
+  - balance: "Infector can now make regular growths more cheaply."
+  - balance: "Infector growth effects reduced."
+  - balance: "Reanimate is slightly more expensive now."
+  - balance: "Infector snare is 40% cheaper."
+  - balance: "Infector engorge now taxes you more essence the more expensive the target."
+  - balance: "Infector engorge health gain changed from 50 to 10 + 15% health. Sorry for all you buff arm lovers, you'll have to do with less now."


### PR DESCRIPTION
Reworks the infector to be more useable. Some nerfs, but primarily equalizes effectiveness of abilities. What was previously strong (engorge) has now been made less overbearingly powerful. For example, a slasher costs 2.45 essence to engorge now, and only gains 23.5 health from engorge. Meanwhile, a brute will get 86.5 hp, but cost 3.8 essence to engorge. Rather than the flat rate of 2 essence. 

Infectors are always considered to be part of the initial outbreak of the necromorph plague. So them being a T2 necro wasn't exactly fun. Now they're something you can spawn way sooner.

 - balance: "Infector cost 150 => 105."
  - balance: "Infector is now a T1 morph."
  - balance: "Infector spine damage reduced by about 33%."
  - balance: "Infector health reduced from 155 => 90."
  - balance: "Infector essence generation when about 7.5 increased from 50 => 60%."
  - balance: "Infector max essence increased by 33%."
  - balance: "Infector can now make new growths far more cheaply 30 => 10. And do so quicker."
  - balance: "Infector can now make regular growths more cheaply."
  - balance: "Infector growth effects reduced."
  - balance: "Reanimate is slightly more expensive now."
  - balance: "Infector snare is 40% cheaper."
  - balance: "Infector engorge now taxes you more essence the more expensive the target."
  - balance: "Infector engorge health gain changed from 50 to 10 + 15% health. Sorry for all you buff arm lovers, you'll have to do with less now."