### PR TITLE
speed adjustments

### DIFF
--- a/code/__defines/movement.dm
+++ b/code/__defines/movement.dm
@@ -43,10 +43,10 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 #define RELEASE_THROW	"throw"	//Inherit velocity and continue flying
 #define RELEASE_LAUNCH	"launch"	//Explicitly launched with a powerful burst of force. Like throw but faster, and rougher start
 
-#define RUN_DELAY 1.6
+#define RUN_DELAY 2.2
 #define WALK_DELAY 2.95
 #define STALK_DELAY 6
 #define MINIMUM_SPRINT_COST 0.85	//The part of sprint cost that everyone gets
-#define SKILL_SPRINT_COST_RANGE 0.775	//The part of sprint cost that is affected by athletics
-#define MINIMUM_STAMINA_RECOVERY 1.75
+#define SKILL_SPRINT_COST_RANGE 0.7	//The part of sprint cost that is affected by athletics
+#define MINIMUM_STAMINA_RECOVERY 2.5
 #define MAXIMUM_STAMINA_RECOVERY 5

--- a/code/modules/necromorph/corruption.dm
+++ b/code/modules/necromorph/corruption.dm
@@ -370,18 +370,18 @@ GLOBAL_DATUM_INIT(corruption_seed, /datum/seed/corruption, new())
 
 	//Effects on necromorphs
 	var/healing_per_tick = 1	//Passive Healing
-	var/speedup = 1.25	//Bonus movespeed
+	var/speedup = 1.20	//Bonus movespeed, THIS ISN'T USED RIGHT NOW
 	var/incoming_damage_mod = 0.85	//Incoming damage reduction
 
 	//Effects on non necros
-	var/slowdown = 0.625	//Movespeed Penalty
+	var/slowdown = 0.9	//Movespeed Penalty
 
 	var/speed_factor = 0
 
 
 	var/necro = FALSE
 
-	statmods = list(STATMOD_MOVESPEED_MULTIPLICATIVE = 1.25,//This is dynamic
+	statmods = list(STATMOD_MOVESPEED_MULTIPLICATIVE = 1.20,//This is dynamic
 	STATMOD_INCOMING_DAMAGE_MULTIPLICATIVE = 0.85)
 
 

--- a/html/changelogs/KetraiSprinting.yml
+++ b/html/changelogs/KetraiSprinting.yml
@@ -58,5 +58,5 @@ changes:
   - balance: "Human sprint speed nerfed heavily."
   - balance: "Human stamina cost improvement from athletics reduced slightly."
   - balance: "Corruption slowdown nerfed from 37.5% to 10%."
-  - balance: "Corruption speedup for necromorphs nerfed from 25% to 10%."
+  - balance: "Corruption speedup for necromorphs nerfed from 25% to 20%."
   - balance: "This means necros are comparatively only 30% faster instead of 62.5% on corruption, leveling speed out more overall."

--- a/html/changelogs/KetraiSprinting.yml
+++ b/html/changelogs/KetraiSprinting.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ""
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Human sprint speed nerfed heavily."
+  - balance: "Human stamina cost improvement from athletics reduced slightly."
+  - balance: "Corruption slowdown nerfed from 37.5% to 10%."
+  - balance: "Corruption speedup for necromorphs nerfed from 25% to 10%."
+  - balance: "This means necros are comparatively only 30% faster instead of 62.5% on corruption, leveling speed out more overall."


### PR DESCRIPTION
Nerfs human sprint speed heavily. It's hard to measure the exact numbers with how cursed slowdown code is, but it should be only 40% faster now, instead of 80%.
Humans can kite extremely easily when sprinting, allowing for little to no counterplay from most necros. In fact, they can almost outrun charges, and easily dive behind corners in a lot of areas.
Also lowers sprint stamina bonus from athetics slightly as it compensated for almost the entire sprint cost when maxed, which is extreme.
Raises base stamina regen so humans without athletics don't just... never regain stamina?

In return, corruption slows down humans drastically less. From 37.5% to 10% slowdown
Necros are also slightly slower on corruption now, from 25% to 20% speedboost

This is to try and make combat on corruption and off corruption more consistent and enjoyable in general. As well as general map traversal. Feeling like you're walking an extra 30+ tiles every hundred on corruption isn't exactly fun.