### PR TITLE
Reduces the volume of salt in salt sacks

### DIFF
--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -96,7 +96,8 @@
 				center_of_mass = "x=16;y=6"
 			if(/datum/reagent/nutriment/soysauce)
 				name = "Soy Sauce"
-				desc = "A salty soy-based flavoring."
+				desc = "A 
+				y soy-based flavoring."
 				icon_state = "soysauce"
 				center_of_mass = "x=16;y=6"
 			if(/datum/reagent/frostoil)
@@ -238,12 +239,12 @@
 
 /obj/item/reagent_containers/food/condiment/salt
 	name = "big bag of salt"
-	desc = "A nonsensically large bag of salt. Carefully refined from countless shifts."
+	desc = "A nonsensically large sack of salt that's seen some heavy use. Carefully refined from countless shifts. A label reads, 'CAUTION: EXCESSIVE CONSUMPTION MAY RESULT IN ILLNESS, AND IN SEVERE CASES, DEATH. "
 	icon = 'icons/obj/food.dmi'
 	icon_state = "salt"
 	item_state = "flour"
 	randpixel = 10
-	volume = 500
+	volume = 50
 	w_class = ITEM_SIZE_LARGE
 
 /obj/item/reagent_containers/food/condiment/salt/on_reagent_change()

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -86,7 +86,7 @@
 				center_of_mass = "x=16;y=6"
 			if(/datum/reagent/capsaicin)
 				name = "Hotsauce"
-				desc = "You can almost TASTE the stomach ulcers now!"
+				desc = "A can of delicious hot sauce."
 				icon_state = "hotsauce"
 				center_of_mass = "x=16;y=6"
 			if(/datum/reagent/enzyme)
@@ -96,8 +96,7 @@
 				center_of_mass = "x=16;y=6"
 			if(/datum/reagent/nutriment/soysauce)
 				name = "Soy Sauce"
-				desc = "A 
-				y soy-based flavoring."
+				desc = "A soy-based flavoring."
 				icon_state = "soysauce"
 				center_of_mass = "x=16;y=6"
 			if(/datum/reagent/frostoil)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -96,7 +96,7 @@
 				center_of_mass = "x=16;y=6"
 			if(/datum/reagent/nutriment/soysauce)
 				name = "Soy Sauce"
-				desc = "A soy-based flavoring."
+				desc = "A salty soy-based flavoring."
 				icon_state = "soysauce"
 				center_of_mass = "x=16;y=6"
 			if(/datum/reagent/frostoil)


### PR DESCRIPTION
What this PR Does & Why:

Simply put, it reduces the amount of salt found in the large salt containers in spawn lockers to 50 units, from 500, and adds a warning note.

Why? 'Cause being permanently round-removed from excessive salt consumption isn't fun, and, there's really no reason for such a huge amount of salt to exist round start. It makes ordering salt from Supply pointless as there's enough salt in each bag to last the entire shift even if you're an active cook.

EDIT: Crew & Others can munch on spicy food without fear of stomach ulcers now! :) (No idea if that's a thing in the code or not.)