### PR TITLE
SCSS fixes: Admins Can Read Chat Edition

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -287,8 +287,19 @@ em {
   font-weight: bold;
 }
 
-.adminsay {
+.admin_channel {
   color: #ff4500;
+  font-weight: bold;
+}
+
+.mod_channel {
+  color: #978571;
+  font-weight: bold;
+}
+
+/*Admins speaking over msay*/
+.mod_channel .admin {
+  color: #ec693d;
   font-weight: bold;
 }
 
@@ -296,6 +307,17 @@ em {
   color: #5975da;
   font-weight: bold;
 }
+
+.log_message {
+  color: #386aff;
+  font-weight: bold;
+}
+
+/* Admin: Private Messages */
+.pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}
+.pm  .in				{color: #ff0000;}
+.pm  .out				{color: #ff0000;}
+.pm  .other				{color: #0000ff;}
 
 .name {
   font-weight: bold;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -320,8 +320,19 @@ em {
   font-weight: bold;
 }
 
-.adminsay {
+.admin_channel {
   color: #ff4500;
+  font-weight: bold;
+}
+
+.mod_channel {
+  color: #735638;
+  font-weight: bold;
+}
+
+/*Admins speaking over msay*/
+.mod_channel .admin {
+  color: #b82e00;
   font-weight: bold;
 }
 
@@ -329,6 +340,14 @@ em {
   color: #4473ff;
   font-weight: bold;
 }
+
+.log_message			{color: #386aff;	font-weight: bold;}
+
+/* Admin: Private Messages */
+.pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}
+.pm  .in				{color: #ff0000;}
+.pm  .out				{color: #ff0000;}
+.pm  .other				{color: #0000ff;}
 
 .name {
   font-weight: bold;


### PR DESCRIPTION
the TGUI SCSS files were missing a lot of the bay-origin span classes. This implements them, and should make being an admin a little more pleasant on the eyes.