### PR TITLE
Readjusts the Heavy pulse rifle again

### DIFF
--- a/code/modules/projectiles/guns/ds13/heavy_pulse.dm
+++ b/code/modules/projectiles/guns/ds13/heavy_pulse.dm
@@ -54,7 +54,7 @@
 	var/overheat_cooldown_mult = 1.6
 
 	//When overheating, we exit the overheat state if heat drops below this value
-	var/overheat_min = 0.8625 //75%
+	var/overheat_min = 0.42 //75%
 
 	//Loses this much heat per second. Approx 120 seconds to cooldown completely
 	var/cooldown_per_second	=	0.00475
@@ -66,7 +66,7 @@
 	var/heat_per_burst = 0.04
 
 	//Firing delay is divided by 1 + (heat * this), making the gun speed up as it gets closer to max heat
-	var/heat_delay_multiplier = 1.85
+	var/heat_delay_multiplier = 1.75
 
 /obj/item/gun/projectile/automatic/pulse_heavy/Initialize()
 	.=..()

--- a/code/modules/projectiles/guns/ds13/heavy_pulse.dm
+++ b/code/modules/projectiles/guns/ds13/heavy_pulse.dm
@@ -45,19 +45,19 @@
 	heat = 0
 
 	//Enters overheating state when heat gets this high
-	var/max_heat = 1.15
+	var/max_heat = 0.56 // 140 bullets before overheating, it cools down fast.
 
 	//When true, cannot fire
 	var/overheating = FALSE
 
 	//While we're overheating, we cooldown this much faster
-	var/overheat_cooldown_mult = 1.75
+	var/overheat_cooldown_mult = 1.6
 
 	//When overheating, we exit the overheat state if heat drops below this value
 	var/overheat_min = 0.8625 //75%
 
-	//Loses this much heat per second. Approx 200 seconds to cooldown completely
-	var/cooldown_per_second	=	0.00575
+	//Loses this much heat per second. Approx 120 seconds to cooldown completely
+	var/cooldown_per_second	=	0.00475
 
 	//Heat gained per bullet fired
 	var/heat_per_shot = 0.004

--- a/html/changelogs/ketraiHPR.yml
+++ b/html/changelogs/ketraiHPR.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: "Ketrai"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "HPR ammo before overheating 287 => 140."
+  - balance: "HPR overheat duration from 200 seconds to 120 seconds. This is still a nerf, the lower overheat limit reduces ammo regeneration."


### PR DESCRIPTION
Lowers the max ammo from 287.5 to 140. It was too flexible.
Cooldown time reduced from 200 seconds to 120 seconds to compensate. This still means less ammo is generated per second than before, decreasing overall effectiveness of the weapon, without affecting the killing power too much.