### PR TITLE
QoL refactor for necromorph posses

### DIFF
--- a/code/modules/mob/dead/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/dead/observer/freelook/marker/signal.dm
@@ -261,9 +261,9 @@ GLOBAL_LIST_INIT(signal_sprites, list("markersignal-1",
 
 /mob/dead/observer/signal/verb/necro_possess(var/mob/living/L)
 	set name = "Possess"
-	set category = "Necromorph"
+	set category = null
 	set desc = "Take control of a necromorph vessel"
-	set hidden = 1
+	set hidden = TRUE
 
 	if (!istype(L))
 		to_chat(src, SPAN_DANGER("That can't be possessed!"))

--- a/code/modules/mob/dead/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/dead/observer/freelook/marker/signal.dm
@@ -244,10 +244,26 @@ GLOBAL_LIST_INIT(signal_sprites, list("markersignal-1",
 
 //Possession and evacuating
 //-------------------------------
+/mob/dead/observer/signal/verb/necro_posses_verb()
+	set name = "Posses Necromorph"
+	set category = "Necromorph"
+	set desc = "Take control of a necromorph vessel"
+
+	var/list/possible_hosts = list()
+	for(var/mob/living/carbon/human/necromorph/necro in SSnecromorph.major_vessels)
+		if(!necro.client && necro.stat != DEAD)
+			possible_hosts += necro
+	var/choice = tgui_input_list(usr, "Pick the necromorph from the current list", "Who you want to be?", possible_hosts)
+	if(choice)
+		necro_possess(choice)
+
+
+
 /mob/dead/observer/signal/verb/necro_possess(var/mob/living/L)
 	set name = "Possess"
 	set category = "Necromorph"
 	set desc = "Take control of a necromorph vessel"
+	set hidden = 1
 
 	if (!istype(L))
 		to_chat(src, SPAN_DANGER("That can't be possessed!"))

--- a/code/modules/mob/dead/observer/freelook/marker/signal.dm
+++ b/code/modules/mob/dead/observer/freelook/marker/signal.dm
@@ -263,7 +263,6 @@ GLOBAL_LIST_INIT(signal_sprites, list("markersignal-1",
 	set name = "Possess"
 	set category = null
 	set desc = "Take control of a necromorph vessel"
-	set hidden = TRUE
 
 	if (!istype(L))
 		to_chat(src, SPAN_DANGER("That can't be possessed!"))


### PR DESCRIPTION
Gives the signals a different verb that shows a list of possible possession targets, THEN call posses on that mob. instead of having a list of everything that is on screen including humans, signals, fennecs, already possed necromorphs and what ever else happens to cross your sight lines.

I could also add morphs that are in nests but not sure if thats desired

apparently there is a bug though that adds duplicate entrys to the major_vessels list. not sure what causes is but thats why you see multiple entrys for the same morph sometimes


![necro](https://user-images.githubusercontent.com/36102060/218255673-4599ec8a-ef71-4417-be8c-041bbfd111b8.gif)



changes:
 - qol: "The posses verb for necromorphs now shows a list of possible targets"