### PR TITLE
R-UST adjustments and temp fixes

### DIFF
--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -88,8 +88,8 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 /decl/fusion_reaction/oxygen_oxygen
 	p_react = "oxygen"
 	s_react = "oxygen"
-	energy_consumption = 10
-	energy_production = 0
+	energy_consumption = 4 //We lose a lot of energy
+	energy_production = 2 // BUT we still get some back.
 	instability = 5
 	radiation = 5
 	products = list("silicon"= 1)
@@ -106,9 +106,9 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 /decl/fusion_reaction/phoron_hydrogen
 	p_react = "hydrogen"
 	s_react = MATERIAL_PHORON
-	energy_consumption = 10
-	energy_production = 0
-	instability = 5
+	energy_consumption = 0
+	energy_production = 10
+	instability = 8 //This is very unstable
 	products = list("mydrogen" = 1)
 	minimum_reaction_temperature = 8000
 
@@ -154,11 +154,10 @@ proc/get_fusion_reaction(var/p_react, var/s_react, var/m_energy)
 
 
 // High end reactions.
-/decl/fusion_reaction/boron_hydrogen
-	p_react = "boron"
+/decl/fusion_reaction/chlorine_hydrogen
+	p_react = "chlorine"
 	s_react = "hydrogen"
-	minimum_energy_level = FUSION_HEAT_CAP * 0.5
 	energy_consumption = 3
-	energy_production = 15
-	radiation = 3
-	instability = 3
+	energy_production = 15 //This is very much a bad idea to do
+	radiation = 5 //VERY radioactive
+	instability = 4 //More unstable

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -1,42 +1,31 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:33
-
 /obj/effect/accelerated_particle
 	name = "Accelerated Particles"
 	desc = "Small things moving very fast."
 	icon = 'icons/obj/machines/particle_accelerator2.dmi'
-	icon_state = "particle"//Need a new icon for this
-	anchored = 1
-	density = 1
+	icon_state = "particle"
+	anchored = TRUE
+	density = TRUE
 	var/movement_range = 10
-	var/energy = 10		//energy in eV
-	var/mega_energy = 0	//energy in MeV
+	var/energy = 10 //energy in eV
+	var/mega_energy = 0 //energy in MeV
 	var/particle_type
 	var/additional_particles = 0
 	var/turf/target
 	var/turf/source
-	var/movetotarget = 1
+	var/movetotarget = TRUE
+	var/active = FALSE
 
-/obj/effect/accelerated_particle/weak
-	movement_range = 8
-	energy = 5
-
-/obj/effect/accelerated_particle/strong
-	movement_range = 15
-	energy = 15
-
-
-/obj/effect/accelerated_particle/New(loc, dir = 2)
-	.=..()
-	src.forceMove(loc)
-	src.set_dir(dir)
+/obj/effect/accelerated_particle/Initialize(maploading, dir = 2)
+	. = ..()
+	set_dir(dir)
 	if(movement_range > 20)
 		movement_range = 20
-	spawn(0)
-		move(1)
-	return
-
+	active = TRUE
+	move(1)
 
 /obj/effect/accelerated_particle/Bump(atom/A)
+	if (!active)
+		return
 	if (A)
 		if(ismob(A))
 			toxmob(A)
@@ -48,50 +37,61 @@
 				if(collided_core.AddParticles(particle_type, 1 + additional_particles))
 					collided_core.owned_field.plasma_temperature += mega_energy
 					collided_core.owned_field.energy += energy
-					forceMove(null)
+					qdel(src)
 		else if(istype(A, /obj/effect/fusion_particle_catcher))
 			var/obj/effect/fusion_particle_catcher/PC = A
 			if(particle_type && particle_type != "neutron")
 				if(PC.parent.owned_core.AddParticles(particle_type, 1 + additional_particles))
 					PC.parent.plasma_temperature += mega_energy
 					PC.parent.energy += energy
-					forceMove(null)
-	return
-
+					qdel(src)
 
 /obj/effect/accelerated_particle/Bumped(atom/A)
+	if (!active)
+		return
 	if(ismob(A))
 		Bump(A)
-	return
-
 
 /obj/effect/accelerated_particle/ex_act(severity)
-	if(atom_flags & ATOM_FLAG_INDESTRUCTIBLE)
+	if (!active)
 		return
 	qdel(src)
-	return
 
 /obj/effect/accelerated_particle/proc/toxmob(var/mob/living/M)
+	if (!active)
+		return
 	var/radiation = (energy*2)
 	M.apply_effect((radiation*3),IRRADIATE,blocked = M.getarmor(null, "rad"))
 	M.updatehealth()
-//	to_chat(M, "<span class='warning'>You feel odd.</span>")
-	return
-
 
 /obj/effect/accelerated_particle/proc/move(var/lag)
+	set waitfor = FALSE
+	if(QDELETED(src))
+		return
+	if (!active)
+		return
+	var/destination
 	if(target)
-		if(movetotarget)
-			src.forceMove(get_step(src, get_dir(src,target)))
-			if(get_dist(src,target) < 1)
-				movetotarget = 0
-		else
-			src.forceMove(get_step(src, get_step_away(src,source)))
+		destination = movetotarget ? get_step_towards(src, target) : get_step_away(src, source)
 	else
-		src.forceMove(get_step(src,dir))
+		destination = get_step(src, dir)
+	if(!step_towards(src, destination))
+		if(QDELETED(src))
+			return
+		forceMove(destination)
+	if(target && movetotarget && (get_dist(src,target) < 1))
+		movetotarget = FALSE
 	movement_range--
 	if(movement_range <= 0)
 		qdel(src)
-	else
-		sleep(lag)
-		move(lag)
+		return
+	sleep(lag)
+	move(lag)
+
+/obj/effect/accelerated_particle/weak
+	movement_range = 8
+	energy = 5
+
+/obj/effect/accelerated_particle/strong
+	movement_range = 15
+	energy = 15

--- a/html/changelogs/Yawetrustchanges.yml
+++ b/html/changelogs/Yawetrustchanges.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Yawet330"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Most invalid R-UST reactions have been replaced, and R-UST projectile code has been reverted to a more functional state. May require further re-updating in the future, but is otherwise stable and causes no runtimes"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->
This does as the title says, by reverting R-UST code (or technically 1:1ing it with an equivalent codebase), it fixes the forcemove() issue with the R-UST without having to entirely recode how it catches projectiles.

This also changes a few reactions to be possible, and no longer runtime via invaid math.