### PR TITLE
"Reposses" ability costs 0 energy now

### DIFF
--- a/code/modules/mob/dead/observer/freelook/marker/signal_abilities/reposess.dm
+++ b/code/modules/mob/dead/observer/freelook/marker/signal_abilities/reposess.dm
@@ -4,7 +4,7 @@
 	desc = "Seperates the target necromorph from their controlling signal, causing them to become an inert vessel once more, that can be posessed by any other signal.<br>\
 	Good to use in cases of a necromorph player going AFK"
 	target_string = "A currently controlled necromorph vessel"
-	energy_cost = 50
+	energy_cost = 0
 	autotarget_range = 1
 
 	target_types = list(/mob/living)


### PR DESCRIPTION
Why the fuck did Marker need to spend psy energy to remove AFK player from a necromorph?