### PR TITLE
Gallop buffs

### DIFF
--- a/code/modules/mob/living/abilities/gallop.dm
+++ b/code/modules/mob/living/abilities/gallop.dm
@@ -19,6 +19,8 @@
 	var/stopped_at
 	var/ongoing_timer
 	var/crashed = FALSE
+	var/crash_limit = 2
+	var/crash_count = 0
 
 	statmods = list(STATMOD_MOVESPEED_MULTIPLICATIVE = 1)
 /***********************
@@ -82,6 +84,9 @@
 
 /datum/extension/gallop/proc/user_hit(var/obj/item/organ/external/organ, brute, burn, damage_flags, used_weapon)
 	SIGNAL_HANDLER
+	if (crash_count < crash_limit)
+		crash_count++
+		return
 	if (!crashed)
 		user.visible_message(SPAN_DANGER("[user] crumples under the impact [istype(used_weapon, /obj) ? "of":"from"] [used_weapon]"))
 		stop_crash(used_weapon)

--- a/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
+++ b/code/modules/mob/living/carbon/human/species/necromorph/leaper.dm
@@ -61,7 +61,7 @@
 	KEY_CTRLSHIFT = list(/mob/living/proc/leaper_gallop),
 	KEY_ALT = list(/mob/living/carbon/human/proc/tailstrike_leaper))
 
-	slowdown = 4.5
+	slowdown = 4.2
 
 	//Leaper has no legs, it moves with arms and tail
 	locomotion_limbs = list(BP_R_ARM, BP_L_ARM, BP_TAIL)
@@ -415,7 +415,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 		return
 
 
-	if (gallop_ability(_duration = 4 SECONDS, _cooldown = 10 SECONDS, _power = 3))
+	if (gallop_ability(_duration = 6 SECONDS, _cooldown = 10 SECONDS, _power = 3))
 		H.play_species_audio(H, SOUND_SHOUT, VOLUME_MID, 1, 3)
 
 /mob/living/proc/leaper_gallop_enhanced()
@@ -428,7 +428,7 @@ It can be used to chase down a fleeing opponent, to move along long hallways qui
 		return
 
 
-	if (gallop_ability(_duration = 4 SECONDS, _cooldown = 9 SECONDS, _power = 1.5))
+	if (gallop_ability(_duration = 6 SECONDS, _cooldown = 8 SECONDS, _power = 1.5))
 		H.play_species_audio(H, SOUND_SHOUT, VOLUME_MID, 1, 3)
 
 

--- a/html/changelogs/Ketraileapergallop.yml
+++ b/html/changelogs/Ketraileapergallop.yml
@@ -58,3 +58,4 @@ changes:
   - balance: "Leaper gallop duration extended by 50%."
   - balance: "Enhanced leaper gallop cooldown lowered."
   - balance: "Leaper speed increased."
+  - balance: "Gallop isn't as easily interrupted by bullets/shrapnel anymore"

--- a/html/changelogs/Ketraileapergallop.yml
+++ b/html/changelogs/Ketraileapergallop.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Leaper gallop duration extended by 50%."
+  - balance: "Enhanced leaper gallop cooldown lowered."
+  - balance: "Leaper speed increased."


### PR DESCRIPTION
Buff leaper gallop. Mostly a much longer duration so they can use it to get around the ship again rather than purely escape. Also a slight increase in base speed so they're not quite as much of a slug. Humans still keep up easily in a rig, don't you worry.

  - balance: "Leaper gallop duration extended by 50%."
  - balance: "Enhanced leaper gallop cooldown lowered."
  - balance: "Leaper speed increased."