### PR TITLE
Server FPS now is 20. Client FPS you can change

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -291,6 +291,7 @@
 #include "code\controllers\subsystems\supply.dm"
 #include "code\controllers\subsystems\tgui.dm"
 #include "code\controllers\subsystems\ticker.dm"
+#include "code\controllers\subsystems\time_track.dm"
 #include "code\controllers\subsystems\timer.dm"
 #include "code\controllers\subsystems\trade.dm"
 #include "code\controllers\subsystems\vote.dm"

--- a/code/__defines/movement.dm
+++ b/code/__defines/movement.dm
@@ -12,7 +12,22 @@
 //Takes a speed in metres per second, and outputs the number of ticks to wait between each step to achieve that
 #define SPEED_TO_TICKS(speed) (SPEED_TO_DELAY(speed) / world.tick_lag)
 
-#define DELAY2GLIDESIZE(delay) (world.icon_size / max(Ceiling(delay / world.tick_lag), 1))
+/// The minimum for glide_size to be clamped to.
+#define MIN_GLIDE_SIZE 1
+/// The maximum for glide_size to be clamped to.
+/// This shouldn't be higher than the icon size, and generally you shouldn't be changing this, but it's here just in case.
+#define MAX_GLIDE_SIZE 32
+
+/// Compensating for time dialation
+GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
+
+///Broken down, here's what this does:
+/// divides the world icon_size (32) by delay divided by ticklag to get the number of pixels something should be moving each tick.
+/// The division result is given a min value of 1 to prevent obscenely slow glide sizes from being set
+/// Then that's multiplied by the global glide size multiplier. 1.25 by default feels pretty close to spot on. This is just to try to get byond to behave.
+/// The whole result is then clamped to within the range above.
+/// Not very readable but it works
+#define DELAY2GLIDESIZE(delay) (clamp(((world.icon_size / max((delay) / world.tick_lag, 1)) * GLOB.glide_size_multiplier), MIN_GLIDE_SIZE, MAX_GLIDE_SIZE))
 
 //Returned by structures which have no opinion on whether to allow/block ztransition, when asked
 #define ZTRANSITION_MAYBE	-1

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -63,6 +63,7 @@
 #define SS_INIT_GARBAGE				99
 #define SS_INIT_DATABASE			95
 #define SS_INIT_SERVER_MAINT		93
+#define SS_INIT_TIMETRACK			46
 #define SS_INIT_MATERIALS        8
 #define SS_INIT_ANTAGS           7
 #define SS_INIT_PLANTS           7

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -117,10 +117,10 @@ Basics, the most important.
 	config_entry_value = 120
 
 /datum/config_entry/number/fps
-	config_entry_value = 50
+	default = 20
 	integer = FALSE
-	min_val = 50
-	max_val = 50   //byond will start crapping out at 50, so this is just ridic
+	min_val = 1
+	max_val = 100   //byond will start crapping out at 100, so this is just ridic
 	var/sync_validate = FALSE
 
 /datum/config_entry/number/fps/ValidateAndSet(str_val)
@@ -133,13 +133,12 @@ Basics, the most important.
 		sync_validate = FALSE
 
 /datum/config_entry/number/ticklag
-	config_entry_value = 0.5
 	integer = FALSE
 	var/sync_validate = FALSE
 
 /datum/config_entry/number/ticklag/New()	//ticklag weirdly just mirrors fps
 	var/datum/config_entry/CE = /datum/config_entry/number/fps
-	config_entry_value = 10 / initial(CE.config_entry_value)
+	config_entry_value = 10 / initial(CE.default)
 	return ..()
 
 /datum/config_entry/number/ticklag/ValidateAndSet(str_val)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -207,7 +207,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 #else
 	world.sleep_offline = TRUE
 #endif
-	world.fps = CONFIG_GET(number/fps)
+	world.change_fps(CONFIG_GET(number/fps))
 	var/initialized_tod = REALTIMEOFDAY
 
 	initializations_finished_with_no_players_logged_in = initialized_tod < REALTIMEOFDAY - 10

--- a/code/controllers/subsystems/time_track.dm
+++ b/code/controllers/subsystems/time_track.dm
@@ -1,0 +1,38 @@
+SUBSYSTEM_DEF(time_track)
+	name = "Time Tracking"
+	wait = 100
+	init_order = SS_INIT_TIMETRACK
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
+
+	var/time_dilation_current = 0
+
+	var/time_dilation_avg_fast = 0
+	var/time_dilation_avg = 0
+	var/time_dilation_avg_slow = 0
+
+	var/first_run = TRUE
+
+	var/last_tick_realtime = 0
+	var/last_tick_byond_time = 0
+	var/last_tick_tickcount = 0
+
+/datum/controller/subsystem/time_track/fire()
+
+	var/current_realtime = REALTIMEOFDAY
+	var/current_byondtime = world.time
+	var/current_tickcount = world.time/world.tick_lag
+
+	if (!first_run)
+		var/tick_drift = max(0, (((current_realtime - last_tick_realtime) - (current_byondtime - last_tick_byond_time)) / world.tick_lag))
+
+		time_dilation_current = tick_drift / (current_tickcount - last_tick_tickcount) * 100
+
+		time_dilation_avg_fast = MC_AVERAGE_FAST(time_dilation_avg_fast, time_dilation_current)
+		time_dilation_avg = MC_AVERAGE(time_dilation_avg, time_dilation_avg_fast)
+		time_dilation_avg_slow = MC_AVERAGE_SLOW(time_dilation_avg_slow, time_dilation_avg)
+		GLOB.glide_size_multiplier = (current_byondtime - last_tick_byond_time) / (current_realtime - last_tick_realtime)
+	else
+		first_run = FALSE
+	last_tick_realtime = current_realtime
+	last_tick_byond_time = current_byondtime
+	last_tick_tickcount = current_tickcount

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -669,3 +669,24 @@ var/world_topic_spam_protect_time = world.timeofday
 	// but those are both private, so let's put the commit info in the runtime
 	// log which is ultimately public.
 	log_runtime(GLOB.revdata.get_log_message())
