### PR TITLE
[EXPERIMENTAL] Firedoors always act as zoneblockers(?)

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -31,10 +31,6 @@
 	min_force = 12
 	explosion_resistance = 15
 
-	//These are frequenly used with windows, so make sure zones can pass.
-	//Generally if a firedoor is at a place where there should be a zone boundery then there will be a regular door underneath it.
-	block_air_zones = 0
-
 	var/blocked = 0
 	var/lockdown = 0 // When the door has detected a problem, it locks.
 	var/pdiff_alert = 0


### PR DESCRIPTION
The "old" controlflow of ZAS sucks. I miss my `zas_canpass()` dearly. 

The intended goal of this change is for firedoors to act as zone blockers no matter what. Im not sure if this works right but it's worth trying.