### PR TITLE
NO SUPERMATTER CARGO CRATE

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -155,6 +155,7 @@
 	containername = "\improper Disposal Dispenser Crate"
 	access = access_engineering
 
+/*
 /decl/hierarchy/supply_pack/engineering/smbig
 	name = "Supermatter Core"
 	contains = list(/obj/machinery/power/supermatter)
@@ -162,6 +163,7 @@
 	containertype = /obj/structure/closet/crate/secure/large/phoron
 	containername = "\improper Supermatter crate (CAUTION)"
 	access = access_ce
+*/
 
 /decl/hierarchy/supply_pack/engineering/fueltank
 	name = "Fuel tank crate"


### PR DESCRIPTION
People are stupid and keep ordering in the supermatter crystals which then proceeds to kill everyone. That or it's used to delete the ubermorph. Which is kinda funny, but only if it didn't just rad everyone to death too.

Comments it out, just in case we like, ever need it again.