+
+/world/proc/change_fps(new_value = 20)
+	if(new_value <= 0)
+		CRASH("change_fps() called with [new_value] new_value.")
+	if(fps == new_value)
+		return //No change required.
+
+	fps = new_value
+	on_tickrate_change()
+
+/world/proc/change_tick_lag(new_value = 0.5)
+	if(new_value <= 0)
+		CRASH("change_tick_lag() called with [new_value] new_value.")
+	if(tick_lag == new_value)
+		return //No change required.
+
+	tick_lag = new_value
+	on_tickrate_change()
+
+/world/proc/on_tickrate_change()
+	SStimer?.reset_buckets()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -83,7 +83,7 @@
 	var/atom/movable/screen/click_catcher/void = null
 
 	//Static framerate
-	fps = 50
+	fps = 100
 
 	/// our current tab
 	var/stat_tab

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -219,13 +219,13 @@ var/list/_client_preferences_by_type
 	default_value = "1"
 
 //recommened client FPS
-#define RECOMMENDED_FPS 100
+#define RECOMMENDED_FPS 50
 
 /datum/client_preference/client_fps
 	description = "Client FPS"
 	key = "CLIENT_FPS"
 	options = list("20", "30", "50", "60", "100")
-	default_value = "100"
+	default_value = "50"
 
 /datum/client_preference/client_fps/changed(mob/preference_mob, new_value)
 	var/value = text2num(new_value)

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -153,7 +153,7 @@ var/list/_client_preferences_by_type
 	key = "SHOW_TYPING"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
 
-/datum/client_preference/show_typing_indicator/changed(var/mob/preference_mob, var/new_value)
+/datum/client_preference/show_typing_indicator/changed(mob/preference_mob, new_value)
 	if(new_value == GLOB.PREF_HIDE)
 		QDEL_NULL(preference_mob.typing_indicator)
 
@@ -218,6 +218,19 @@ var/list/_client_preferences_by_type
 	options = list("0.2", "0.3", "0.5", "0.75", "0.9", "1", "1.25", "1.5", "2", "2.5", "3")
 	default_value = "1"
 
+//recommened client FPS
+#define RECOMMENDED_FPS 100
+
+/datum/client_preference/client_fps
+	description = "Client FPS"
+	key = "CLIENT_FPS"
+	options = list("20", "30", "50", "60", "100")
+	default_value = "100"
+
+/datum/client_preference/client_fps/changed(mob/preference_mob, new_value)
+	var/value = text2num(new_value)
+	preference_mob.client.fps = (value < 0) ? RECOMMENDED_FPS : value
+
 /datum/client_preference/show_credits
 	description = "Show End Titles"
 	key = "SHOW_CREDITS"
@@ -229,7 +242,7 @@ var/list/_client_preferences_by_type
 /datum/client_preference/staff
 	var/flags
 
-/datum/client_preference/staff/may_set(var/mob/preference_mob)
+/datum/client_preference/staff/may_set(mob/preference_mob)
 	if(flags)
 		return check_rights(flags, 0, preference_mob)
 	else

--- a/code/world.dm
+++ b/code/world.dm
@@ -11,7 +11,7 @@
 	cache_lifespan = 7
 	hub = "Exadv1.spacestation13"
 	icon_size = WORLD_ICON_SIZE
-	fps = 50
+	fps = 20
 #ifdef GC_FAILURE_HARD_LOOKUP
 	loop_checks = FALSE
 #endif

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -10,5 +10,3 @@ max_stone_rig{MrMischief2015}
 mouse{nanakoac}
 plaugewalker_rig{plaugewalker}
 banditofdoom_rig{banditofdoom}
-marshal_wrench{marshalred}
-blackwolf_rig{blackwolf602}

--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -10,3 +10,5 @@ max_stone_rig{MrMischief2015}
 mouse{nanakoac}
 plaugewalker_rig{plaugewalker}
 banditofdoom_rig{banditofdoom}
+marshal_wrench{marshalred}
+blackwolf_rig{blackwolf602}

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -233,7 +233,7 @@ DISCORD_URL https://discord.gg/WH2fT2Y
 #ALLOW_HOLIDAYS TO_DO
 
 ##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
-TICKLAG 0.7
+TICKLAG 0.5
 
 ##Defines world FPS. Defaults to 20.
 FPS 20

--- a/config/example/custom_items.txt
+++ b/config/example/custom_items.txt
@@ -10,3 +10,5 @@ max_stone_rig{MrMischief2015}
 mouse{nanakoac}
 plaugewalker_rig{plaugewalker}
 banditofdoom_rig{banditofdoom}
+marshal_wrench{marshalred}
+blackwolf_rig{blackwolf602}


### PR DESCRIPTION
## About this PR
This PR make normal server FPS to 20. And players can change client FPS.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
